### PR TITLE
beam 1963 - adds back a named Instance method to buss configuration

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Config/ConfigManager.cs
+++ b/client/Packages/com.beamable/Editor/UI/Config/ConfigManager.cs
@@ -79,7 +79,8 @@ namespace Beamable.Editor.Config
                   if (!isConfigurationType) continue;
 
                   var staticInstanceProperty = type.GetProperty(nameof(AvatarConfiguration.Instance),
-                     BindingFlags.Static | BindingFlags.Public);
+                     BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+
 
                   var hasInstanceProperty = staticInstanceProperty != null && staticInstanceProperty.CanRead;
                   if (!hasInstanceProperty) continue;

--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/BussConfiguration.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/BussConfiguration.cs
@@ -17,14 +17,15 @@ namespace Beamable.UI.Buss // TODO: rename it to Beamable.UI.BUSS - new system's
 {
 	public class BussConfiguration : ModuleConfigurationObject
 	{
-		// New system
-		public static Optional<BussConfiguration> Instance
+
+		private static BussConfiguration Instance => Get<BussConfiguration>();
+		public static Optional<BussConfiguration> OptionalInstance
 		{
 			get
 			{
 				try
 				{
-					return new Optional<BussConfiguration> {Value = Get<BussConfiguration>(), HasValue = true};
+					return new Optional<BussConfiguration> {Value = Instance, HasValue = true};
 				}
 				catch (ModuleConfigurationNotReadyException)
 				{
@@ -35,7 +36,7 @@ namespace Beamable.UI.Buss // TODO: rename it to Beamable.UI.BUSS - new system's
 
 		public static void UseConfig(Action<BussConfiguration> callback)
 		{
-			Instance.DoIfExists(callback);
+			OptionalInstance.DoIfExists(callback);
 		}
 
 		[SerializeField] private BussStyleSheet globalStyleSheet = null;


### PR DESCRIPTION
# Brief Description
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?assignee=5f344c62323607003855295d&selectedIssue=BEAM-1963

The issue was that the `ConfigManager` wants to load up all the configuration scriptable objects with the static `.Instance` method. This begs some love, because we find that method via reflection. 

When earlier, I'd changed the type of the `Instance` field to an optional configuration, it broke the config manager. ... Hear Jeff Goldblum saying "oops". 

I've added a private `Instance` field back that does the old thing, and changed the config manager to be able to see private fields too. I just don't want that `Instance` field public, or we are going to end up back where we started.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
