### PR TITLE
[BEAM-2091] 1.0 Blocker - The Docker image should not running if MS build fails

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Model/MicroserviceBuilder.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Model/MicroserviceBuilder.cs
@@ -84,7 +84,7 @@ namespace Beamable.Editor.UI.Model
 			}
 			catch(Exception e)
             {
-                MicroserviceLogHelper.HandleBuildCommandOutput(this, e);
+                MicroserviceLogHelper.HandleBuildCommandOutput(this, e.Message);
 			}
 			finally
 			{


### PR DESCRIPTION
# Brief Description

Based on repro steps:

1. Create MS
2. Delete namespace Beamable.Server
3. Try to build
4. Got an error and not running (same as you see in first screenshot)
5. Restore namespace Beamable.Server
6. Try to build
7. Now it's fine
8. Repeat steps 2-3
9. Now your MS is running even if there is an error

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
