### PR TITLE
beam-1678. datepicker doesnt always set to now

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]
 ### Fixed
 - Able to build game
+- Content Inspector datepicker with no user given value no longer constantly updates
 
 ## [0.17.0]
 ### Added

--- a/client/Packages/com.beamable/Editor/Modules/Content/DatePropertyDrawer.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/DatePropertyDrawer.cs
@@ -177,7 +177,7 @@ namespace Beamable.Editor.Content {
 
         private static void ApplyNewDate(SerializedProperty property, DateTime date) {
             var stringProperty = GetStringProperty(property);
-            var dateString = date.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+            var dateString = date.ToUniversalTime().ToString(DateUtility.ISO_FORMAT, CultureInfo.InvariantCulture);
             if (dateString != stringProperty.stringValue) {
                 stringProperty.stringValue = dateString;
                 Undo.RecordObjects(property.serializedObject.targetObjects, "change date");
@@ -187,10 +187,11 @@ namespace Beamable.Editor.Content {
         }
 
         private static DateTime GetCurrentDateTime(SerializedProperty property) {
-            if (!DateTime.TryParseExact(GetStringProperty(property).stringValue, "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture,
+            if (!DateTime.TryParseExact(GetStringProperty(property).stringValue, DateUtility.ISO_FORMAT, CultureInfo.InvariantCulture,
                 DateTimeStyles.None, out var date)) {
                 var now = DateTime.UtcNow;
                 date = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second); // skipping milliseconds
+                ApplyNewDate(property, date);
             }
 
             date = date.ToUniversalTime();

--- a/client/Packages/com.beamable/Editor/Utility/DateUtility.cs
+++ b/client/Packages/com.beamable/Editor/Utility/DateUtility.cs
@@ -3,7 +3,11 @@ using System.Globalization;
 using UnityEngine;
 
 namespace Beamable.Editor {
-    public static class DateUtility {
+    public static class DateUtility
+    {
+
+        public const string ISO_FORMAT = "yyyy-MM-ddTHH:mm:ssZ";
+
         public static bool TryToCreateDateTime(int year, int month, int day, int hour, int minute, int second, out DateTime dateTime) {
             try {
                 dateTime = new DateTime(year, month, day, hour, minute, second);


### PR DESCRIPTION

![dateErrorFix](https://user-images.githubusercontent.com/3848374/137481766-680b7fd3-2b64-45ec-a71c-c9c49dc2fad6.gif)
# TIcket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-1678 

# Brief Description
the IMGUI date picker would constantly get now() if there was an invalid date. I changed it so that it gets now(), but then _sets_ the field to _now()_, so that the field isn't always updating in the background. 

Also, we re-use the date string format a lot. I'm not going to replace it every single spot, but I figured it should be constant somewhere.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 