### PR TITLE
Ignore Editor Meta File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,4 +101,5 @@ client/Assets/AddressableAssetsData/Android/
 client/Assets/Beamable/Resources/config-defaults.txt
 
 # Every developer's Editor.meta is going to be different by virtue of different layouts and stuff. If Editor.meta is missing, Unity will regenerate it from scratch.
+client/Assets/Editor.meta
 client/Assets/Plugins/Editor.meta

--- a/client/Assets/Editor.meta
+++ b/client/Assets/Editor.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 0c3c38d71e24a4b4095069909a6f4159
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
# Brief Description

The `Editor.meta` file is gonna differ for every developer, so let's just ignore it.
Because Unity will regenerate `Editor.meta` from scratch if needed, I believe it is fine to not even have it in the repo.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 