### PR TITLE
BEAM-1675 dont bother searching directory if no directory existed

### DIFF
--- a/client/Packages/com.beamable/Editor/Modules/Content/ContentIO.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/ContentIO.cs
@@ -387,7 +387,11 @@ namespace Beamable.Editor.Content
       public IEnumerable<TContent> FindAllContent<TContent>(ContentQuery query = null, bool inherit = true) where TContent : ContentObject, new()
       {
          if (query == null) query = ContentQuery.Unit;
-         Directory.CreateDirectory(BeamableConstants.DATA_DIR);
+         if (!Directory.Exists(BeamableConstants.DATA_DIR))
+         {
+            Directory.CreateDirectory(BeamableConstants.DATA_DIR);
+            yield break; // there is no folder, therefore, no content. Nothing to search for.
+         }
 
          var assetGuids = AssetDatabase.FindAssets(
             $"t:{typeof(TContent).Name}",


### PR DESCRIPTION
# Brief Description
https://disruptorbeam.atlassian.net/browse/BEAM-1675
The first time we ever run this method, 
We were getting a warning saying that the directory didn't exist in the asset database. of course it doesn't exist, we just made it.

I'm just saying, "if it didn't exist, don't bother doing anything else". This will dodge the warning.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?

(no changelog needed, this is a bug-fix for a bug-fix)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 