### PR TITLE
BEAM-2244 - BeamableToolbar AssetDatabase Refresh can throw a non-blocking exception in some cases

### DIFF
--- a/client/Packages/com.beamable/Editor/BeamableAssistant/BeamableToolbarExtender/BeamableToolbarExtender.cs
+++ b/client/Packages/com.beamable/Editor/BeamableAssistant/BeamableToolbarExtender/BeamableToolbarExtender.cs
@@ -121,8 +121,6 @@ namespace Beamable.Editor.ToolbarExtender
 				_noHintsTexture = AssetDatabase.LoadAssetAtPath<Texture>("Packages/com.beamable/Editor/UI/BeamableAssistant/Icons/info.png");
 				_hintsTexture = AssetDatabase.LoadAssetAtPath<Texture>("Packages/com.beamable/Editor/UI/BeamableAssistant/Icons/info hit.png");
 				_validationTexture = AssetDatabase.LoadAssetAtPath<Texture>("Packages/com.beamable/Editor/UI/BeamableAssistant/Icons/info valu.png");
-
-				AssetDatabase.Refresh();
 			});
 		}
 


### PR DESCRIPTION
# Brief Description
Just removed some stale code that would throw an exception when called from `Editor.delayCall` in some rare cases.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
