### PR TITLE
[BEAM-1855] Unity constantly tries to switch to non-existing namespace

### DIFF
--- a/client/Assets/Beamable/Resources/ContentConfiguration.asset
+++ b/client/Assets/Beamable/Resources/ContentConfiguration.asset
@@ -13,5 +13,5 @@ MonoBehaviour:
   m_Name: ContentConfiguration
   m_EditorClassIdentifier: 
   EnableMultipleContentNamespaces: 1
-  EditorManifestID: second-manifest
+  EditorManifestID: global
   _runtimeManifestID: global


### PR DESCRIPTION
# Brief Description

Probably someone pushed contentConfig to repo so default (init) config for Editor ManifestID in scriptable was always set on not existed manifest (in my opinion should be "global" there)

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 