### PR TITLE
[BEAM-2126] 1.0 Blocker - announcement buttons low contrast in dark mode

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Common/Common.2018.uss
+++ b/client/Packages/com.beamable/Editor/UI/Common/Common.2018.uss
@@ -1,0 +1,6 @@
+﻿.announcement-buttons {
+    border-left-width: 0px;
+    border-right-width: 0px;
+    border-top-width: 0px;
+    border-bottom-width: 0px;
+}

--- a/client/Packages/com.beamable/Editor/UI/Common/Common.2018.uss.meta
+++ b/client/Packages/com.beamable/Editor/UI/Common/Common.2018.uss.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 4a462bb397724effa22c2cabf35e39be
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: stylesheet
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}

--- a/client/Packages/com.beamable/Editor/UI/Common/Common.uss
+++ b/client/Packages/com.beamable/Editor/UI/Common/Common.uss
@@ -128,10 +128,10 @@
     height: 21px;
     font-size: 10px;
     align-self: stretch;
-    border-left-width: 0px;
-    border-right-width: 0px;
-    border-top-width: 0px;
-    border-bottom-width: 0px;
+    border-left-width: 1px;
+    border-right-width: 1px;
+    border-top-width: 1px;
+    border-bottom-width: 1px;
 }
 
 .announcement-hiddenButton {


### PR DESCRIPTION
# Brief Description

## 2018 Light
![Button_2018_light](https://user-images.githubusercontent.com/18366601/151363133-5271cd19-21b4-4018-baa6-3b26d43ca094.png)

## 2018 Dark
![Button_2018_dark](https://user-images.githubusercontent.com/18366601/151363127-c9748a6a-bd8c-4a35-a952-8988ca704387.png)

## 2020 Light
![Button_2020_light](https://user-images.githubusercontent.com/18366601/151363140-a8aaa9bd-ea63-4e8d-9829-e24cc461498c.png)

## 2020 Dark
![Button_2020_dark](https://user-images.githubusercontent.com/18366601/151363118-6e6a5695-bd7c-4ffe-b424-31bdb415f372.png)

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
