### PR TITLE
beam 1942 - only use InitializeOnEnterPlayMode in 2019.3

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Renamed Beamable's iOS plugin for Google Sign-In from `GoogleSignIn` to `BeamableGoogleSignIn` to prevent name collisions with public plugins.
 - `InventoryService.GetCurrent` is no longer limited by URI length
+- only use `InitializeOnEnterPlayMode` in Unity 2019.3 or higher
 
 ## [0.17.4]
 - no changes

--- a/client/Packages/com.beamable/Runtime/3rdParty/PubNub/Scripts/Pubnub/LoggingMethod.cs
+++ b/client/Packages/com.beamable/Runtime/3rdParty/PubNub/Scripts/Pubnub/LoggingMethod.cs
@@ -18,7 +18,7 @@ namespace PubNubMessaging.Core
     #endif
     {
         private static int logLevel = 0;
-        
+
 #if UNITY_EDITOR && UNITY_2019_1_OR_NEWER
 		[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
 #endif
@@ -272,8 +272,8 @@ namespace PubNubMessaging.Core
     public class PubnubErrorFilter
     {
         private static int errorLevel = 0;
-        
-#if UNITY_2019_1_OR_NEWER && UNITY_EDITOR
+
+#if UNITY_2019_3_OR_NEWER && UNITY_EDITOR
         [UnityEditor.InitializeOnEnterPlayMode]
 #endif
         static void Init()


### PR DESCRIPTION
# Brief Description
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-1942
Yep, silly oversight.

I'd recommend disabling whitespace on the diff.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [-] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
