### PR TITLE
[BEAM-2182] Moved hover pseudo style to parent's uss, cleaned up some styles

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussStyleCardVisualElement/BussStyleCardVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussStyleCardVisualElement/BussStyleCardVisualElement.cs
@@ -83,7 +83,7 @@ namespace Beamable.Editor.UI.Components
 			RefreshButtons();
 		}
 
-		private void RefreshButtons()
+		public void RefreshButtons()
 		{
 			bool enabled = !_styleSheet.IsReadOnly;
 

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussStylePropertyVisualElement/VariableConnectionVisualElement/VariableConnectionVisualElement.dark.uss
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussStylePropertyVisualElement/VariableConnectionVisualElement/VariableConnectionVisualElement.dark.uss
@@ -1,17 +1,4 @@
 #button {
-    background-color: rgba(0, 0, 0, 0);
-    border-color: rgba(0, 0, 0, 0);
-}
-
-#button:hover {
-    -unity-background-image-tint-color: #808080;
-}
-
-DropdownVisualElement #mainContainer{
-    background-color: #808080;
-}
-
-#button {
     background-image: resource("Packages/com.beamable/Editor/UI/Common/Icons/addNewLight.png");
 }
 

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussStylePropertyVisualElement/VariableConnectionVisualElement/VariableConnectionVisualElement.light.uss
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussStylePropertyVisualElement/VariableConnectionVisualElement/VariableConnectionVisualElement.light.uss
@@ -1,17 +1,4 @@
 #button {
-    background-color: rgba(0, 0, 0, 0);
-    border-color: rgba(0, 0, 0, 0);
-}
-
-#button:hover {
-    -unity-background-image-tint-color: #808080;
-}
-
-DropdownVisualElement #mainContainer{
-    background-color: #808080;
-}
-
-#button {
     background-image: resource("Packages/com.beamable/Editor/UI/Common/Icons/addNewDark.png");
 }
 

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussStylePropertyVisualElement/VariableConnectionVisualElement/VariableConnectionVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussStylePropertyVisualElement/VariableConnectionVisualElement/VariableConnectionVisualElement.uss
@@ -25,3 +25,7 @@ DropdownVisualElement #button{
     min-width: 0px;
     max-width: 10000px;
 }
+
+#button:hover {
+    -unity-background-image-tint-color: #808080;
+}

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussStylePropertyVisualElement/VariableConnectionVisualElement/VariableConnectionVisualElement.uxml
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussStylePropertyVisualElement/VariableConnectionVisualElement/VariableConnectionVisualElement.uxml
@@ -7,7 +7,7 @@
         xsi:schemaLocation="UnityEngine.Experimental.UIElements ../UIElementsSchema/UnityEngine.Experimental.UIElements.xsd">
 
     <engine:VisualElement name="variableConnectionElement">
-        <engine:Button name="button"></engine:Button>
+        <engine:Button name="button"/>
         <beamable:DropdownVisualElement name="dropdown"/>
     </engine:VisualElement>
 

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussThemeManager.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussThemeManager.cs
@@ -187,6 +187,7 @@ namespace Beamable.Editor.UI.Buss
 					if (spawned != null)
 					{
 						spawned.RefreshProperties();
+						spawned.RefreshButtons();
 					}
 					else
 					{

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownOptionsVisualElement/DropdownOptionsVisualElement.light.uss
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownOptionsVisualElement/DropdownOptionsVisualElement.light.uss
@@ -1,0 +1,5 @@
+﻿.container {
+    border-color: #6C6C6C;
+    background-color: #b4b4b4;
+}
+

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownOptionsVisualElement/DropdownOptionsVisualElement.light.uss.meta
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownOptionsVisualElement/DropdownOptionsVisualElement.light.uss.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 48d82c65fb154fb4ba5d6a79d64a0852
+timeCreated: 1643812154

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownOptionsVisualElement/DropdownOptionsVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownOptionsVisualElement/DropdownOptionsVisualElement.uss
@@ -1,6 +1,4 @@
 ﻿.container {
-    border-color: #6C6C6C;
-    background-color: #b4b4b4;
     border-left-width: 1px;
     border-right-width: 1px;
     border-top-width: 1px;
@@ -8,3 +6,6 @@
     border-radius: 3px;
 }
 
+DropdownSingleOptionVisualElement:hover {
+    background-color: #828292;
+}

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownSingleOptionVisualElement/DropdownSingleOptionVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownSingleOptionVisualElement/DropdownSingleOptionVisualElement.cs
@@ -1,6 +1,4 @@
-﻿using Beamable.Editor.UI.Buss;
-using System;
-using UnityEngine;
+﻿using System;
 #if UNITY_2018
 using UnityEngine.Experimental.UIElements;
 using UnityEditor.Experimental.UIElements;

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownSingleOptionVisualElement/DropdownSingleOptionVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownSingleOptionVisualElement/DropdownSingleOptionVisualElement.uss
@@ -3,7 +3,3 @@
     padding-left: 15px;
     -unity-font: url("project:///Packages/com.beamable/Editor/UI/Font/Lato-Semibold.ttf");
 }
-
-#value:hover {
-   background-color: #828292;
-}

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownVisualElement.dark.uss
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownVisualElement.dark.uss
@@ -3,6 +3,10 @@
     background-color: #575757;
 }
 
+#value {
+    color: #ffffff;
+}
+
 #button {
     background-image: resource("Packages/com.beamable/Editor/UI/Content/Icons/dropdown_Line_light.png");
 }

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownVisualElement.light.uss
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownVisualElement.light.uss
@@ -1,0 +1,12 @@
+﻿#mainContainer {
+    border-color: #6C6C6C;
+    background-color: #b4b4b4;
+}
+
+#value {
+    color: #000000;
+}
+
+#button {
+    background-image: resource("Packages/com.beamable/Editor/UI/Content/Icons/dropdown_Line_dark.png");
+}

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownVisualElement.light.uss.meta
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownVisualElement.light.uss.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cb0c97ef293d46cdbfb5680f31932508
+timeCreated: 1643810762

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/DropdownVisualElement/DropdownVisualElement.uss
@@ -1,8 +1,6 @@
 ﻿#mainContainer {
     min-width: 100px;
     min-height: 26px;
-    border-color: #6C6C6C;
-    background-color: #b4b4b4;
     border-left-width: 1px;
     border-right-width: 1px;
     border-top-width: 1px;
@@ -25,7 +23,6 @@
 }
 
 #button {
-    background-image: resource("Packages/com.beamable/Editor/UI/Content/Icons/dropdown_Line_dark.png");
     width: 30px;
     margin-right: 3px;
 }


### PR DESCRIPTION
# Brief Description
I've moved hover pseudo style control from DropdownSingleOptionVisualElement to it's parent. Issue still happens in 2019 on Mac only but much less often.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevant JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
