### PR TITLE
beam-1669 fix invalid DateTime throwing error

### DIFF
--- a/client/Packages/com.beamable.server/Editor/DockerCommands/FollowLogCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/FollowLogCommand.cs
@@ -92,13 +92,17 @@ namespace Beamable.Server.Editor.DockerCommands
 
             // report the log message to the right bucket.
             #if !BEAMABLE_LEGACY_MSW
+            if (!DateTime.TryParse(timestamp, out var time))
+            {
+               time = DateTime.Now;
+            }
             var logMessage = new LogMessage
             {
                Message = message,
                Parameters = objs,
                ParameterText = objsToString,
                Level = logLevelValue,
-               Timestamp = LogMessage.GetTimeDisplay(DateTime.Parse(timestamp))
+               Timestamp = LogMessage.GetTimeDisplay(time)
             };
             EditorApplication.delayCall += () =>
             {


### PR DESCRIPTION
# Brief Description
The log helper was throwing an error because the given `timestamp` wasn't a valid timestamp string. I think this is because of the Storage Object logs getting forwarded. 

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 