### PR TITLE
beam-2039 fix swagger doc generic types

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `StorageDocument` base class for storage data classes that automatically handle document ID assignment.
 - Added automatic Mongo serialization for basic Unity structs like `Vector2`, `Color`, and `Quaternion`
 
+### Fixed
+- Swagger docs handle generic types instead of failing to load
+
 ## [0.18.2]
 ### Fixed
 - Typless `Promise` in `ClientCallable` methods

--- a/client/Packages/com.beamable.server/Editor/CodeGen/ClientCodeGenerator.cs
+++ b/client/Packages/com.beamable.server/Editor/CodeGen/ClientCodeGenerator.cs
@@ -53,7 +53,7 @@ namespace Beamable.Server.Editor.CodeGen
       public static string GetTargetParameterClassName(MicroserviceDescriptor descriptor) =>
 	      $"MicroserviceParameters{descriptor.Name}Client";
 
-      public static string GetParameterClassName(Type parameterType) => $"{PARAMETER_STRING}{GetTypeStr(parameterType).Replace(".","_")}";
+      public static string GetParameterClassName(Type parameterType) => $"{PARAMETER_STRING}{parameterType.GetTypeString().Replace(".","_")}";
 
       public static Type GetDataWrapperTypeForParameter(MicroserviceDescriptor descriptor, Type parameterType)
       {
@@ -61,41 +61,6 @@ namespace Beamable.Server.Editor.CodeGen
 		      $"{CLIENT_NAMESPACE}.{GetTargetParameterClassName(descriptor)}+{GetParameterClassName(parameterType)}, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
 	      var t = Type.GetType(name, true, true);
 	      return t;
-      }
-
-      private static string GetTypeStr(Type type)
-      {
-	      StringBuilder retType = new StringBuilder();
-
-	      if (type.IsGenericType)
-	      {
-		      string[] parentType = type.FullName.Split('`');
-
-		      Type[] arguments = type.GetGenericArguments();
-
-		      StringBuilder argList = new StringBuilder();
-		      foreach (Type t in arguments)
-		      {
-			      string arg = GetTypeStr(t);
-			      if (argList.Length > 0)
-				      argList.AppendFormat("_{0}", arg);
-			      else
-				      argList.Append(arg);
-		      }
-
-		      if (argList.Length > 0)
-			      retType.AppendFormat("{0}_{1}", parentType[0], argList.ToString());
-	      }
-	      else if (type.IsArray)
-	      {
-		      retType.AppendFormat("{0}_{1}", type.BaseType, GetTypeStr(type.GetElementType()));
-	      }
-	      else
-	      {
-		      return type.ToString();
-	      }
-
-	      return retType.ToString();
       }
 
       /// <summary>

--- a/client/Packages/com.beamable/Common/Runtime/TypeExtensions.cs
+++ b/client/Packages/com.beamable/Common/Runtime/TypeExtensions.cs
@@ -1,0 +1,44 @@
+
+using System;
+using System.Text;
+
+namespace Beamable.Common
+{
+	public static class TypeExtensions
+	{
+		public static string GetTypeString(this Type type)
+		{
+			StringBuilder retType = new StringBuilder();
+
+			if (type.IsGenericType)
+			{
+				string[] parentType = type.FullName.Split('`');
+
+				Type[] arguments = type.GetGenericArguments();
+
+				StringBuilder argList = new StringBuilder();
+				foreach (Type t in arguments)
+				{
+					string arg = GetTypeString(t);
+					if (argList.Length > 0)
+						argList.AppendFormat("_{0}", arg);
+					else
+						argList.Append(arg);
+				}
+
+				if (argList.Length > 0)
+					retType.AppendFormat("{0}_{1}", parentType[0], argList.ToString());
+			}
+			else if (type.IsArray)
+			{
+				retType.AppendFormat("{0}_{1}", type.BaseType, GetTypeString(type.GetElementType()));
+			}
+			else
+			{
+				return type.ToString();
+			}
+
+			return retType.ToString();
+		}
+	}
+}

--- a/client/Packages/com.beamable/Common/Runtime/TypeExtensions.cs.meta
+++ b/client/Packages/com.beamable/Common/Runtime/TypeExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ae82d922b39c479ab97663ccf1b9186
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# TIcket 
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?issueParent=110457&selectedIssue=BEAM-2039

# Brief Description
The swagger docs used to break for some types (lists of things you already had element types for), and then it used to look like this
![image](https://user-images.githubusercontent.com/3848374/149999984-3b9bf13d-33e3-4e05-90fa-31bf33355ee2.png)

Now, it looks like this
![image](https://user-images.githubusercontent.com/3848374/150000032-809bcabb-6acf-4ec2-92cf-c68da68e6631.png)

1. There was a bug on type assignment check, where I had it backwards. IT wasn't detecting lists well at all.
2. I moved Lukasz's type string code to a common location, and used it to come up with the schema name, instead of just using the type name. This also let me remove some crappy generic type handling from before. 

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
