### PR TITLE
[BEAM-1721] 0.17.0 Blocker - manifest namespace textfield should be vertical aligned

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Content/Components/PublishContentVisualElement/PublishContentVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/PublishContentVisualElement/PublishContentVisualElement.uss
@@ -131,12 +131,13 @@ LoadingSpinnerVisualElement {
 
 #manifestNameLabel{
     -unity-font-style: bold;
+    -unity-text-align: middle-left;
+    max-height: 20px;
 }
 
 #manifestName{
     min-height: 20px;
-    /*min-width: 120px;*/
-    /*flex: auto;*/
+    -unity-text-align: middle-left;
 }
 
 .invalidManifestName{
@@ -161,3 +162,8 @@ LoadingSpinnerVisualElement {
 #manifestArchivedMessage.visible{
     height: 30px;
  }
+
+.beamableErrorLabel {
+    margin-left: 4px;
+    margin-right: 4px;
+}


### PR DESCRIPTION
# Brief Description

![image](https://user-images.githubusercontent.com/18366601/137402058-e24d753e-6b24-499c-85b9-fd95bb62dd87.png)
![image](https://user-images.githubusercontent.com/18366601/137402080-d1109398-1a18-4a5e-a25d-10d6e8759c59.png)

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 