### PR TITLE
[BEAM-1734] Fix publish new namespace for 2018

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Content/Components/PublishContentVisualElement/PublishContentVisualElement.2018.uss
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/PublishContentVisualElement/PublishContentVisualElement.2018.uss
@@ -1,0 +1,3 @@
+#manifestNameRow{
+    flex-direction: column;
+}

--- a/client/Packages/com.beamable/Editor/UI/Content/Components/PublishContentVisualElement/PublishContentVisualElement.2018.uss.meta
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/PublishContentVisualElement/PublishContentVisualElement.2018.uss.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 614133f6bfae10946b51be713bf1824c
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: stylesheet
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}


### PR DESCRIPTION
# Brief Description
![obraz](https://user-images.githubusercontent.com/13188195/137485550-8e9e07e0-7a92-450e-8ba5-5446d560c446.png)


Looks like scaling elements in 2018 does not work as good as in newer version of Unity and causes to be Label and TextField be outside  the container. This is why I've put Label above TextField in 2018

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 