### PR TITLE
[BEAM-2134] 1.0 Blocker - Theme window GameObject bug, NULL error

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/ComponentBasedHierarchyVisualElement/ComponentBasedHierarchyVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/ComponentBasedHierarchyVisualElement/ComponentBasedHierarchyVisualElement.cs
@@ -84,7 +84,7 @@ namespace Beamable.Editor.UI.Components
 
 			if (indentedLabelVisualElement != null)
 			{
-				SelectedComponent = indentedLabelVisualElement.RelatedGameObject.GetComponent<T>();
+				SelectedComponent = indentedLabelVisualElement?.RelatedGameObject?.GetComponent<T>();
 				ChangeSelectedLabel(indentedLabelVisualElement, false);
 			}
 		}


### PR DESCRIPTION
# Brief Description

"The object of type 'GameObject' has been destroyed but you are still trying to access it."

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
