### PR TITLE
[BEAM-1983] can't view remote service data even if C#MS is deployed

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Model/MicroserviceModel.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Model/MicroserviceModel.cs
@@ -131,7 +131,7 @@ namespace Beamable.Editor.UI.Model
         // TODO === BEGIN
         public override void PopulateMoreDropdown(ContextualMenuPopulateEvent evt)
         {
-            var existsOnRemote = RemoteReference?.enabled ?? false || RemoteStatus?.serviceName?.Length > 0;
+            var existsOnRemote = RemoteReference?.enabled ?? false;
             var hasImageSuffix = ServiceBuilder.HasBuildDirectory ? string.Empty : " (Build first)";
             var localCategory = IsRunning ? "Local" : "Local (not running)";
             var remoteCategory = existsOnRemote ? "Cloud" : "Cloud (not deployed)";


### PR DESCRIPTION
# Brief Description

my repro for that, but not 100% was sth like:

- crete new beamable account 
- create MS
- deploy without play/building

so, I added remoteReference check (similar like in MS visual element header for "Remote Enabled") and it should works now

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
