### PR TITLE
Revert "[BEAM-1761] Fix of content fields serialization"

### DIFF
--- a/client/Packages/com.beamable/Common/Runtime/Content/ContentEnums.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Content/ContentEnums.cs
@@ -33,16 +33,10 @@ namespace Beamable.Common.Content
         /// <param name="value">Value to be converted</param>
         /// <param name="defaultValue">Value to be set if conversion fails</param>
         /// <typeparam name="T">Target enum type</typeparam>
-        /// /// <returns>True if value was actually converted</returns>
-        public static bool ConvertIfNotDoneAlready<T>(ref T conversionTarget, ref OptionalString value,
+        public static void ConvertIfNotDoneAlready<T>(ref T conversionTarget, ref OptionalString value,
             T defaultValue = default) where T : Enum
         {
-            if (value == null)
-            {
-                return false;
-            }
-            
-            return ConvertIfNotDoneAlready(ref conversionTarget, ref value.Value, defaultValue);
+            ConvertIfNotDoneAlready(ref conversionTarget, ref value.Value, defaultValue);
         }
         
         /// <summary>
@@ -54,18 +48,13 @@ namespace Beamable.Common.Content
         /// <param name="value">Value to be converted</param>
         /// <param name="defaultValue">Value to be set if conversion fails</param>
         /// <typeparam name="T">Target enum type</typeparam>
-        /// <returns>True if value was actually converted</returns>
-        public static bool ConvertIfNotDoneAlready<T>(ref T conversionTarget, ref string value, T defaultValue = default) where T : Enum
+        public static void ConvertIfNotDoneAlready<T>(ref T conversionTarget, ref string value, T defaultValue = default) where T : Enum
         {
-            if (value != null && value != VALUE_CONVERTED_MARKER)
+            if (value != VALUE_CONVERTED_MARKER)
             {
                 conversionTarget = ParseEnumType(value, defaultValue);
                 value = VALUE_CONVERTED_MARKER;
-
-                return true;
             }
-
-            return false;
         }
     }
     

--- a/client/Packages/com.beamable/Common/Runtime/Modules/Announcements/AnnouncementRef.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Modules/Announcements/AnnouncementRef.cs
@@ -1,7 +1,6 @@
 using System;
 using Beamable.Common.Content;
 using Beamable.Common.Content.Validation;
-using Beamable.Content;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -56,7 +55,7 @@ namespace Beamable.Common.Announcements
 
    [System.Serializable]
    [Agnostic]
-   public class AnnouncementAttachment : ISerializationCallbackReceiver
+   public class AnnouncementAttachment :ISerializationCallbackReceiver
    {
       [Tooltip("This should be the contentId of the attachment. Either an item id, or a currency id.")]
       [MustBeCurrencyOrItem]
@@ -68,16 +67,8 @@ namespace Beamable.Common.Announcements
 
       [FormerlySerializedAs("type")]
       [SerializeField, HideInInspector]
-      [IgnoreContentField]
       // TODO: [MustMatchReference(nameof(symbol))]
       private string typeOld;
-
-      /// <summary>
-      /// Don't use this field. It's used only for JSON serialization.
-      /// </summary>
-      [SerializeField, HideInInspector]
-      [ContentField("type")]
-      private string typeSerializedValue;
 
       [Obsolete("Use 'contentType' instead")]
       public string type
@@ -87,20 +78,15 @@ namespace Beamable.Common.Announcements
       }
 
       [Tooltip("Must specify the type of the attachment symbol. If you referenced an item in the symbol, this should be \"items\", otherwise it should be \"currency\"")]
-      [IgnoreContentField]
       public ContentType contentType;
 
       public void OnBeforeSerialize()
       {
-         typeSerializedValue = contentType.ToString().ToLower();
       }
 
       public void OnAfterDeserialize()
       {
-         if (!EnumConversionHelper.ConvertIfNotDoneAlready(ref contentType, ref typeOld))
-         {
-            contentType = EnumConversionHelper.ParseEnumType<ContentType>(typeSerializedValue);
-         }
+         EnumConversionHelper.ConvertIfNotDoneAlready(ref contentType, ref typeOld);
       }
    }
 }

