### PR TITLE
[BEAM-2105] Update buttons and local status at once

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Components/MicroserviceVisualElement/MicroserviceVisualElement.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/MicroserviceVisualElement/MicroserviceVisualElement.cs
@@ -87,12 +87,11 @@ namespace Beamable.Editor.Microservice.UI.Components
 		}
 		private void OnIsBuildingChanged(bool isBuilding)
 		{
-			UpdateButtons();
-			UpdateStatusIcon();
+			UpdateLocalStatus();
 		}
 		private void HandleLastImageIdChanged(string newId)
 		{
-			UpdateButtons();
+			UpdateLocalStatus();
 		}
 		private void OnServiceReferenceChanged(ServiceReference serviceReference)
 		{
@@ -117,37 +116,10 @@ namespace Beamable.Editor.Microservice.UI.Components
 			_remoteStatusIcon.tooltip = _remoteStatusLabel.text;
 			_remoteStatusIcon.AddToClassList(statusClassName);
 		}
-		protected override void UpdateStatusIcon()
+		protected override void UpdateLocalStatus()
 		{
-			_statusIcon.ClearClassList();
-
-			string statusClassName;
-			string statusText;
-
-			string status = _microserviceModel.IsRunning ? "localRunning" :
-				_microserviceModel.IsBuilding ? "localBuilding" : "localStopped";
-			switch (status)
-			{
-				case "localRunning":
-					statusText = "Local Running";
-					statusClassName = "localRunning";
-					break;
-				case "localBuilding":
-					statusClassName = "localBuilding";
-					statusText = "Local Building";
-					break;
-				case "localStopped":
-					statusClassName = "localStopped";
-					statusText = "Local Stopped";
-					break;
-				default:
-					statusClassName = "different";
-					statusText = "Different";
-					break;
-			}
-
-			_statusIcon.tooltip = _statusLabel.text = statusText;
-			_statusIcon.AddToClassList(statusClassName);
+			base.UpdateLocalStatus();
+			UpdateLocalStatusIcon(_microserviceModel.IsRunning, _microserviceModel.IsBuilding);
 		}
 		private void SetupProgressBarForBuildAndStart(Task task)
 		{
@@ -178,7 +150,7 @@ namespace Beamable.Editor.Microservice.UI.Components
 					: Constants.BUILD_ENABLE_DEBUG, pos =>
 				{
 					_microserviceModel.IncludeDebugTools = !_microserviceModel.IncludeDebugTools;
-					UpdateButtons();
+					UpdateLocalStatus();
 				});
 			}
 			else

--- a/client/Packages/com.beamable.server/Editor/UI/Components/MicroserviceVisualElement/RemoteMicroserviceVisualElement.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/MicroserviceVisualElement/RemoteMicroserviceVisualElement.cs
@@ -68,10 +68,8 @@ namespace Beamable.Editor.Microservice.UI.Components
 
 			_separator.Refresh();
 
-			UpdateButtons();
-			UpdateStatusIcon();
+			UpdateLocalStatus();
 			UpdateRemoteStatusIcon();
-			UpdateHeaderColor();
 			UpdateModel();
 		}
 
@@ -89,7 +87,7 @@ namespace Beamable.Editor.Microservice.UI.Components
 
 		private void HandleLastImageIdChanged(string newId)
 		{
-			UpdateButtons();
+			UpdateLocalStatus();
 		}
 
 		private void OnServiceReferenceChanged(ServiceReference serviceReference)
@@ -106,9 +104,10 @@ namespace Beamable.Editor.Microservice.UI.Components
 			_remoteStatusIcon.AddToClassList(statusClassName);
 		}
 
-		protected override void UpdateStatusIcon()
+		protected override void UpdateLocalStatus()
 		{
-
+			base.UpdateLocalStatus();
+			UpdateLocalStatusIcon(false,false);
 		}
 	}
 }

--- a/client/Packages/com.beamable.server/Editor/UI/Components/ServiceBaseVisualElement/ServiceBaseVisualElement.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/ServiceBaseVisualElement/ServiceBaseVisualElement.cs
@@ -152,23 +152,59 @@ namespace Beamable.Editor.Microservice.UI.Components
 			_mainParent.AddToClassList("collapsedMain");
 			_rootVisualElement.AddToClassList("collapsedMain");
 
-			UpdateButtons();
 			CreateLogSection(Model.AreLogsAttached);
-			UpdateStatusIcon();
+			UpdateLocalStatus();
 			UpdateRemoteStatusIcon();
-			UpdateHeaderColor();
 			ChangeCollapseState();
 			UpdateModel();
 		}
-		protected abstract void UpdateStatusIcon();
+
 		protected abstract void UpdateRemoteStatusIcon();
 		protected virtual void UpdateButtons()
 		{
 			_stopButton.text = Model.IsRunning ? Constants.STOP : Constants.START;
 		}
