### PR TITLE
[BEAM-1981] 0.18.0 Blocker - schedule window missing dropdown images on win2018 light

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Common/Components/LabeledNumberPicker/LabeledNumberPicker.uss
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/LabeledNumberPicker/LabeledNumberPicker.uss
@@ -28,6 +28,7 @@ LabeledTextField #textField > TextInput {
 }
 
 #button {
+    opacity: 0;
     background-color: rgba(0,0,0,0);
     border-top-width: 0px;
     border-bottom-width: 0px;


### PR DESCRIPTION
# Brief Description

Added only opacity property  to USS and now it's working on all Unity version.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
