### PR TITLE
beam 1692- fix null reference and disable logs for health check

### DIFF
--- a/microservice/microservice/dbmicroservice/LocalDebugService.cs
+++ b/microservice/microservice/dbmicroservice/LocalDebugService.cs
@@ -12,7 +12,7 @@ namespace Beamable.Server {
 
         public LocalDebugService(BeamableMicroService beamableService) {
             _beamableService = beamableService;
-            Logger.UnregisterLogger<ConsoleLogger>();
+            Swan.Logging.ConsoleLogger.Instance.LogLevel = LogLevel.Error;
             var server = new WebServer(SharedConstants.HEALTH_PORT)
                 .WithModule(new ActionModule("/health", HttpVerbs.Any, HealthCheck));
             server.RunAsync();


### PR DESCRIPTION
# Brief Description
Now that we have health checks running in AWS, a bug popped up.
The first health check runs really quickly, before the beamable service has been initialized. I had to add a null check to stop the server for 500ing. 
I also set the webserver's logging level to error, so we don't see the non-helpful init text.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 