### PR TITLE
beam 2003 - server editor ui fixes

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -7,10 +7,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [TBD]
-### Added
-- Device ID Deletion APIs (bulk and selective)
-
 ## [0.18.0]
 ### Added
 - Content can be prebaked with game-builds to speed up content initialization
@@ -19,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Announcement content includes gifts in addition to attachments. Gifts support webhook calls.
 - `scheduleInstancePurchaseLimit` field to the `ListingContent` to enable setting a purchase limit scoped to the schedule instance
 - `SearchStats()` admin method is usable from client and microservice code.
+- Device ID Deletion APIs (bulk and selective)
 
 ### Changed
 - `BeamableEnvironment` has moved to the Runtime to enable sdk version checking at runtime

--- a/client/Packages/com.beamable/Editor/Modules/Content/HideServerPropertyDrawer.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/HideServerPropertyDrawer.cs
@@ -9,7 +9,6 @@ namespace Beamable.Editor.Content
    [CustomPropertyDrawer(typeof(HideUnlessServerPackageInstalled))]
    public class HideServerPropertyDrawer : PropertyDrawer
    {
-      private static Promise<BeamablePackageMeta> _serverPackagePromise;
       private static Promise<bool> _check;
 
       public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
@@ -70,16 +69,10 @@ namespace Beamable.Editor.Content
 
       private async Promise<bool> HasMicroservicePackage()
       {
-         if (_serverPackagePromise == null)
-         {
-            _serverPackagePromise = BeamablePackages.GetServerPackage();
-            return await HasMicroservicePackage();
-         }
-
          var hasPackage = false;
          try
          {
-            var result = await _serverPackagePromise;
+            var result = await BeamablePackages.ServerPackageMeta;
             hasPackage = result.IsPackageAvailable;
          }
          catch

--- a/client/Packages/com.beamable/Editor/Modules/Content/UI/ReadonlyUntilMicroserviceEditor.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/UI/ReadonlyUntilMicroserviceEditor.cs
@@ -9,20 +9,11 @@ using UnityEngine;
 namespace Beamable.Editor.Content.UI
 {
 	[CustomEditor(typeof(ApiContent), true)]
-	public class ReadonlyUntilMicroserviceEditor : UnityEditor.Editor
+	public class ReadonlyUntilMicroserviceEditor : ContentObjectEditor
 	{
-		private Promise<BeamablePackageMeta> _packagePromise;
-
-		private BeamablePackageMeta Package =>  (_packagePromise ?? (_packagePromise = BeamablePackages.GetServerPackage())).GetResult();
-
-		private void OnEnable()
-		{
-			var _ = Package;
-		}
-
 		public override void OnInspectorGUI()
 		{
-			var package = Package;
+			var package = BeamablePackages.ServerPackageMeta.GetResult();
 			if (package?.IsPackageAvailable ?? false)
 			{
 				base.OnInspectorGUI();


### PR DESCRIPTION
# Brief Description
3 things.
1. We were missing the changelog entry for the deviceId stuff, so I just moved it from the unreleased section to the .18
2. The custom editor for apiContent should extend from `ContentObjectEditor` so that it gets the tag editor
3. I shared a bit of code for the apiContent hiding-unless-server is installed bit. Its static now, so its shared in the editor, and it also happens right away, which should reduce the visual lag.
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2003

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
