### PR TITLE
beam 2000 - docker check too strict

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Components/MicroserviceContentVisualElement/MicroserviceContentVisualElement.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/MicroserviceContentVisualElement/MicroserviceContentVisualElement.cs
@@ -336,7 +336,7 @@ namespace Beamable.Editor.Microservice.UI.Components
 	        {
 		        try
 		        {
-			        if (procList[i].ProcessName.ToLower().Contains("docker desktop"))
+			        if (procList[i].ProcessName.ToLower().Contains("docker"))
 			        {
 				        return true;
 			        }


### PR DESCRIPTION
# Brief Description
https://disruptorbeam.atlassian.net/browse/BEAM-2000

The check to see if docker is running was too aggressive, and wasn't working on my machine. I didn't have a process named "docker desktop". 

I've just shorted the string to "docker", which captures the programs on my machine that give me docker capabilities.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
