### PR TITLE
[BEAM-1869] fix content reimport for identical content data

### DIFF
--- a/client/Packages/com.beamable/Common/Runtime/Content/ContentObject.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Content/ContentObject.cs
@@ -235,7 +235,8 @@ namespace Beamable.Common.Content
             typeName = ContentRegistry.GetTypeNameFromId(id);
          }
 
-         _contentTypeName = typeName;
+			if (!string.Equals(_contentTypeName, typeName))
+				_contentTypeName = typeName;
 
          if (!id.StartsWith(typeName))
          {
@@ -243,7 +244,9 @@ namespace Beamable.Common.Content
          }
 
          SetContentName(id.Substring(typeName.Length + 1)); // +1 for the dot.
-         Version = version;
+
+		 if (!string.Equals(Version, version))
+			Version = version;
       }
 
       /// <summary>
@@ -262,10 +265,13 @@ namespace Beamable.Common.Content
       /// <returns></returns>
       public ContentObject SetContentName(string newContentName)
       {
-         ContentName = newContentName;
+		 if (!string.Equals(ContentName, newContentName))
+			 ContentName = newContentName;
+
          if (Application.isPlaying)
          {
-            name = newContentName; // only set the SO name if we are in-game. Internally, Beamable does not depend on the SO name, but a gameMaker may want to use it.
+			if (!string.Equals(name, newContentName))
+				name = newContentName; // only set the SO name if we are in-game. Internally, Beamable does not depend on the SO name, but a gameMaker may want to use it.
          }
 
          return this;


### PR DESCRIPTION
# Brief Description

after investigation based on IdleKit showcase sample i realized that problem with unnecessarily reimport occurs in content update on our side so we don't need any asset reimport option just this small magic fix

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
