### PR TITLE
beam 2131 - be more generous for toolbox announcement resizing

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Toolbox/Components/ToolboxAnnouncementListVisualElement/ToolboxAnnouncementListVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Toolbox/Components/ToolboxAnnouncementListVisualElement/ToolboxAnnouncementListVisualElement.cs
@@ -69,7 +69,7 @@ namespace Beamable.Editor.Toolbox.Components
 				elem.Refresh();
 			}
 
-			var attemptsLeft = 25;
+			var attemptsLeft = 250;
 			void WaitForRedraw()
 			{
 				var height = _mainContainer.worldBound.height;

--- a/client/Packages/com.beamable/Editor/UI/Toolbox/ToolboxWindow.cs
+++ b/client/Packages/com.beamable/Editor/UI/Toolbox/ToolboxWindow.cs
@@ -166,7 +166,6 @@ namespace Beamable.Editor.Toolbox.UI
 
 			_actionBarVisualElement.OnInfoButtonClicked += () =>
 			{
-				Debug.Log("Show info");
 				Application.OpenURL(BeamableConstants.URL_TOOL_WINDOW_TOOLBOX);
 			};
 
@@ -176,6 +175,7 @@ namespace Beamable.Editor.Toolbox.UI
 		{
 			// TODO: animate the height...
 			_contentListVisualElement?.style.SetTop(65 + height);
+			_contentListVisualElement?.MarkDirtyRepaint();
 		}
 		private void CheckForDeps()
 		{


### PR DESCRIPTION
# Ticket 
https://disruptorbeam.atlassian.net/browse/BEAM-2131

# Brief Description
The toolbox on win 2018 wasn't resizing after the TMP announcement showed up. I was having a hard time reproducing this, so I think I'll need to double check with Kamil when the next RC rolls out. But, I think the two changes I made should help.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
