### PR TITLE
use dotnet 6 in build step

### DIFF
--- a/build/docker/image.microservice/Dockerfile
+++ b/build/docker/image.microservice/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 # RUN npm install -g json
 ADD build/docker/scripts /scripts


### PR DESCRIPTION
# Brief Description

When our jenkins jobs run, they use these scripts, but I'd forgot to set it build with dotnet 6.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
