### PR TITLE
[BEAM-2026] C#MS Autogenerated Generic list wrong class name problem

### DIFF
--- a/client/Packages/com.beamable.server/Editor/CodeGen/ClientCodeGenerator.cs
+++ b/client/Packages/com.beamable.server/Editor/CodeGen/ClientCodeGenerator.cs
@@ -51,7 +51,7 @@ namespace Beamable.Server.Editor.CodeGen
               namespaceStr = string.Join("_", parameterType.Namespace.Split('.'));
 
           if (parameterType.IsGenericType && parameterType.GetGenericTypeDefinition() == typeof(List<>))
-              name = GetParameterClassName(parameterType.GetGenericArguments()[0], false);
+              name = $"{parameterType.Name.Substring(0, parameterType.Name.IndexOf('`'))}_{ GetParameterClassName(parameterType.GetGenericArguments()[0], false)}";
           else
               name = parameterType.Name;
 


### PR DESCRIPTION
# Brief Description

Fixes in get parameter class name in client code generator for generic types.

Before fix:

_internal sealed class ParameterSystem_Collections_Generic_List`1_

After fix:

![image](https://user-images.githubusercontent.com/90316748/148257813-d729fdc0-50c9-42e4-9f57-7d97e9e71d29.png)

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
