### PR TITLE
beam 1763- logs are serialized through recompiles

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Model/MicroserviceModel.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Model/MicroserviceModel.cs
@@ -24,7 +24,15 @@ namespace Beamable.Editor.UI.Model
     [System.Serializable]
     public class MicroserviceModel : ServiceModelBase, IBeamableMicroservice
     {
-        public MicroserviceDescriptor ServiceDescriptor { get; protected set; }
+        [SerializeField]
+        private MicroserviceDescriptor _serviceDescriptor;
+
+        public MicroserviceDescriptor ServiceDescriptor
+        {
+            get => _serviceDescriptor;
+            set => _serviceDescriptor = value;
+        }
+
         public MicroserviceBuilder ServiceBuilder { get; protected set; }
         public override IBeamableBuilder Builder => ServiceBuilder;
         public override IDescriptor Descriptor => ServiceDescriptor;

--- a/client/Packages/com.beamable.server/Editor/UI/Model/ServiceModelBase.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Model/ServiceModelBase.cs
@@ -23,8 +23,17 @@ namespace Beamable.Editor.UI.Model
     public abstract class ServiceModelBase : IBeamableService
     {
         public abstract bool IsRunning { get; }
-        public bool AreLogsAttached { get; protected set; } = true;
-        public LogMessageStore Logs { get; } = new LogMessageStore();
+        public bool AreLogsAttached
+        {
+            get => _areLogsAttached;
+            protected set => _areLogsAttached = value;
+        }
+
+        [SerializeField] private bool _areLogsAttached = true;
+        [SerializeField] private LogMessageStore _logs = new LogMessageStore();
+
+        public LogMessageStore Logs => _logs;
+
         public abstract IDescriptor Descriptor { get; }
         public abstract IBeamableBuilder Builder { get; }
         public ServiceType ServiceType => Descriptor.ServiceType;


### PR DESCRIPTION
# Ticket 
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-1763

# Brief Description
A few things, in Unity, properties don't get serialized, and unity doesn't support polymorphic serialization. In order to support logs and statefullness through recompiles, we need to have some backing fields, and some separate lists where we pull apart the uniqued list of services. 

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 