### PR TITLE
[BEAM-2239] Merged BeamableBasic and Beamable VisualElement classes

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Components/PublishPopup/PublishPopup.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/PublishPopup/PublishPopup.cs
@@ -73,7 +73,7 @@ namespace Beamable.Editor.Microservice.UI.Components
 		public void PrepareParent()
 		{
 			parent.name = "PublishWindowContainer";
-			parent.AddStyleSheet(USSPath);
+			parent.AddStyleSheet(UssPath);
 		}
 
 		public override void Refresh()

--- a/client/Packages/com.beamable/Editor/UI/Common/BeamableBasicVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/BeamableBasicVisualElement.cs
@@ -13,22 +13,14 @@ namespace Beamable.Editor.UI.Common
 {
 	public class BeamableBasicVisualElement : VisualElement
 	{
-		protected VisualElement Root
-		{
-			get;
-			set;
-		}
+		protected VisualElement Root { get; set; }
+		protected string UssPath { get; }
 
-		protected string USSPath
-		{
-			get;
-		}
-
-		public BeamableBasicVisualElement(string ussPath)
+		protected BeamableBasicVisualElement(string ussPath)
 		{
 			Assert.IsTrue(File.Exists(ussPath), $"Cannot find {ussPath}");
 
-			USSPath = ussPath;
+			UssPath = ussPath;
 
 			RegisterCallback<DetachFromPanelEvent>(evt =>
 			{
@@ -36,14 +28,32 @@ namespace Beamable.Editor.UI.Common
 			});
 		}
 
-		public virtual void OnDetach()
+		public virtual void Refresh() { }
+
+		protected virtual void OnDestroy() { }
+
+		protected virtual void OnDetach() { }
+
+		public virtual void Init()
 		{
-			// Do any sort of cleanup
+			Destroy();
+			Clear();
+
+			this.AddStyleSheet(BeamableComponentsConstants.COMMON_USS_PATH);
+			this.AddStyleSheet(UssPath);
+
+			Root = new VisualElement();
+			Root.name = "root";
+			Add(Root);
+
+			this?.Query<VisualElement>(className: "--image-scale-to-fit").ForEach(elem =>
+			{
+				elem?.SetBackgroundScaleModeToFit();
+			});
 		}
 
 		public void Destroy()
 		{
-			// call OnDestroy on all child elements.
 			foreach (var child in Children())
 			{
 				if (child is BeamableVisualElement beamableChild)
@@ -59,27 +69,5 @@ namespace Beamable.Editor.UI.Common
 
 			OnDestroy();
 		}
-
-		protected virtual void OnDestroy() { }
-
-		public virtual void Init()
-		{
-			Destroy();
-			Clear();
-
-			this.AddStyleSheet(BeamableComponentsConstants.COMMON_USS_PATH);
-			this.AddStyleSheet(USSPath);
-
-			Root = new VisualElement();
-			Root.name = "root";
-			Add(Root);
-
-			this?.Query<VisualElement>(className: "--image-scale-to-fit").ForEach(elem =>
-			{
-				elem?.SetBackgroundScaleModeToFit();
-			});
-		}
-
-		public virtual void Refresh() { }
 	}
 }

--- a/client/Packages/com.beamable/Editor/UI/Common/BeamableVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/BeamableVisualElement.cs
@@ -1,3 +1,4 @@
+using Beamable.Editor.UI.Common;
 using System.IO;
 using UnityEditor;
 using UnityEngine.Assertions;
@@ -11,56 +12,28 @@ using UnityEditor.UIElements;
 
 namespace Beamable.Editor.UI.Components
 {
-	public class BeamableVisualElement : VisualElement
+	public class BeamableVisualElement : BeamableBasicVisualElement
 	{
-		protected VisualTreeAsset TreeAsset { get; private set; }
-		protected VisualElement Root { get; private set; }
+		private VisualTreeAsset TreeAsset { get; }
 
-		protected string UXMLPath { get; private set; }
+		private string UxmlPath { get; }
 
-		protected string USSPath { get; private set; }
+		protected BeamableVisualElement(string commonPath) : this(commonPath + ".uxml", commonPath + ".uss") { }
 
-		public BeamableVisualElement(string commonPath) : this(commonPath + ".uxml", commonPath + ".uss") { }
-
-		public BeamableVisualElement(string uxmlPath, string ussPath)
+		private BeamableVisualElement(string uxmlPath, string ussPath) : base(ussPath)
 		{
 			Assert.IsTrue(File.Exists(uxmlPath), $"Cannot find {uxmlPath}");
-			Assert.IsTrue(File.Exists(ussPath), $"Cannot find {ussPath}");
-			UXMLPath = uxmlPath;
-			USSPath = ussPath;
-			TreeAsset = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(UXMLPath);
+
+			UxmlPath = uxmlPath;
+			TreeAsset = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(UxmlPath);
 
 			RegisterCallback<DetachFromPanelEvent>(evt =>
 			{
 				OnDetach();
 			});
-
 		}
 
-		public virtual void OnDetach()
-		{
-			// Do any sort of cleanup
-		}
-
-		public void Destroy()
-		{
-			// call OnDestroy on all child elements.
-			foreach (var child in Children())
-			{
-				if (child is BeamableVisualElement beamableChild)
-				{
-					beamableChild.Destroy();
-				}
-			}
-			OnDestroy();
-		}
-
-		protected virtual void OnDestroy()
-		{
-			// Unregister any events...
-		}
-
-		public virtual void Refresh()
+		public override void Refresh()
 		{
 			Destroy();
 			Clear();
@@ -68,8 +41,7 @@ namespace Beamable.Editor.UI.Components
 			Root = TreeAsset.CloneTree();
 
 			this.AddStyleSheet(BeamableComponentsConstants.COMMON_USS_PATH);
-			this.AddStyleSheet(USSPath);
-
+			this.AddStyleSheet(UssPath);
 
 			Add(Root);
 

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/LabeledCheckboxVisualElement/LabeledCheckboxVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/LabeledCheckboxVisualElement/LabeledCheckboxVisualElement.cs
@@ -83,10 +83,6 @@ namespace Beamable.Editor.UI.Components
 			Flip = isFlipped;
 		}
 
-		public LabeledCheckboxVisualElement(string uxmlPath, string ussPath) : base(uxmlPath, ussPath)
-		{
-		}
-
 		public override void Refresh()
 		{
 			base.Refresh();

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/SearchBarVisualElement/SearchBarVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/SearchBarVisualElement/SearchBarVisualElement.cs
@@ -52,7 +52,7 @@ namespace Beamable.Editor.UI.Components
 			});
 		}
 
-		public override void OnDetach()
+		protected override void OnDetach()
 		{
 			base.OnDetach();
 			EditorApplication.update -= OnEditorUpdate;

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/SearchabledDropdownVisualElement/SearchabledDropdownVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/SearchabledDropdownVisualElement/SearchabledDropdownVisualElement.cs
@@ -42,7 +42,7 @@ namespace Beamable.Editor.UI.Components
 			this._switchText = switchText;
 		}
 
-		public override void OnDetach()
+		protected override void OnDetach()
 		{
 			Model.OnAvailableElementsChanged -= OnUpdated;
 			Model.OnElementChanged -= OnActiveChanged;

--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ContentVisualElement/ContentVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ContentVisualElement/ContentVisualElement.cs
@@ -51,7 +51,7 @@ namespace Beamable.Editor.Content.Components
 
 		public ContentVisualElement() : base(nameof(ContentVisualElement)) { }
 
-		public override void OnDetach()
+		protected override void OnDetach()
 		{
 			ContentItemDescriptor = null; // trigger the cleanup.
 		}

--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ValidateContentVisualElement/ValidateContentVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ValidateContentVisualElement/ValidateContentVisualElement.cs
@@ -186,7 +186,7 @@ namespace Beamable.Editor.Content.Components
 			_listView.Refresh();
 		}
 
-		public override void OnDetach()
+		protected override void OnDetach()
 		{
 			base.OnDetach();
 			foreach (var elem in _listSource)


### PR DESCRIPTION
# Brief Description
While we were creating Buss Theme Manager we've introduced a new class for custom visual elements (BeamableBasicVisualElement). This class helped us to create components without Uxml files and with separate Init and Refresh methods (lack of separation was a problem in a matter of performance and architectural in general). Until now these were paralel classes. For now I've made BeamableBasicVisualElement a basic class that BeamableVisualElement class derives from. It doesn't change anything for current objects that derives directly from BeamableVisualElements but this merge is necessary to perform further refactoring and cleanups (mostly because our helpers for showing different windows and popups takes BeamableVisualElements as a parameters and other ones, those deriving from BeamabelBasic version, couldn't be used there without "hacks"). In general... if You want to create components with Uxml and Uss files derive from BeamableVisualElement as before and use Refresh method to initialize and refresh, if You want to create something with separate Init and Refresh functionality use BeamableBasic version. In the future BeamableVisualElement will also receive separate Init and Refresh methods.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
