### PR TITLE
beam 1999 - make api content readonly unless server installed

### DIFF
--- a/client/Packages/com.beamable/Editor/Modules/Content/UI/ReadonlyUntilMicroserviceDrawer.cs.meta
+++ b/client/Packages/com.beamable/Editor/Modules/Content/UI/ReadonlyUntilMicroserviceDrawer.cs.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: c4d5bb9dcd834977a713eefa216f5b0d
-timeCreated: 1639603254

--- a/client/Packages/com.beamable/Editor/Modules/Content/UI/ReadonlyUntilMicroserviceEditor.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/UI/ReadonlyUntilMicroserviceEditor.cs
@@ -8,19 +8,20 @@ using UnityEngine;
 namespace Beamable.Editor.Content.UI
 {
 	[CustomEditor(typeof(ApiContent), true)]
-	public class ReadonlyUntilMicroserviceDrawer : UnityEditor.Editor
+	public class ReadonlyUntilMicroserviceEditor : UnityEditor.Editor
 	{
-		private Promise<BeamablePackageMeta> _hasPackage;
+		private Promise<BeamablePackageMeta> _packagePromise;
 
-		public ReadonlyUntilMicroserviceDrawer()
+		private BeamablePackageMeta Package =>  (_packagePromise ?? (_packagePromise = BeamablePackages.GetServerPackage())).GetResult();
+
+		public ReadonlyUntilMicroserviceEditor()
 		{
-			_hasPackage = BeamablePackages.GetServerPackage();
+			_packagePromise = BeamablePackages.GetServerPackage();
 		}
 
 		public override void OnInspectorGUI()
 		{
-			var package = (_hasPackage ?? (_hasPackage = BeamablePackages.GetServerPackage())).GetResult();
-
+			var package = Package;
 			if (package?.IsPackageAvailable ?? false)
 			{
 				base.OnInspectorGUI();

--- a/client/Packages/com.beamable/Editor/Modules/Content/UI/ReadonlyUntilMicroserviceEditor.cs.meta
+++ b/client/Packages/com.beamable/Editor/Modules/Content/UI/ReadonlyUntilMicroserviceEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b4e211dfe00b46b8a30d87dc483dc7f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Brief Description
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-1999

All I've done is create a small UI wrapper for the api content class that makes it readonly, and shows a warning to go download the server package if the user doesn't have it.

Here is what it looks like when you don't have the package
![image](https://user-images.githubusercontent.com/3848374/146268185-10dc8652-bfee-4b13-8ac2-7c4d3fc1b7d9.png)

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
