### PR TITLE
beam 1720- adds loading indicator on realm switch

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `API.Instance.Requester` is now an `IBeamableRequester`
 - The `Promise` class is no longer static, and extends from `Promise<Unit>`
 - Validated string fields of `ListingPrice`, `StatRequirement`, `CohortRequirement`, `OfferConstraint` and `AnnouncementAttachment` in Content Manager were changed to dropdowns
+- The realm dropdown now has a loading spinner on realm switches
 
 ### Fixed
 - If no internet connection exists on startup, `API.Instance()` will retry every 2 seconds until a connection is established

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/RealmDropdownVisualElement/RealmDropdownVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/RealmDropdownVisualElement/RealmDropdownVisualElement.uss
@@ -7,8 +7,8 @@
 }
 
 RealmDropdownVisualElement LoadingIndicatorVisualElement {
-    position: absolute;
     top: 20px;
+    align-items: center;
 }
 RealmDropdownVisualElement {
     flex-grow: 1;
@@ -16,6 +16,7 @@ RealmDropdownVisualElement {
 RealmDropdownVisualElement > TemplateContainer {
     flex-grow: 1;
 }
+RealmDropdownVisualElement .cover,
 RealmDropdownVisualElement #mainBlockedContent.cover {
     position: absolute;
     left: 100000px;

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/RealmDropdownVisualElement/RealmDropdownVisualElement.uxml
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/RealmDropdownVisualElement/RealmDropdownVisualElement.uxml
@@ -14,7 +14,9 @@
         </engine:Button>
 
         <engine:VisualElement>
-            <beamable:LoadingIndicatorVisualElement/>
+            <beamable:LoadingIndicatorVisualElement>
+                <beamable:LoadingSpinnerVisualElement/>
+            </beamable:LoadingIndicatorVisualElement>
         </engine:VisualElement>
 
         <engine:VisualElement name="mainBlockedContent">
@@ -23,6 +25,7 @@
                     <!-- list of realm -->
                 </engine:VisualElement>
             </engine:ScrollView>
+
         </engine:VisualElement>
 
     </engine:VisualElement>


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-1720

# Brief Description
![realms](https://user-images.githubusercontent.com/3848374/137536423-7d46529c-e74f-448b-933b-71434e5a7207.gif)

The loading spinner color feels wrong for dark mode, but, thats what it is everywhere else too. 
And yeah, now when you change realms, we show this spinner while the actual realm switch happens.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 