### PR TITLE
[BEAM-1605] CMV2 download loading bar is too short to fit in container

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Content/Components/DownloadContentVisualElement/DownloadContentVisualElement.uxml
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/DownloadContentVisualElement/DownloadContentVisualElement.uxml
@@ -8,6 +8,8 @@
         xsi:noNamespaceSchemaLocation="../UIElementsSchema/UIElements.xsd"
         xsi:schemaLocation="UnityEngine.Experimental.UIElements ../UIElementsSchema/UnityEngine.Experimental.UIElements.xsd Beamable.Editor.Content.Components">
 
+    <beamable:LoadingBarElement/>
+    
     <engine:VisualElement name="loadingViewContainer">
         <beamable:LoadingIndicatorVisualElement>
             <beamable:LoadingSpinnerVisualElement/>
@@ -15,7 +17,6 @@
     </engine:VisualElement>
 
     <engine:VisualElement name="mainVisualElement" >
-        <beamable:LoadingBarElement/>
 
         <engine:Label name="message" text="placeholder"/>
 


### PR DESCRIPTION
# Brief Description

![image](https://user-images.githubusercontent.com/18366601/138121115-a3cd8afd-27bf-4276-aaff-039a06d844ab.png)
![image](https://user-images.githubusercontent.com/18366601/138121082-ce21b30a-cac7-4cd3-b79a-95bb80c18fc2.png)

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 