### PR TITLE
BEAM-2217 - Selecting a Hint Domain isn't correctly filtering the list

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/BeamableAssistant/BeamableAssistantWindow.cs
+++ b/client/Packages/com.beamable/Editor/UI/BeamableAssistant/BeamableAssistantWindow.cs
@@ -91,8 +91,9 @@ namespace Beamable.Editor.Assistant
 		private void Update()
 		{
 			// If there are any new notifications, we refresh to get the new data rendered.
-			if (_hintNotificationManager != null && _hintNotificationManager.AllPendingNotifications.Any() || _beamHintsDataModel.RefreshDisplayingHints())
+			if (_beamHintsDataModel.RefreshDisplayingHints() || _hintNotificationManager != null && _hintNotificationManager.AllPendingNotifications.Any())
 			{
+				FillTreeViewFromDomains(_treeViewIMGUI,  _beamHintsDataModel.SortedDomainsInStorage, _beamHintsDataModel.SelectedDomains);
 				FillDisplayingBeamHints(_hintsContainer, _beamHintsDataModel.DisplayingHints);
 				_hintNotificationManager.ClearPendingNotifications();
 				_windowRoot.MarkDirtyRepaint();
@@ -200,7 +201,7 @@ namespace Beamable.Editor.Assistant
 					list => { });
 
 				beamHintsDataModel.SelectDomains(beamHintsDataModel.SelectedDomains);
-				FillTreeViewFromDomains(_treeViewIMGUI, beamHintsDataModel.SortedDomainsInStorage);
+				FillTreeViewFromDomains(_treeViewIMGUI, beamHintsDataModel.SortedDomainsInStorage, beamHintsDataModel.SelectedDomains);
 				FillDisplayingBeamHints(_hintsContainer, beamHintsDataModel.DisplayingHints);
 			}
 		}
@@ -226,9 +227,10 @@ namespace Beamable.Editor.Assistant
 		/// <summary>
 		/// Updates a <see cref="TreeViewGUI"/> to display the given list of <see cref="BeamHintDomains"/> strings. 
 		/// </summary>
-		public void FillTreeViewFromDomains(TreeViewIMGUI imgui, List<string> sortedDomains)
+		public void FillTreeViewFromDomains(TreeViewIMGUI imgui, List<string> sortedDomains, List<string> selectedDomains)
 		{
 			var treeViewItems = new List<BeamHintDomainTreeViewItem>();
+			var selectedIds = new List<int>();
 			var parentCache = new Dictionary<string, BeamHintDomainTreeViewItem>();
 			var id = 1;
 			foreach (string domain in sortedDomains)
@@ -250,11 +252,24 @@ namespace Beamable.Editor.Assistant
 						parentCache.Add(domainSubstring, item);
 						treeViewItems.Add(item);
 						id += 1;
+
+						if (selectedDomains.Contains(domain))
+						{
+							selectedIds.Add(item.id);
+						}
+						
 					}
 				}
 			}
 
 			imgui.TreeViewItems = treeViewItems.Cast<TreeViewItem>().ToList();
+			
+			// Only select if  we have any selected domains (selected domains defaults to all sorted domains unless someone clicks a subdomain).
+			// This means their counts greater than or the same when no selection is made. 
+			if (sortedDomains.Count > selectedDomains.Count && selectedDomains.Count != 0)
+			{
+				imgui.SetSelectionSafe(selectedIds);
+			}
 		}
 
 		public void SetupTreeViewCallbacks(TreeViewIMGUI imgui,

--- a/client/Packages/com.beamable/Editor/UI/BeamableAssistant/Models/BeamHintsDataModel.cs
+++ b/client/Packages/com.beamable/Editor/UI/BeamableAssistant/Models/BeamHintsDataModel.cs
@@ -81,10 +81,9 @@ namespace Beamable.Editor.Assistant
 			var hints = _hintGlobalStorages.SelectMany(storage => storage).ToList();
 			RefreshDomainsFromHints(hints);
 
-
 			var previouslyDisplayingHints = new BeamHintHeader[DisplayingHints.Count];
 			DisplayingHints.CopyTo(previouslyDisplayingHints);
-			RefreshDisplayingHints(hints, SortedDomainsInStorage);
+			RefreshDisplayingHints(hints, SelectedDomains);
 
 			// If any of the new hints was not contained in the previously displayed hints, we return true as there are new hints.
 			var newHintsAppeared = DisplayingHints.Except(previouslyDisplayingHints).Any();


### PR DESCRIPTION
# Brief Description
- Assistant Hint Domains now update correctly when a new hint is detected;
- Fixed domain filtering of BeamableAssistantWindow; 
- Assistant Domain Tree view selection now survives domain reload

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
