### PR TITLE
using default docker location if path in config is empty

### DIFF
--- a/client/Assets/Beamable/Resources/MicroserviceConfiguration.asset
+++ b/client/Assets/Beamable/Resources/MicroserviceConfiguration.asset
@@ -49,11 +49,13 @@ MonoBehaviour:
       Username: root
       Password: Password!
       SshPort: 11103
+  StorageObjects: []
   CustomContainerPrefix: 
   AutoReferenceContent: 0
   ColorLogs: 0
   EnableDockerBuildkit: 0
-  DockerCommand: /usr/local/bin/docker
+  EnableStoragePreview: 0
+  DockerCommand: 
   ForwardContainerLogsToUnityConsole: 1
   LogProcessLabelColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   LogStandardOutColor: {r: 0.4, g: 0.4, b: 1, a: 1}

--- a/client/Packages/com.beamable.server/Editor/DockerCommands/ProcessCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/ProcessCommand.cs
@@ -31,7 +31,7 @@ namespace Beamable.Server.Editor.DockerCommands
 
       private bool _started, _hasExited;
       protected int _exitCode = -1;
-      protected string DockerCmd => MicroserviceConfiguration.Instance.DockerCommand;
+      protected string DockerCmd => MicroserviceConfiguration.Instance.ValidatedDockerCommand;
       public Action<int> OnExit;
 
       public bool WriteLogToUnity { get; set; }

--- a/client/Packages/com.beamable.server/Editor/MicroserviceConfiguration.cs
+++ b/client/Packages/com.beamable.server/Editor/MicroserviceConfiguration.cs
@@ -57,6 +57,11 @@ namespace Beamable.Server.Editor
 
       public string DockerCommand = DOCKER_LOCATION;
       private string _dockerCommandCached = DOCKER_LOCATION;
+      
+      public string ValidatedDockerCommand => string.IsNullOrWhiteSpace(DockerCommand) ? 
+         DOCKER_LOCATION :
+         DockerCommand;
+      
       private bool _enableStoragePreviewCached = false;
 
       #if !BEAMABLE_LEGACY_MSW


### PR DESCRIPTION
# Brief Description
When a path to Docker is empty, we should use the default location.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 