### PR TITLE
[BEAM-2152] MicroserviceWindow required manual refresh to update "docker not running" message when docker was started

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Components/MicroserviceContentVisualElement/MicroserviceContentVisualElement.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/MicroserviceContentVisualElement/MicroserviceContentVisualElement.cs
@@ -92,6 +92,7 @@ namespace Beamable.Editor.Microservice.UI.Components
 			if (DockerCommand.DockerNotInstalled || !_dockerHubIsRunning)
 			{
 				ShowDockerNotInstalledAnnouncement();
+				EditorApplication.delayCall += Refresh;
 			}
 			if (DockerCommand.DockerNotInstalled)
 				return;


### PR DESCRIPTION
# Brief Description
Added `Refresh` to `EditorApplication.delayCall` so that the window keeps checking if the DockerProcess if the process is not running.

In the future, might be nice to separate out the detection of docker into a "DockerHealthManager" that only exists in the editor and various windows/systems can read an updated state (every second) of it.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
