### PR TITLE
fix bad announcement tmp names

### DIFF
--- a/client/Packages/com.beamable/Runtime/Modules/Announcements/Prefabs/AnnouncementRow Variant.prefab
+++ b/client/Packages/com.beamable/Runtime/Modules/Announcements/Prefabs/AnnouncementRow Variant.prefab
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: da9492a689bd94fcbb4ada778908cee7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TxtTitle: {fileID: 4606141328379453207}
-  TxtBody: {fileID: 3210686060304290086}
+  _txtTitle: {fileID: 4606141328379453207}
+  _txtBody: {fileID: 3210686060304290086}
 --- !u!1001 &882225108800391910
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# ticket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2142

# Brief Description
Looks like at some point the field references on the announcement flow got broken; causing a null error downstream. 

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