+		protected virtual void UpdateLocalStatus()
+		{
+			_header.EnableInClassList("running", Model.IsRunning);
+			UpdateButtons();
+		}
 		protected async void UpdateModel()
 		{
 			await Model.Builder.CheckIfIsRunning();
+		}
+
+		protected void UpdateLocalStatusIcon(bool isRunning, bool isBuilding)
+		{
+			_statusIcon.ClearClassList();
+
+			string statusClassName;
+			string statusText;
+
+			string status = isRunning ? "localRunning" :
+				isBuilding ? "localBuilding" : "localStopped";
+			switch (status)
+			{
+				case "localRunning":
+					statusText = "Local Running";
+					statusClassName = "localRunning";
+					break;
+				case "localBuilding":
+					statusClassName = "localBuilding";
+					statusText = "Local Building";
+					break;
+				case "localStopped":
+					statusClassName = "localStopped";
+					statusText = "Local Stopped";
+					break;
+				default:
+					statusClassName = "different";
+					statusText = "Different";
+					break;
+			}
+
+			_statusIcon.tooltip = _statusLabel.text = statusText;
+			_statusIcon.AddToClassList(statusClassName);
 		}
 		private void OnDrag(float value)
 		{
@@ -204,21 +240,9 @@ namespace Beamable.Editor.Microservice.UI.Components
 		}
 		private void HandleIsRunningChanged(bool isRunning)
 		{
-			UpdateButtons();
-			UpdateStatusIcon();
-			UpdateHeaderColor();
+			UpdateLocalStatus();
 		}
-		protected void UpdateHeaderColor()
-		{
-			if (Model.IsRunning)
-			{
-				_header.AddToClassList("running");
-			}
-			else
-			{
-				_header.RemoveFromClassList("running");
-			}
-		}
+
 		private void CreateLogSection(bool areLogsAttached)
 		{
 			_logElement?.Destroy();

--- a/client/Packages/com.beamable.server/Editor/UI/Components/StorageObjectVisualElement/RemoteStorageObjectVisualElement.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/StorageObjectVisualElement/RemoteStorageObjectVisualElement.cs
@@ -60,10 +60,8 @@ namespace Beamable.Editor.Microservice.UI.Components
 
 			_separator.Refresh();
 
-			UpdateButtons();
-			UpdateStatusIcon();
+			UpdateLocalStatus();
 			UpdateRemoteStatusIcon();
-			UpdateHeaderColor();
 			UpdateModel();
 		}
 

--- a/client/Packages/com.beamable.server/Editor/UI/Components/StorageObjectVisualElement/StorageObjectVisualElement.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/StorageObjectVisualElement/StorageObjectVisualElement.cs
@@ -49,45 +49,23 @@ namespace Beamable.Editor.Microservice.UI.Components
 			_mongoStorageModel.ServiceBuilder.OnIsRunningChanged -= OnIsRunningChanged;
 			_mongoStorageModel.ServiceBuilder.OnIsRunningChanged += OnIsRunningChanged;
 		}
-
-		protected override void UpdateStatusIcon()
+		
+		protected override void UpdateLocalStatus()
 		{
-			_statusIcon.ClearClassList();
-
-			string statusClassName;
-			string statusText;
-
-			var status = _mongoStorageModel.IsRunning ? "localRunning" : "localStopped";
-			switch (status)
-			{
-				case "localRunning":
-					statusClassName = "localRunning";
-					statusText = "Local Running";
-					break;
-				case "localStopped":
-					statusClassName = "localStopped";
-					statusText = "Local Stopped";
-					break;
-				default:
-					statusClassName = "different";
-					statusText = "Different";
-					break;
-			}
-
-			_statusIcon.tooltip = _statusLabel.text = statusText;
-			_statusIcon.AddToClassList(statusClassName);
+			base.UpdateLocalStatus();
+			UpdateLocalStatusIcon(_mongoStorageModel.IsRunning, false);
 		}
 
 		private void OnIsRunningChanged(bool isRunning)
 		{
 			UpdateRemoteStatusIcon();
-			UpdateButtons();
+			UpdateLocalStatus();
 		}
 
 		private void OnBuildingFinished(bool isFinished)
 		{
 			UpdateRemoteStatusIcon();
-			UpdateButtons();
+			UpdateLocalStatus();
 		}
 
 		private void OnServiceReferenceChanged(ServiceStorageReference serviceReference)


### PR DESCRIPTION
# Brief Description

After few attempts I did found the issue mentioned by @PedroRauizBeamable before. 

Looks like sometimes just after opening Unity it behave like this:
- calls `Refresh` and `UpdateVisualElements` on each `Service Visual Element`- Model returns that is not running even when it is
- there is callback `_microserviceModel.ServiceBuilder.OnLastImageIdChanged` called that updates the buttons on the bottom of the service element but did not updated service header elements.

I fixed it and also put updating header, and buttons in one call so starting now we will update all elements related to local status of the service at once.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