--- a/client/Packages/com.beamable/Common/Runtime/Modules/Shop/ListingContent.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Modules/Shop/ListingContent.cs
@@ -188,7 +188,6 @@ namespace Beamable.Common.Shop
    {
       [FormerlySerializedAs("type")]
       [SerializeField, HideInInspector]
-      [IgnoreContentField]
       private string typeOld;
 
       [Obsolete("Use 'priceType' instead")]
@@ -200,15 +199,7 @@ namespace Beamable.Common.Shop
 
       [Tooltip(ContentObject.TooltipType1)]
       [MustBeNonDefault]
-      [IgnoreContentField]
       public PriceType priceType;
-
-      /// <summary>
-      /// Don't use this field. It's used only for JSON serialization.
-      /// </summary>
-      [SerializeField, HideInInspector]
-      [ContentField("type")]
-      private string priceSerializedValue;
       
       [Tooltip(ContentObject.TooltipSymbol1)]
       [MustReferenceContent(false, typeof(CurrencyContent), typeof(SKUContent))]
@@ -220,15 +211,11 @@ namespace Beamable.Common.Shop
 
       public void OnBeforeSerialize()
       {
-         priceSerializedValue = priceType.ToString().ToLower();
       }
 
       public void OnAfterDeserialize()
       {
-         if (!EnumConversionHelper.ConvertIfNotDoneAlready(ref priceType, ref typeOld))
-         {
-            priceType = EnumConversionHelper.ParseEnumType<PriceType>(priceSerializedValue);
-         }
+         EnumConversionHelper.ConvertIfNotDoneAlready(ref priceType, ref typeOld);
       }
    }
 
@@ -270,17 +257,9 @@ namespace Beamable.Common.Shop
       
       [FormerlySerializedAs("domain")]
       [SerializeField, HideInInspector]
-      [IgnoreContentField]
       private OptionalString domainOld;
 
       private OptionalString domainCached;
-
-      /// <summary>
-      /// Don't use this field. It's used only for JSON serialization.
-      /// </summary>
-      [SerializeField, HideInInspector]
-      [ContentField("domain")]
-      private string domainSerializedValue;
       
       [Obsolete("Use 'domainType' instead")]
       public OptionalString domain
@@ -294,7 +273,6 @@ namespace Beamable.Common.Shop
       }
 
       [Tooltip("Domain of the stat (e.g. 'platform', 'game', 'client'). Default is 'game'.")]
-      [IgnoreContentField]
       public DomainType domainType;
 
       #endregion
@@ -302,17 +280,9 @@ namespace Beamable.Common.Shop
       #region access
       
       [SerializeField, HideInInspector] [FormerlySerializedAs("access")]
-      [IgnoreContentField]
       private OptionalString accessOld;
 
       private OptionalString accessCached;
-
-      /// <summary>
-      /// Don't use this field. It's used only for JSON serialization.
-      /// </summary>
-      [ContentField("access")] 
-      [SerializeField, HideInInspector]
-      private string accessSerializedValue;
 
       [Obsolete("Use 'accessType' instead")]
       public OptionalString access
@@ -326,7 +296,6 @@ namespace Beamable.Common.Shop
       }
 
       [Tooltip("Visibility of the stat (e.g. 'private', 'public'). Default is 'private'.")]
-      [IgnoreContentField]
       public AccessType accessType;
       
       #endregion
@@ -338,16 +307,8 @@ namespace Beamable.Common.Shop
       
       [FormerlySerializedAs("constraint")] 
       [SerializeField, HideInInspector]
-      [IgnoreContentField]
       private string constraintOld;
 
