### PR TITLE
beam 2125

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Login/UI/Model/LoginModel.cs
+++ b/client/Packages/com.beamable/Editor/UI/Login/UI/Model/LoginModel.cs
@@ -125,11 +125,14 @@ namespace Beamable.Editor.Login.UI.Model
 				b.OnRealmChange += SetRealm;
 				b.OnCustomerChange += SetCustomer;
 
-				b.RealmService.GetGames().Then(games =>
-			 {
-				 Games = games;
-				 OnGamesUpdated?.Invoke(games);
-			 });
+				if (!string.IsNullOrEmpty(b.CidOrAlias))
+				{
+					b.RealmService.GetGames().Then(games =>
+					{
+						Games = games;
+						OnGamesUpdated?.Invoke(games);
+					});
+				}
 
 				if (b.HasToken)
 				{


### PR DESCRIPTION
# Ticket 
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2125

# Brief Description
This one is kind of funny- in that, this has _technically_ been a bug ever since we built the sign-in flow in editor. The reason we never saw it before was the we were returning a Failed Promise immediately, and until recently, we had a bug in our uncaught promise handling code where immediately failed promises wouldn't register. 
So since we fixed the error reporting, this error started (correctly) appearing. 

The reason we are checking for games in the first place is to expedite the flow _if_ the user is just switching games. Turns out; we can't do that if you don't have a CID yet.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
