### PR TITLE
beam 2073 - change default mongo log level to info

### DIFF
--- a/client/Packages/com.beamable.server/Editor/DockerCommands/RunImageCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/RunImageCommand.cs
@@ -49,7 +49,7 @@ namespace Beamable.Server.Editor.DockerCommands
       }
       protected override void HandleStandardErr(string data)
       {
-         if (!MicroserviceLogHelper.HandleMongoLog(_storage, data, LogLevel.ERROR, true))
+         if (!MicroserviceLogHelper.HandleMongoLog(_storage, data, LogLevel.INFO, true))
          {
             base.HandleStandardErr(data);
          }


### PR DESCRIPTION
# Brief Description
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?issueParent=110457&selectedIssue=BEAM-2070

The issue is that docker reports the log lines about pulling an image on the Standard Error buffer, even though they aren't really "errors". I've simply changed the default log level to info for messages received on the error buffer. I think this is okay, but _actual_ errors should come on the standard out buffer with an error tag in the message itself, which we already parse correctly.


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