-      /// <summary>
-      /// Don't use this field. It's used only for JSON serialization.
-      /// </summary>
-      [SerializeField, HideInInspector]
-      [ContentField("constraint")]
-      private string constraintSerializedValue;
-      
       [Obsolete("Use 'constraintType' instead")]
       public string constraint
       {
@@ -357,7 +318,6 @@ namespace Beamable.Common.Shop
 
       [Tooltip(ContentObject.TooltipConstraint1)]
       [MustBeNonDefault]
-      [IgnoreContentField]
       public ComparatorType constraintType;
       
       #endregion
@@ -366,27 +326,13 @@ namespace Beamable.Common.Shop
 
       public void OnBeforeSerialize()
       {
-         domainSerializedValue = domainType.ToString().ToLower();
-         accessSerializedValue = accessType.ToString().ToLower();
-         constraintSerializedValue = constraintType.ToString().ToLower();
       }
 
       public void OnAfterDeserialize()
       {
-         if (!EnumConversionHelper.ConvertIfNotDoneAlready(ref accessType, ref accessOld))
-         {
-            accessType = EnumConversionHelper.ParseEnumType<AccessType>(accessSerializedValue);
-         }
-
-         if (!EnumConversionHelper.ConvertIfNotDoneAlready(ref constraintType, ref constraintOld))
-         {
-            constraintType = EnumConversionHelper.ParseEnumType<ComparatorType>(constraintSerializedValue);
-         }
-
-         if (!EnumConversionHelper.ConvertIfNotDoneAlready(ref domainType, ref domainOld))
-         {
-            domainType = EnumConversionHelper.ParseEnumType<DomainType>(domainSerializedValue);
-         }
+         EnumConversionHelper.ConvertIfNotDoneAlready(ref accessType, ref accessOld);
+         EnumConversionHelper.ConvertIfNotDoneAlready(ref constraintType, ref constraintOld);
+         EnumConversionHelper.ConvertIfNotDoneAlready(ref domainType, ref domainOld);
       }
    }
 
@@ -403,15 +349,7 @@ namespace Beamable.Common.Shop
 
       [FormerlySerializedAs("constraint")]
       [SerializeField, HideInInspector]
-      [IgnoreContentField]
       private string constraintOld;
-
-      /// <summary>
-      /// Don't use this field. It's used only for JSON serialization.
-      /// </summary>
-      [SerializeField, HideInInspector]
-      [ContentField("constraint")]
-      private string constraintSerializedValue;
 
       [Obsolete("Use 'constraintType' instead")]
       public string constraint
@@ -421,20 +359,15 @@ namespace Beamable.Common.Shop
       }
 
       [Tooltip(ContentObject.TooltipConstraint1)]
-      [IgnoreContentField]
       public ComparatorType constraintType;
 
       public void OnBeforeSerialize()
       {
-         constraintSerializedValue = constraintType.ToString().ToLower();
       }
 
       public void OnAfterDeserialize()
       {
-         if (!EnumConversionHelper.ConvertIfNotDoneAlready(ref constraintType, ref constraintOld))
-         {
-            constraintType = EnumConversionHelper.ParseEnumType<ComparatorType>(constraintSerializedValue);
-         }
+         EnumConversionHelper.ConvertIfNotDoneAlready(ref constraintType, ref constraintOld);
       }
    }
 
@@ -448,15 +381,7 @@ namespace Beamable.Common.Shop
    public class OfferConstraint : ISerializationCallbackReceiver
    {
       [FormerlySerializedAs("constraint"), HideInInspector]
-      [IgnoreContentField]
       public string constraintOld;
-
-      /// <summary>
-      /// Don't use this field. It's used only for JSON serialization.
-      /// </summary>
-      [SerializeField, HideInInspector]
-      [ContentField("constraint")]
-      private string constraintSerializedValue;
 
       [Obsolete("Use 'constraintType' instead")]
       public string constraint
@@ -466,7 +391,6 @@ namespace Beamable.Common.Shop
       }
       
       [Tooltip(ContentObject.TooltipConstraint1)]
-      [IgnoreContentField]
       public ComparatorType constraintType;
 
       [Tooltip(ContentObject.TooltipValue1)]
