### PR TITLE
open the code with the default editor

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Model/ServiceModelBase.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Model/ServiceModelBase.cs
@@ -102,7 +102,9 @@ namespace Beamable.Editor.UI.Model
 		protected void OpenCode()
 		{
 			var path = Path.GetDirectoryName(AssemblyDefinitionHelper.ConvertToInfo(Descriptor).Location);
-			EditorUtility.OpenWithDefaultApp($@"{path}/{Descriptor.Name}.cs");
+			var fileName = $@"{path}/{Descriptor.Name}.cs";
+			var asset = AssetDatabase.LoadMainAssetAtPath(fileName);
+			AssetDatabase.OpenAsset(asset);
 		}
 	}
 }


### PR DESCRIPTION
# Ticket 
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2171

# Brief Description
The old way was using the _system_'s default program for handling a file. On my system, the default program to open a `.cs` file is VSCODE, but really what I wanted was for Unity to open up Rider. 
This change goes through Unity, and opens up the right program.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
