### PR TITLE
beam 2143 - move dep gathering logs to log helper

### DIFF
--- a/client/Packages/com.beamable.server/Editor/DockerCommands/BuildImageCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/BuildImageCommand.cs
@@ -76,7 +76,7 @@ namespace Beamable.Server.Editor.DockerCommands
 			{
 				var sourceDirectory = Path.GetDirectoryName(dll.assetPath);
 				var fullSource = Path.Combine(rootPath, sourceDirectory);
-				Debug.Log("Copying dll from " + fullSource);
+				MicroserviceLogHelper.HandleLog(descriptor, "Build", "Copying dll from " + fullSource);
 
 				// TODO: better folder namespacing?
 				CopyFolderToBuildDirectory(fullSource, "libdll", descriptor);
@@ -97,7 +97,7 @@ namespace Beamable.Server.Editor.DockerCommands
 			{
 				var sourceDirectory = Path.GetDirectoryName(assemblyDependency.Location);
 				var fullSource = Path.Combine(rootPath, sourceDirectory);
-				Debug.Log("Copying assembly from " + fullSource);
+				MicroserviceLogHelper.HandleLog(descriptor, "Build", "Copying assembly from " + fullSource);
 
 				// TODO: better folder namespacing?
 				CopyFolderToBuildDirectory(fullSource, assemblyDependency.Name, descriptor);
@@ -122,7 +122,8 @@ namespace Beamable.Server.Editor.DockerCommands
 				var targetRelative = dep.Agnostic.SourcePath.Substring(Application.dataPath.Length - "Assets/".Length);
 				var targetFull = descriptor.BuildPath + targetRelative;
 
-				Debug.Log("Copying source code to " + targetFull);
+				MicroserviceLogHelper.HandleLog(descriptor, "Build", "Copying source code to " + targetFull);
+
 				var targetDir = Path.GetDirectoryName(targetFull);
 				Directory.CreateDirectory(targetDir);
 


### PR DESCRIPTION
# Brief Description
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?assignee=5f344c62323607003855295d&selectedIssue=BEAM-2143

So I thought this was a bug, but actually, its a feature!

We added a "common" assembly, but in that common assembly, we added mongo dependencies; so the C#MS picks up the mongo assemblies indirectly through the common reference. 

I still didn't like the logs showing up in the console- so I moved them to the Microservice container logs.
![image](https://user-images.githubusercontent.com/3848374/151237269-ce5a5953-de65-4362-a321-6b1b9d1ca626.png)



# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