@@ -474,15 +398,11 @@ namespace Beamable.Common.Shop
 
       public void OnBeforeSerialize()
       {
-         constraintSerializedValue = constraintType.ToString().ToLower();
       }
 
       public void OnAfterDeserialize()
       {
-         if (!EnumConversionHelper.ConvertIfNotDoneAlready(ref constraintType, ref constraintOld))
-         {
-            constraintType = EnumConversionHelper.ParseEnumType<ComparatorType>(constraintSerializedValue);
-         }
+         EnumConversionHelper.ConvertIfNotDoneAlready(ref constraintType, ref constraintOld);
       }
    }
    [System.Serializable]

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Content/Serialization/ClientContentSerializer/DeserializeTests.cs
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Content/Serialization/ClientContentSerializer/DeserializeTests.cs
@@ -2,9 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
-using Beamable.Common.Announcements;
 using Beamable.Common.Content;
-using Beamable.Common.Shop;
 using Beamable.Tests.Content.Serialization.Support;
 using Beamable.Content;
 using Beamable.UI;
@@ -1026,92 +1024,6 @@ namespace Beamable.Tests.Content.Serialization.ClientContentSerializationTests
            Assert.AreEqual("bogus.nothing", o.Id);
         }
 
-        [Test]
-        public void ListingEnumsDeserialization()
-        {
-           string json = @"{
-           ""id"": ""bogus.nothing"",
-               ""version"": """",
-               ""properties"":
-               {
-                  ""price"":
-                  {
-                     ""data"":
-                     {
-                        ""symbol"": null,
-                        ""amount"": 100,
-                        ""type"": ""currency""
-                     }
-                  },
-                  ""requirement"":
-                  {
-                     ""data"":
-                     {
-                        ""stat"": null,
-                        ""value"": 0,
-                        ""domain"": ""client"",
-                        ""access"": ""public"",
-                        ""constraint"": ""lt""
-                     }
-                  },
-                  ""cohort"":
-                  {
-                     ""data"":
-                     {
-                        ""trial"": ""trial"",
-                        ""cohort"": ""cohort"",
-                        ""constraint"": ""eq""
-                     }
-                  },
-                  ""offer"":
-                  {
-                     ""data"":
-                     {
-                        ""value"": 0,
-                        ""constraint"": ""ge""
-                     }
-                  }
-               }
-           }";
-           
-           var serializer = new TestSerializer();
-           var deserialized = serializer.Deserialize<ListingTestContent>(json);
-
-           Assert.AreEqual(PriceType.Currency, deserialized.price.priceType);
-           Assert.AreEqual(DomainType.Client, deserialized.requirement.domainType);
-           Assert.AreEqual(AccessType.Public, deserialized.requirement.accessType);
-           Assert.AreEqual(ComparatorType.Lt, deserialized.requirement.constraintType);
-           Assert.AreEqual(ComparatorType.Eq, deserialized.cohort.constraintType);
-           Assert.AreEqual(ComparatorType.Ge, deserialized.offer.constraintType);
-        }
-
-        [Test]
-        public void AnnouncementDeserialization()
-        {
-           string json =
-              @"{
-                ""id"": ""bogus.nothing"",
-                ""version"": """",
-                ""properties"":
-                {
-                    ""announcement"":
-                    {
-                        ""data"":
-                        {
-                            ""symbol"": null,
-                            ""count"": 5,
-                            ""type"": ""items""
-                        }
-                    }
-                }
-              }";
-           
-           var serializer = new TestSerializer();
-           var deserialized = serializer.Deserialize<AnnouncementContent>(json);
-           
-           Assert.AreEqual(ContentType.Items, deserialized.announcement.contentType);
-        }
-
 
 #pragma warning disable CS0649
 
@@ -1237,19 +1149,6 @@ namespace Beamable.Tests.Content.Serialization.ClientContentSerializationTests
         class FormerlyContentNestedContent : TestContentObject
         {
             public FormerlyContentField Nested;
-        }
-        
-        class ListingTestContent : TestContentObject
-        {
-           public ListingPrice price;
-           public StatRequirement requirement;
-           public CohortRequirement cohort;
-           public OfferConstraint offer;
-        }
-
-        class AnnouncementContent : TestContentObject
-        {
-           public AnnouncementAttachment announcement;
         }
 
         [ContentType("test")]

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Content/Serialization/ClientContentSerializer/SerializeTests.cs
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Content/Serialization/ClientContentSerializer/SerializeTests.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Beamable.Common.Announcements;
 using Beamable.Common.Content;
