### PR TITLE
beam-1759

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Common/Components/BeamableCheckboxVisualElement/BeamableCheckboxVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/BeamableCheckboxVisualElement/BeamableCheckboxVisualElement.cs
@@ -36,6 +36,8 @@ namespace Beamable.Editor.UI.Components
             }
         }
 
+        public Button Button => _button;
+
         private bool _value;
 
         private VisualElement _onNotifier;

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/LabeledCheckboxVisualElement/LabeledCheckboxVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/LabeledCheckboxVisualElement/LabeledCheckboxVisualElement.cs
@@ -70,6 +70,8 @@ namespace Beamable.Editor.UI.Components
         private string Label { get; set; }
         private string Icon { get; set; }
 
+        public BeamableCheckboxVisualElement Checkbox => _checkbox;
+
         public LabeledCheckboxVisualElement() : base(ComponentPath)
         {
         }

--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ArchiveManifestsVisualElement/ArchiveManifestsVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ArchiveManifestsVisualElement/ArchiveManifestsVisualElement.cs
@@ -114,8 +114,10 @@ namespace Beamable.Editor.Content.Components
                 listRoot.Add(visualElement);
                 manifestId = model.id;
                 visualElement.SetEnabled(enabled);
+                visualElement.EnableInClassList("disabled", !enabled);
                 visualElement.SetFlipState(true);
                 visualElement.Refresh();
+                visualElement.Checkbox.Button.pickingMode = enabled ? PickingMode.Position : PickingMode.Ignore;
                 visualElement.DisableIcon();
                 visualElement.SetText(model.id);
                 visualElement.OnValueChanged += _ => onValueChange();

--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ArchiveManifestsVisualElement/ArchiveManifestsVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ArchiveManifestsVisualElement/ArchiveManifestsVisualElement.uss
@@ -38,6 +38,10 @@ ArchiveManifestsVisualElement > * {
     height: 28px;
 }
 
+.disabled *{
+    opacity: .5;
+}
+
 LabeledCheckboxVisualElement #checkbox {
 
     width: 40px;


### PR DESCRIPTION
# Brief Description
In Archive Manifest window it was possible to select namespaces we are currently on in Unity 2018.
Now it should be impossible.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 