### PR TITLE
dont comment on push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,7 +174,7 @@ jobs:
         if: ${{ matrix.targetPlatform == 'WebGL' }}
         run: AWS_ACCESS_KEY_ID=${{secrets.AWS_KEY_ID}} AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY}} AWS_REGION=us-west-2 aws s3 cp --recursive ./dist/WebGL s3://${{secrets.AWS_BUCKET_BUILDS}}/uploads/${{github.sha}}
       - uses: github-actions-up-and-running/pr-comment@v1.0.1
-        if: ${{ matrix.targetPlatform == 'WebGL' }}
+        if: ${{ matrix.targetPlatform == 'WebGL' && github.event_name == 'pull_request' }}
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           message: Have a ${{ matrix.targetPlatform }} build, friend. [${{github.sha}}](https://beamable-product-github-builds.s3.us-west-2.amazonaws.com/uploads/${{github.sha}}/WebGL/index.html)


### PR DESCRIPTION
the webGL build action tries to comment on a pull request, but the same job runs on push to `main`. There is nothing to comment on, and so it fails. This adds a check to only run the commenter on a pull request.