### PR TITLE
[BEAM-1811] adds device id view, add, remove

### DIFF
--- a/portal/src/components/PlayerProfile.svelte
+++ b/portal/src/components/PlayerProfile.svelte
@@ -63,6 +63,11 @@
         return next;
     }
 
+    async function handleDeviceIdWrite(next, old){
+        await players.updateDeviceId(player, next);
+        return next;
+    }
+
 </script>
 
 <style lang="scss">
@@ -211,6 +216,20 @@
                     <!-- only exists to provide consisten spacing with email input. -->
                 </div>
             </div>
+        </div>
+
+        <div class="field">
+            <label class="label">Device Id</label>
+            <AsyncInput
+                value={player.deviceId}
+                inputType="text"
+                placeholder="No Device Id Provided"
+                onWrite={handleDeviceIdWrite}
+                editable={true}
+                floatError={true}
+                buttonTopPadding={4}
+            />
+       
         </div>
 
         <div class="field">

--- a/portal/src/services/players.ts
+++ b/portal/src/services/players.ts
@@ -40,6 +40,7 @@ export interface PlayerDataInterface {
     readonly email: string;
     readonly createdTimeMillis: number;
     readonly id: number;
+    readonly deviceId: string;
     readonly updatedTimeMillis: number;
     readonly gamerTags: Array<GamerTag>;
     readonly thirdParties: Array<ThirdPartyAssociation>;
@@ -49,18 +50,20 @@ export class PlayerData {
     readonly email: string;
     readonly createdTimeMillis: number;
     readonly id: number;
+    readonly deviceId: string;
     readonly updatedTimeMillis: number;
     readonly gamerTags: Array<GamerTag>;
     readonly thirdParties: Array<ThirdPartyAssociation>;
     private defaultRealmId: string;
 
     constructor(
-        {email, createdTimeMillis, id, updatedTimeMillis, gamerTags, thirdParties}: PlayerDataInterface,
+        {email, createdTimeMillis, id, deviceId, updatedTimeMillis, gamerTags, thirdParties}: PlayerDataInterface,
         realmId: string
     ) {
         this.email = email;
         this.createdTimeMillis = createdTimeMillis;
         this.id = id;
+        this.deviceId = deviceId ?? '';
         this.updatedTimeMillis = updatedTimeMillis;
         this.gamerTags = gamerTags;
         this.thirdParties = thirdParties;
@@ -157,6 +160,19 @@ export class PlayersService extends BaseService {
             newEmail,
         };
         const url = `/object/accounts/${player.id}/admin/email`;
+        const response = await http.request(url, request, 'put');
+
+        return new PlayerData(response.data as PlayerDataInterface, router.getRealmId());
+    }
+
+    async updateDeviceId(player: PlayerData, newDeviceId: string): Promise<PlayerData> {
+        const { http, router } = this.app;
+
+        const request = newDeviceId && newDeviceId.length > 0 
+            ? { deviceId: newDeviceId }
+            : null;
+        
+        const url = `/object/accounts/${player.id}`;
         const response = await http.request(url, request, 'put');
 
         return new PlayerData(response.data as PlayerDataInterface, router.getRealmId());


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-1811 

# Brief Description
The svelte portal didn't have a way to view the player's registered device Id. _Until Now_. 
Now there is a text line in the player profile, located near the email and third parties. Unlike the email, you can actually set the device Id if it doesn't yet exist. (which means you are adding it). You can also edit it. To remove it, you edit it to an empty string. The frontend will see the empty string, and turn the operation into a delete. 


![image](https://user-images.githubusercontent.com/3848374/139311982-ad7e5d6c-5a81-4d80-8bca-b600e246b181.png)

![deviceId](https://user-images.githubusercontent.com/3848374/139312149-a6bc80fa-723d-4db5-858f-ecbe36f72fdf.gif)

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 