### PR TITLE
[BEAM-1808] Fix Microservice publish progress bar

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Components/PublishManifestEntryVisualElement/PublishManifestEntryVisualElement.uss
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/PublishManifestEntryVisualElement/PublishManifestEntryVisualElement.uss
@@ -59,6 +59,7 @@
 
 #nameMS {
     -unity-font-style: bold;
+    margin-top: 6px;
 }
 
 #typeImage {


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-1808

# Brief Description
Previously progress bar in Microservices Manager would not disappear after deploy when remote-only services were being published. Currently this progress bar shows only local services which images need to be uploaded. Publish Window on the other hand shows progress for all services which manifests are to be uploaded. The gif shows an example: 2 remote services which only need manifests to be updated (so are presented only in Publish Window) and 2 local services which images and manifests are being uploaded (so are presented both in Publish Window and Microservices Manager).

![yDY9O6PryD](https://user-images.githubusercontent.com/12371373/140376690-ea1515fa-7037-42e8-8b0c-6a7dc664ae6b.gif)

Storage object manifests are also uploaded but without notifying the user since they are officially not supported on the server side.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 