### PR TITLE
beam-1710 MicroserviceWindow updates on changing EnableStoragePreview

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Components/ServiceBaseVisualElement/ServiceBaseVisualElement.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/ServiceBaseVisualElement/ServiceBaseVisualElement.cs
@@ -132,6 +132,8 @@ namespace Beamable.Editor.Microservice.UI.Components
 
             Model.Builder.OnIsRunningChanged -= HandleIsRunningChanged;
             Model.Builder.OnIsRunningChanged += HandleIsRunningChanged;
+
+            Root.Q("dependentServicesContainer").visible = MicroserviceConfiguration.Instance.EnableStoragePreview;
             
             _separator.Setup(OnDrag);
             _separator.Refresh();

--- a/client/Packages/com.beamable.server/Editor/UI/MicroserviceWindow.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/MicroserviceWindow.cs
@@ -224,7 +224,9 @@ namespace Beamable.Editor.Microservice.UI
 
         private void Refresh() {
             new CheckDockerCommand().Start(null).Then(_ => {
-                _microserviceContentVisualElement.Refresh();
+                _microserviceBreadcrumbsVisualElement?.Refresh();
+                _actionBarVisualElement?.Refresh();
+                _microserviceContentVisualElement?.Refresh();
             });
         }
 


### PR DESCRIPTION
# Brief Description
Three things should now be updated on changing EnableStoragePreview in MicroserviceConfig:
1. Visibility of service filter.
2. Visibility of Dependent services button.
3. Behaviour of 'Create New' button

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 