### PR TITLE
move script gen first

### DIFF
--- a/client/Packages/com.beamable.server/Editor/MicroserviceEditor.cs
+++ b/client/Packages/com.beamable.server/Editor/MicroserviceEditor.cs
@@ -142,6 +142,8 @@ namespace Beamable.Server.Editor
 					}
 				}
 
+				SetupServiceFileInfo(serviceName, scriptTemplatePath,
+				                     destinationDirectory.FullName + $"/{serviceName}.cs");
 				AssemblyDefinitionHelper.CreateAssetDefinitionAssetOnDisk(
 					asmPath,
 					new AssemblyDefinitionInfo
@@ -154,9 +156,6 @@ namespace Beamable.Server.Editor
 						IncludePlatforms = new[] { "Editor" },
 						References = references.ToArray()
 					});
-
-				SetupServiceFileInfo(serviceName, scriptTemplatePath,
-									 destinationDirectory.FullName + $"/{serviceName}.cs");
 
 				CommonAreaService.EnsureCommon();
 


### PR DESCRIPTION
# Brief Description
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2153
Looks like the script pipeline can pick this up before the asset database locks in the asm. I think the script can show up first, but the asm can't live before the script. 

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
