### PR TITLE
[BEAM-1990] Fix "Forgot password" functionality working only once

### DIFF
--- a/client/Packages/com.beamable/Runtime/Modules/AccountManagement/Scripts/AccountForgotPassword.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/AccountManagement/Scripts/AccountForgotPassword.cs
@@ -20,7 +20,6 @@ namespace Beamable.AccountManagement
         void Start()
         {
             ErrorText.Value = "";
-            SetForSendEmail();
         }
 
         // Update is called once per frame
@@ -33,6 +32,7 @@ namespace Beamable.AccountManagement
         {
             Arguments.Password.Value = "";
             Arguments.Code.Value = "";
+            SetForSendEmail();
         }
 
         public void SetEmail(string email)


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-1990

# Brief Description
Before "send email" state was being set only on `Start` which runs only once. Now I'm setting this state on each `OnOpened` method call.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