-using Beamable.Common.Shop;
 using Beamable.Tests.Content.Serialization.Support;
 using Beamable.Content;
 using NUnit.Framework;
@@ -837,117 +835,6 @@ namespace Beamable.Tests.Content.Serialization.ClientContentSerializationTests
          Assert.AreEqual(expected, json);
       }
 
-      [Test]
-      public void ListingEnumsSerialization()
-      {
-         string expected = 
-         @"{
-          ""id"": null,
-               ""version"": """",
-               ""properties"":
-               {
-                  ""price"":
-                  {
-                     ""data"":
-                     {
-                        ""symbol"": null,
-                        ""amount"": 100,
-                        ""type"": ""currency""
-                     }
-                  },
-                  ""requirement"":
-                  {
-                     ""data"":
-                     {
-                        ""stat"": null,
-                        ""value"": 0,
-                        ""domain"": ""client"",
-                        ""access"": ""public"",
-                        ""constraint"": ""lt""
-                     }
-                  },
-                  ""cohort"":
-                  {
-                     ""data"":
-                     {
-                        ""trial"": ""trial"",
-                        ""cohort"": ""cohort"",
-                        ""constraint"": ""eq""
-                     }
-                  },
-                  ""offer"":
-                  {
-                     ""data"":
-                     {
-                        ""value"": 0,
-                        ""constraint"": ""ge""
-                     }
-                  }
-               }
-         }".Replace(Environment.NewLine, "").Replace(" ", "");
-         
-         var content = new ListingTestContent
-         {
-            price = new ListingPrice
-            {
-               amount = 100, priceType = PriceType.Currency
-            },
-            cohort = new CohortRequirement
-            {
-               cohort= "cohort", constraintType =  ComparatorType.Eq, trial = "trial"
-            },
-            offer = new OfferConstraint
-            {
-               value = 0, constraintType = ComparatorType.Ge
-            },
-            requirement = new StatRequirement
-            {
-               accessType = AccessType.Public, domainType = DomainType.Client, 
-               constraintType = ComparatorType.Lt, value = 0
-            }
-         };
-         
-         var serializer = new TestSerializer();
-         string serialized = serializer.Serialize(content);
-         
-         Assert.AreEqual(expected, serialized);
-      }
-
-      [Test]
-      public void AnnouncementSerialization()
-      {
-         string expected = 
-         @"{
-             ""id"": null,
-             ""version"": """",
-             ""properties"":
-             {
-                 ""announcement"":
-                 {
-                     ""data"":
-                     {
-                         ""symbol"": null,
-                         ""count"": 5,
-                         ""type"": ""items""
-                     }
-                 }
-             }
-         }".Replace(Environment.NewLine, "").Replace(" ", "");
-         
-         var content = new AnnouncementContent
-         {
-            announcement = new AnnouncementAttachment
-            {
-               contentType = ContentType.Items, count = 5
-            }
-         };
-
-         var serializer = new TestSerializer();
-         string serialized = serializer.Serialize(content);
-         
-         Assert.AreEqual(expected, serialized);
-      }
-
 
       [System.Serializable]
       class PrimitiveContent : TestContentObject
@@ -1051,19 +938,6 @@ namespace Beamable.Tests.Content.Serialization.ClientContentSerializationTests
       class LinkListContent : TestContentObject
       {
          public List<PrimitiveLink> links;
-      }
-
-      class ListingTestContent : TestContentObject
-      {
-         public ListingPrice price;
-         public StatRequirement requirement;
-         public CohortRequirement cohort;
-         public OfferConstraint offer;
-      }
-
-      class AnnouncementContent : TestContentObject
-      {
-         public AnnouncementAttachment announcement;
       }
 
       enum TestEnum


### PR DESCRIPTION
These changes caused an issue with changing values of content enums in the inspector.