### PR TITLE
beam 2073 - get correct data from server

### DIFF
--- a/client/Packages/com.beamable.server/Editor/ManagerClient/MicroserviceManager.cs
+++ b/client/Packages/com.beamable.server/Editor/ManagerClient/MicroserviceManager.cs
@@ -5,6 +5,7 @@ using Beamable.Common;
 using Beamable.Common.Api;
 using Beamable.Serialization;
 using Beamable.Server.Editor.UI.Components;
+using UnityEngine;
 
 namespace Beamable.Server.Editor.ManagerClient
 {
@@ -56,7 +57,7 @@ namespace Beamable.Server.Editor.ManagerClient
       {
 	      var post = new PostManifestRequest
 	      {
-		      comments = manifest.comments, manifest = manifest.manifest, storageReferences = manifest.storages
+		      comments = manifest.comments, manifest = manifest.manifest, storageReferences = manifest.storageReference
 	      };
          return Requester.Request<EmptyResponse>(Method.POST, $"{SERVICE}/manifest", post).ToUnit();
       }
@@ -97,7 +98,7 @@ namespace Beamable.Server.Editor.ManagerClient
       public long id;
       public long created;
       public List<ServiceReference> manifest = new List<ServiceReference>();
-      public List<ServiceStorageReference> storages = new List<ServiceStorageReference>();
+      public List<ServiceStorageReference> storageReference = new List<ServiceStorageReference>();
       public long createdByAccountId;
       public string comments;
    }
@@ -123,6 +124,7 @@ namespace Beamable.Server.Editor.ManagerClient
        public string storageType;
        public bool enabled;
        public string templateId;
+       public string checksum;
    }
 
    [System.Serializable]

--- a/client/Packages/com.beamable.server/Editor/Microservices.cs
+++ b/client/Packages/com.beamable.server/Editor/Microservices.cs
@@ -254,7 +254,7 @@ namespace Beamable.Server.Editor
 
                var allStorages = new HashSet<string>();
 
-               foreach (var serverSideStorage in manifest.storages.Select(s => s.id))
+               foreach (var serverSideStorage in manifest.storageReference.Select(s => s.id))
                {
                    allStorages.Add(serverSideStorage);
                }
@@ -655,7 +655,7 @@ namespace Beamable.Server.Editor
          {
             comments = model.Comment,
             manifest = manifest,
-            storages = storages
+            storageReference = storages
          });
          OnDeploySuccess?.Invoke(model, descriptorsCount);
          Debug.Log("Service Deploy Complete");


### PR DESCRIPTION
# Ticket 
https://disruptorbeam.atlassian.net/browse/BEAM-2073

# Brief Description
we weren't getting the storage data, because the field name wasn't correct. I've changed the field name to represent what it is on the server.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
