### PR TITLE
fixes account switching after reset and fixes disabled domain reload

### DIFF
--- a/client/Packages/com.beamable/Runtime/Beam.cs
+++ b/client/Packages/com.beamable/Runtime/Beam.cs
@@ -97,7 +97,7 @@ namespace Beamable
 			}
 
 			// Also initializes the Reflection Cache system with it's IBeamHintGlobalStorage instance when in the editor. When not in the editor, the storage should really not
-			// be used and 
+			// be used and
 			// Finally, calls the Generate Reflection cache
 #if UNITY_EDITOR
 			ReflectionCache.SetStorage(RuntimeGlobalStorage);
@@ -185,6 +185,7 @@ namespace Beamable
 				provider => provider.GetService<PubnubSubscriptionManager>());
 			DependencyBuilder.AddSingleton<INotificationService>(
 				provider => provider.GetService<NotificationService>());
+			DependencyBuilder.AddSingleton<ApiServices>();
 
 			DependencyBuilder.AddSingleton<Promise<IBeamablePurchaser>>(provider => new Promise<IBeamablePurchaser>());
 			DependencyBuilder.AddSingleton<PlayerAnnouncements>();
@@ -210,11 +211,22 @@ namespace Beamable
 		/// <summary>
 		/// Runs the <see cref="BeamContext.ClearPlayerAndStop"/> method on every <see cref="BeamContext"/> in memory.
 		/// </summary>
-		public static async Promise ClearAndDisposeAllContexts()
+		public static async Promise ClearAndStopAllContexts()
 		{
 			foreach (var ctx in BeamContext.All)
 			{
 				await ctx.ClearPlayerAndStop();
+			}
+		}
+
+		/// <summary>
+		/// Runs the <see cref="BeamContext.Stop"/> method on every <see cref="BeamContext"/> in memory.
+		/// </summary>
+		public static async Promise StopAllContexts()
+		{
+			foreach (var ctx in BeamContext.All)
+			{
+				await ctx.Stop();
 			}
 		}
 

--- a/client/Packages/com.beamable/Runtime/PlatformConsoleCommands.cs
+++ b/client/Packages/com.beamable/Runtime/PlatformConsoleCommands.cs
@@ -55,7 +55,7 @@ namespace Beamable.Api
 		protected string Reset(params string[] args)
 		{
 
-			Beam.ClearAndDisposeAllContexts()
+			Beam.ClearAndStopAllContexts()
 				.FlatMap(_ => Beam.ResetToScene(args.Length == 1 ? args[0] : null))
 				.Then(_ =>
 				{
@@ -67,7 +67,7 @@ namespace Beamable.Api
 		[BeamableConsoleCommand(new[] { "RESTART", "FR" }, "Clear access tokens, then Restart the game as if it had just been launched", "FORCE-RESTART")]
 		public string Restart(params string[] args)
 		{
-			Beam.ClearAndDisposeAllContexts()
+			Beam.ClearAndStopAllContexts()
 				.FlatMap(_ => Beam.ResetToScene("0"))
 				.Then(_ =>
 				{


### PR DESCRIPTION
# ticket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2166

# Brief Description
There were two issues.
1. if you used the `RESET` command, we getting into a bad state situation, because `ApiServices` wasn't actually listed as a contextual service, so it wasn't re-initialziing in the right way.
2. If you disable domain reload, then state was getting stuck between runs, so I added a thing to STOP all contexts on subsystem reloads. No domain reloading works just dandy.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
