### PR TITLE
beam 1728 - datepicker fixes

### DIFF
--- a/client/Packages/com.beamable/Editor/Modules/Content/DatePropertyDrawer.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/DatePropertyDrawer.cs
@@ -105,9 +105,9 @@ namespace Beamable.Editor.Content {
             EditorGUI.BeginChangeCheck();
             var text = EditorGUI.DelayedTextField(
                 rectController.ReserveWidth(rectController.rect.width - CalendarButtonWidth - SpaceWidth),
-                date.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"));
+                date.ToUniversalTime().ToString(DateUtility.ISO_FORMAT));
             if (EditorGUI.EndChangeCheck() && DateTime.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.None, out date)) {
-                ApplyNewDate(property, date);
+                ApplyNewDate(property, date.ToUniversalTime());
             }
             rectController.ReserveWidth(SpaceWidth);
 
@@ -177,7 +177,7 @@ namespace Beamable.Editor.Content {
 
         private static void ApplyNewDate(SerializedProperty property, DateTime date) {
             var stringProperty = GetStringProperty(property);
-            var dateString = date.ToUniversalTime().ToString(DateUtility.ISO_FORMAT, CultureInfo.InvariantCulture);
+            var dateString = date.ToString(DateUtility.ISO_FORMAT, CultureInfo.InvariantCulture);
             if (dateString != stringProperty.stringValue) {
                 stringProperty.stringValue = dateString;
                 Undo.RecordObjects(property.serializedObject.targetObjects, "change date");
@@ -191,7 +191,7 @@ namespace Beamable.Editor.Content {
                 DateTimeStyles.None, out var date)) {
                 var now = DateTime.UtcNow;
                 date = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second); // skipping milliseconds
-                ApplyNewDate(property, date);
+                ApplyNewDate(property, date.ToUniversalTime());
             }
 
             date = date.ToUniversalTime();


### PR DESCRIPTION
# Ticket 
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-1728

# Brief Description
I have mac 2018 dark, not windows, and I'm not seeing the issue. For me, it looks like this.
![image](https://user-images.githubusercontent.com/3848374/137485609-7c18c69b-6b1d-469d-8966-92aa57b53a3c.png)


I'll reach out and try and get more repro steps.
However, I found a bug elsewhere in the datepicker about UTC vs not.


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 