### PR TITLE
beam- 1675 use assetdatabase check instead of fileio check

### DIFF
--- a/client/Packages/com.beamable/Editor/Modules/Content/ContentIO.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/ContentIO.cs
@@ -387,7 +387,7 @@ namespace Beamable.Editor.Content
       public IEnumerable<TContent> FindAllContent<TContent>(ContentQuery query = null, bool inherit = true) where TContent : ContentObject, new()
       {
          if (query == null) query = ContentQuery.Unit;
-         if (!Directory.Exists(BeamableConstants.DATA_DIR))
+         if (!AssetDatabase.IsValidFolder(BeamableConstants.DATA_DIR))
          {
             Directory.CreateDirectory(BeamableConstants.DATA_DIR);
             yield break; // there is no folder, therefore, no content. Nothing to search for.


### PR DESCRIPTION
# Brief Description
The folder exists, but it hasn't been synced with the asset database, which is what we actually care about.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 