### PR TITLE
BUSS add component bug fixed

### DIFF
--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/BussConfiguration.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/BussConfiguration.cs
@@ -45,6 +45,8 @@ namespace Beamable.UI.Buss // TODO: rename it to Beamable.UI.BUSS - new system's
 
 		private List<BussElement> _rootBussElements = new List<BussElement>();
 
+		public List<BussElement> RootBussElements => _rootBussElements;
+
 #if UNITY_EDITOR
 		static BussConfiguration()
 		{

--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/BussElement.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/BussElement.cs
@@ -1,6 +1,7 @@
 ﻿using Beamable.Editor.UI.Buss;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -89,6 +90,7 @@ namespace Beamable.UI.Buss
 		private void OnEnable()
 		{
 			CheckParent();
+			CheckRelationToSiblings();
 			OnStyleChanged();
 		}
 
@@ -109,6 +111,7 @@ namespace Beamable.UI.Buss
 		private void OnTransformParentChanged()
 		{
 			CheckParent();
+			CheckRelationToSiblings();
 			OnStyleChanged();
 		}
 
@@ -252,6 +255,12 @@ namespace Beamable.UI.Buss
 			var foundParent = (transform == null || transform.parent == null)
 				? null
 				: transform.parent.GetComponentInParent<BussElement>();
+
+			if (foundParent == Parent)
+			{
+				return;
+			}
+			
 			if (Parent != null)
 			{
 				Parent._children.Remove(this);
@@ -271,6 +280,29 @@ namespace Beamable.UI.Buss
 				if (!Parent._children.Contains(this))
 				{
 					Parent._children.Add(this);
+				}
+			}
+		}
+
+		private void CheckRelationToSiblings()
+		{
+			if (Parent == null)
+			{
+				BussConfiguration.UseConfig(c => CheckRelations(c.RootBussElements));
+			}
+			else
+			{
+				CheckRelations(Parent.Children);
+			}
+		}
+
+		private void CheckRelations(IEnumerable<BussElement> elements)
+		{
+			foreach (BussElement element in elements.ToArray())
+			{
+				if (element != this)
+				{
+					element.CheckParent();
 				}
 			}
 		}


### PR DESCRIPTION
# Brief Description
After adding the BussElement component to the gameobject that is a parent of other BussElements, the new child elements didn't update the parent reference. I fixed that here.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
