### PR TITLE
beam 1949 - adds missing px

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Common/Components/ExpandableListVisualElement/ExpandableListVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/ExpandableListVisualElement/ExpandableListVisualElement.uss
@@ -24,7 +24,7 @@
 #arrowImage {
     background-image: resource("Packages/com.beamable/Editor/UI/Content/Icons/dropdown Close.png");
     width: 14px;
-    height: 7;
+    height: 7px;
     margin-right: 8px;
     flex-direction: column;
     align-self: flex-start;


### PR DESCRIPTION
# Brief Description
In uss property decelerations, we must always have units. I've added a missing `px`
Refer to this document for this gotcha, and other annoying things https://disruptorbeam.atlassian.net/wiki/spaces/PLAT/pages/2156953601/Write+portable+UIElement+code+for+Unity+2018+2019+2020

# Checklist
* [-] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [-] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
