### PR TITLE
[BEAM-1735] CMV2 - can't rename content after deleting other content

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ContentListVisualElement/ContentListVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ContentListVisualElement/ContentListVisualElement.cs
@@ -83,6 +83,7 @@ namespace Beamable.Editor.Content.Components
 
             Model.OnSelectedContentChanged += Model_OnSelectedContentChanged;
             Model.OnFilteredContentsChanged += Model_OnFilteredContentChanged;
+            Model.OnContentDeleted += Model_OnContentDeleted;
             Model.OnManifestChanged += ManifestChanged;
 
             var manipulator = new ContextualMenuManipulator(ContentVisualElement_OnContextMenuOpen);
@@ -284,6 +285,10 @@ namespace Beamable.Editor.Content.Components
             }
         }
 
+        private void Model_OnContentDeleted(ContentItemDescriptor obj)
+        {
+            _listView.ClearSelection();
+        }
 
         private void ContentVisualElement_OnRightMouseButtonClicked(ContentItemDescriptor contentItemDescriptor)
         {


### PR DESCRIPTION
# Brief Description

ListView selection wasn't clear after content delete. So there was a difference with visible and model selection.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 