### PR TITLE
beam 1719- adds manual refresh after imports

### DIFF
--- a/client/Packages/com.beamable/Runtime/Modules/ModuleConfigurationObject.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/ModuleConfigurationObject.cs
@@ -76,6 +76,7 @@ namespace Beamable
          finally
          {
             UnityEditor.AssetDatabase.StopAssetEditing();
+            UnityEditor.AssetDatabase.Refresh();
          }
 
          foreach (var kvp in writtenAssetPathToType)


### PR DESCRIPTION
# Ticket 
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-1719

# Brief Description
I'm having a really hard time reproducing this issue... But, the error is that an gets thrown because it can't load the asset that should have just been imported. I figured I'd try adding a manual refresh call after the assetdatabase opens back up.


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 