### PR TITLE
[beam-1724] fixes warning after opening schedule type dropdown

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `BeamableEnvironment` has moved to the Runtime to enable sdk version checking at runtime
 
+### Fixed
+- Removes _Menu Window/Panels/1_ warning after opening schedule type dropdown on Unity 2019 and 2020
+
 ## [0.17.2]
 ### Added
 - `CoreConfiguration` to project settings to tweak how our Promise library handles uncaught promises by default

--- a/client/Packages/com.beamable/Common/Runtime/Promise.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Promise.cs
@@ -66,9 +66,9 @@ namespace Beamable.Common
       private static event PromiseEvent OnPotentialUncaughtError;
 
       public static bool HasUncaughtErrorHandler => OnPotentialUncaughtError != null;
-      
+
       /// <summary>
-      /// Set error handlers for uncaught promise errors. Beamable has a default handler set in its API initialization. 
+      /// Set error handlers for uncaught promise errors. Beamable has a default handler set in its API initialization.
       /// </summary>
       /// <param name="handler">The new error handler.</param>
       /// <param name="replaceExistingHandlers">When TRUE, will replace all previously set handlers. When FALSE, will add the given handler.</param>
@@ -77,11 +77,11 @@ namespace Beamable.Common
          // This overwrites it everytime, blowing away any other listeners.
          if (replaceExistingHandlers)
          {
-            OnPotentialUncaughtError = handler;            
+            OnPotentialUncaughtError = handler;
          }
          else // This allows someone to override the functionality.
          {
-            OnPotentialUncaughtError += handler;            
+            OnPotentialUncaughtError += handler;
          }
       }
 
@@ -503,6 +503,9 @@ namespace Beamable.Common
    [AsyncMethodBuilder(typeof(PromiseAsyncMethodBuilder))]
    public class Promise : Promise<Unit>
    {
+
+      public void CompleteSuccess() => CompleteSuccess(PromiseBase.Unit);
+
       /// <summary>
       /// Create a <see cref="SequencePromise{T}"/> from List of <see cref="Promise{T}"/>
       /// </summary>

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/BeamablePopupWindow/BeamablePopupWindow.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/BeamablePopupWindow/BeamablePopupWindow.cs
@@ -9,6 +9,7 @@ using Beamable.Editor.Content.Components;
 using Beamable.Editor.Content;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.IO;
+using Beamable.Common;
 #if UNITY_2018
 using UnityEngine.Experimental.UIElements;
 using UnityEditor.Experimental.UIElements;
@@ -80,6 +81,34 @@ namespace Beamable.Editor.UI.Buss.Components
 
             var halfSize = size * .5f;
             return new Rect(pt.x - halfSize.x, pt.y - halfSize.y, size.x, size.y);
+        }
+
+        /// <summary>
+        /// Create new popup with contents of any <see cref="BeamableVisualElement"/>
+        /// This method introduces a delayFrame to let later versions of Unity avoid throwing a warning about an unchecked window.
+        /// </summary>
+        /// <param name="title"></param>
+        /// <param name="sourceRect"></param>
+        /// <param name="size"></param>
+        /// <param name="content"></param>
+        /// <returns></returns>
+        public static async Promise<BeamablePopupWindow> ShowDropdownAsync(string title, Rect sourceRect, Vector2 size,
+            BeamableVisualElement content)
+        {
+            var wnd = CreateInstance<BeamablePopupWindow>();
+            var promise = new Promise();
+            EditorApplication.delayCall += () =>
+            {
+                wnd.titleContent = new GUIContent(title);
+                wnd._contentElement = content;
+                wnd.ShowAsDropDown(sourceRect, size);
+                wnd.GetRootVisualContainer().AddToClassList("fill-popup-window");
+
+                wnd.Refresh();
+                promise.CompleteSuccess();
+            };
+            await promise;
+            return wnd;
         }
 
         /// <summary>

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownVisualElement.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Beamable.Common;
 using Beamable.Editor.UI.Buss;
 using Beamable.Editor.UI.Buss.Components;
 using UnityEditor;
@@ -57,7 +58,7 @@ namespace Beamable.Editor.UI.Components
             _label.text = Value;
 
             _button = Root.Q<VisualElement>("button");
-            _button.RegisterCallback<MouseDownEvent>((e) => { OnButtonClicked(worldBound); });
+            _button.RegisterCallback<MouseDownEvent>(async (e) => await OnButtonClicked(worldBound) );
         }
 
         public void Setup(List<string> options, Action<string> onOptionSelected)
@@ -86,7 +87,7 @@ namespace Beamable.Editor.UI.Components
             _onSelection?.Invoke(option);
         }
 
-        private void OnButtonClicked(Rect bounds)
+        private async Promise OnButtonClicked(Rect bounds)
         {
             if (_optionsPopup != null)
             {
@@ -114,7 +115,7 @@ namespace Beamable.Editor.UI.Components
             DropdownOptionsVisualElement optionsWindow =
                 new DropdownOptionsVisualElement().Setup(allOptions, OnOptionsClosed);
 
-            _optionsPopup = BeamablePopupWindow.ShowDropdown("", popupWindowRect,
+            _optionsPopup = await BeamablePopupWindow.ShowDropdownAsync("", popupWindowRect,
                 new Vector2(_root.localBound.width, optionsWindow.GetHeight()), optionsWindow);
         }
 


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-1724

# Brief Description
In Unity 2019, and 2020, it seems like the Dropdown class needs a frame to come into being before we start messing with it's UIElement content. 
So I added a new method where it wraps a promise around an `EditorApplication.delayCall` and changed the schedule UI to use that one. There are a lot of other call sites to the old one, like on the realm picker that mysteriously works fine in 2020... so... unknown still... But this at leasts fixes the warning issue.

![stupidwarning](https://user-images.githubusercontent.com/3848374/140095990-b8a1fa40-29ac-4680-acaa-886bfbc125fc.gif)



# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 