### PR TITLE
beam-1739 - dont include classname at end of namespace

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Microservice clients can now deserialize json lists
 
+### Changed
+- Generated services no longer include the class name in the namespace
+
 ## [0.16.0]
 ### Added
 - New Microservices Manager window

--- a/client/Packages/com.beamable.server/Template/Microservice.cs
+++ b/client/Packages/com.beamable.server/Template/Microservice.cs
@@ -1,6 +1,6 @@
 using Beamable.Server;
 
-namespace Beamable.Server.XXXX
+namespace Beamable.Server
 {
    [Microservice("XXXX")]
    public class XXXX : Microservice

--- a/client/Packages/com.beamable.server/Template/StorageObject/StorageObject.cs
+++ b/client/Packages/com.beamable.server/Template/StorageObject/StorageObject.cs
@@ -1,6 +1,6 @@
 ﻿using Beamable.Server;
 
-namespace Beamable.Server.XXXX
+namespace Beamable.Server
 {
     [StorageObject("XXXX")]
     public class XXXX : MongoStorageObject


### PR DESCRIPTION
# Brief Description
When a user created a service or storage object, we would stick their given name on the end of the namespace. This was fine when nothing was referencing those files; but now that a service can/needs-to reference a storage object, its a real pita. Its not really important, and people would change it anyway if they cared, so I opt to make the default behaviour, "just be nicer"

# Ticket 
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-1739

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 