### PR TITLE
Fix annoying merge commit

### DIFF
--- a/.github/workflows/buildPR.yml
+++ b/.github/workflows/buildPR.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Commit files
         if: steps.format-changes.outputs.any == 'true'
         run: |
+          git checkout ${{ steps.branch-name.outputs.current_branch }}
           git config --local user.name "github-actions[bot]"
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -a -m 'Autoformat code'


### PR DESCRIPTION
# Brief Description

I've noticed that we are getting annoying merge commit before github bot commit with formatting:

![image](https://user-images.githubusercontent.com/13188195/150784760-b0d2f17f-639b-4d05-a8b0-6097c06f0142.png)

This is a PR with fix for that.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
