### PR TITLE
[Fix] BEAM-2100 -  No ClientCallables in C#MS threw exception in ReflectionCache

### DIFF
--- a/client/Packages/com.beamable.server/Editor/ReflectionCache/UserSystems/MicroserviceReflectionCache.cs
+++ b/client/Packages/com.beamable.server/Editor/ReflectionCache/UserSystems/MicroserviceReflectionCache.cs
@@ -177,7 +177,8 @@ namespace Beamable.Server.Editor
 					// Initialize the ClientCallableDescriptors if the type has any.
 					if (validClientCallablesLookup.TryGetValue(type, out var clientCallables))
 					{
-						descriptor.Methods = clientCallables.Select(delegate(MemberAttribute pair) {
+						descriptor.Methods = clientCallables.Select(delegate (MemberAttribute pair)
+						{
 							var clientCallableAttribute = pair.AttrAs<ClientCallableAttribute>();
 							var clientCallableMethod = pair.InfoAs<MethodInfo>();
 
@@ -185,33 +186,36 @@ namespace Beamable.Server.Editor
 							var callableScopes = clientCallableAttribute.RequiredScopes;
 
 							var parameters = clientCallableMethod
-							                 .GetParameters()
-							                 .Select((param, i) => {
-								                 var paramAttr = param.GetCustomAttribute<ParameterAttribute>();
-								                 var paramName = string.IsNullOrEmpty(paramAttr?.ParameterNameOverride)
-									                 ? param.Name
-									                 : paramAttr.ParameterNameOverride;
-								                 return new ClientCallableParameterDescriptor {
-									                 Name = paramName,
-									                 Index = i,
-									                 Type = param.ParameterType
-								                 };
-							                 }).ToArray();
+											 .GetParameters()
+											 .Select((param, i) =>
+											 {
+												 var paramAttr = param.GetCustomAttribute<ParameterAttribute>();
+												 var paramName = string.IsNullOrEmpty(paramAttr?.ParameterNameOverride)
+													 ? param.Name
+													 : paramAttr.ParameterNameOverride;
+												 return new ClientCallableParameterDescriptor
+												 {
+													 Name = paramName,
+													 Index = i,
+													 Type = param.ParameterType
+												 };
+											 }).ToArray();
 
-							return new ClientCallableDescriptor() {
+							return new ClientCallableDescriptor()
+							{
 								Path = callableName,
 								Scopes = callableScopes,
 								Parameters = parameters,
 							};
-						}).ToList();						
+						}).ToList();
 					}
 					else // If no client callables were found in the C#MS, initialize an empty list.
 					{
 						descriptor.Methods = new List<ClientCallableDescriptor>();
 					}
-					
-					
-					
+
+
+
 
 					Descriptors.Add(descriptor);
 					AllDescriptors.Add(descriptor);


### PR DESCRIPTION
# Brief Description
Fixed issue that caused exception in MicroserviceReflectionCache when a Microservice with no ClientCallables was declared

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
