### PR TITLE
beam-1616. aligns content publish button

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ActionBarVisualElement/ActionBarVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ActionBarVisualElement/ActionBarVisualElement.cs
@@ -127,13 +127,9 @@ namespace Beamable.Editor.Content.Components
       {
          if (_publishDropdownButton?.parent == null) return;
 
-         _publishDropdownButton.parent.visible = ContentConfiguration.Instance.EnableMultipleContentNamespaces;
-         if (_publishDropdownButton.parent.visible) {
-            _publishButton.Q<Label>("publicButtonLabel").RemoveFromClassList("publicButtonLabelSolo");
-         }
-         else {
-            _publishButton.Q<Label>("publicButtonLabel").AddToClassList("publicButtonLabelSolo");
-         }
+
+         _publishDropdownButton.parent.EnableInClassList("hidden",
+            !ContentConfiguration.Instance.EnableMultipleContentNamespaces);
       }
 
       private void SearchBar_OnSearchChanged(string obj)

--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ActionBarVisualElement/ActionBarVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ActionBarVisualElement/ActionBarVisualElement.uss
@@ -121,11 +121,18 @@
     width: 18px;
     background-image: resource("Packages/com.beamable/Editor/UI/Content/Icons/dropdown_Line_dark.png")
 }
+#dropDownImg.hidden {
+    position: absolute;
+    right: 10000px;
+}
 #createNewButton #dropDownImg {
     height: 16px;
 }
 #publishButton #dropDownImg {
     align-self: stretch;
+}
+#publishButton {
+    justify-content: center;
 }
 
 .createButtonLabel{


### PR DESCRIPTION
# Brief Description
Instead of using the `.visible` property, I'm setting the position to absolute and adding a crazy offset to hide the element. This lets the flex layout realign the remaining visible content. 
![Uploading publish_align.gif…]()


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 