### PR TITLE
beam 2096 - error does not need to log

### DIFF
--- a/client/Packages/com.beamable.server/Editor/DockerCommands/GetImageIdCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/GetImageIdCommand.cs
@@ -1,32 +1,32 @@
-using System;
-using Beamable.Server.Editor.DockerCommands;
 using Beamable.Platform.SDK;
+using Beamable.Server.Editor.DockerCommands;
+using System;
 using UnityEngine;
 
 namespace Beamable.Server.Editor.DockerCommands
 {
-   public class GetImageIdCommand : DockerCommandReturnable<string>
-   {
-      public string ImageName { get; }
+	public class GetImageIdCommand : DockerCommandReturnable<string>
+	{
+		public string ImageName { get; }
 
-      public GetImageIdCommand(IDescriptor descriptor)
-      {
-         ImageName = descriptor.ImageName;
-      }
-      public override string GetCommandString()
-      {
-         return $"{DockerCmd} images -q {ImageName}";
-      }
+		public GetImageIdCommand(IDescriptor descriptor)
+		{
+			ImageName = descriptor.ImageName;
+		}
+		public override string GetCommandString()
+		{
+			return $"{DockerCmd} images -q {ImageName}";
+		}
 
-      protected override void Resolve()
-      {
-         if (StandardOutBuffer?.Length > 0)
-         {
-	         Promise.CompleteSuccess(StandardOutBuffer.Trim());
-	         return;
-         }
-		 // there is no built image, we shouldn't log an error, we should just know that empty string means "not built".
-		 Promise.CompleteSuccess(string.Empty);
-      }
-   }
+		protected override void Resolve()
+		{
+			if (StandardOutBuffer?.Length > 0)
+			{
+				Promise.CompleteSuccess(StandardOutBuffer.Trim());
+				return;
+			}
+			// there is no built image, we shouldn't log an error, we should just know that empty string means "not built".
+			Promise.CompleteSuccess(string.Empty);
+		}
+	}
 }


### PR DESCRIPTION
# Brief Description
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2096

The issue is that if you make a C#MS, but never _build_ it, random parts of our UI go to ask for the imageId, and it doesn't exist, so the old code was saying, "AAAAAAH BAD!".

But hey...
Actually, its not that bad. If it doesn't exist at _critical_ moment, thats bad, but its fine if it doesn't exist as the user wonders around the editor.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
