### PR TITLE
beam 1618- removes un-needed event unsub

### DIFF
--- a/client/Packages/com.beamable.server/Editor/Microservices.cs
+++ b/client/Packages/com.beamable.server/Editor/Microservices.cs
@@ -253,13 +253,6 @@ namespace Beamable.Server.Editor
       public static event Action<ManifestModel, int> onBeforeDeploy;
       public static event Action<ManifestModel, int> onAfterDeploy;
 
-      [RuntimeInitializeOnLoadMethod]
-      private static void Init()
-      {
-         onBeforeDeploy = null;
-         onAfterDeploy = null;
-      }
-
       public static async System.Threading.Tasks.Task Deploy(ManifestModel model, CommandRunnerWindow context)
       {
          if (Descriptors.Count == 0) return; // don't do anything if there are no descriptors.


### PR DESCRIPTION
# Brief Description

![beam1618](https://user-images.githubusercontent.com/3848374/134232214-f060210d-846e-4f09-8dc8-e00789747cc8.gif)


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 