### PR TITLE
BEAM-2256 - ClientCallableAttribute validation was priorizing warning over error

### DIFF
--- a/client/Packages/com.beamable.server/SharedRuntime/ClientCallableAttribute.cs
+++ b/client/Packages/com.beamable.server/SharedRuntime/ClientCallableAttribute.cs
@@ -73,18 +73,18 @@ namespace Beamable.Server
 		{
 			var methodInfo = (MethodInfo)member;
 
-			// Check for void signatures to send out warning.
-			if (methodInfo.IsAsyncMethodOfType(typeof(void)))
-			{
-				var message = $"";
-				return new AttributeValidationResult(this, member, ReflectionCache.ValidationResultType.Warning, message);
-			}
-
 			// Check for any unsupported parameter types.
 			if (UNSUPPORTED_PARAMETER_TYPES.MatchAnyParametersOfMethod(methodInfo, out var detectedUnsupportedTypes))
 			{
 				var message = $"The unsupported parameters are: {string.Join(", ", detectedUnsupportedTypes.Select(p => $"{p.ParameterType.Name} {p.Name}"))}";
 				return new AttributeValidationResult(this, member, ReflectionCache.ValidationResultType.Error, message);
+			}
+			
+			// Check for void signatures to send out warning.
+			if (methodInfo.IsAsyncMethodOfType(typeof(void)))
+			{
+				var message = $"";
+				return new AttributeValidationResult(this, member, ReflectionCache.ValidationResultType.Warning, message);
 			}
 
 			return new AttributeValidationResult(this, member, ReflectionCache.ValidationResultType.Valid, $"");


### PR DESCRIPTION
# Brief Description
ClientCallableAttribute now correctly prioritizes generating a error validation result over it's warning.

We should, in the future, refactor the reflection cache's `AttributeValidationResult` APIs to support multiple validation results per-call to prevent the need for this type of ordering concern.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
