### PR TITLE
beam 2258 - add writable check before validation

### DIFF
--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/Styles/BussStyleSheet.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/Styles/BussStyleSheet.cs
@@ -32,8 +32,9 @@ namespace Beamable.UI.Buss
 			{
 #if BEAMABLE_DEVELOPER
 				return true;
-#endif
+#else
 				return !IsReadOnly;
+#endif
 			}
 		}
 


### PR DESCRIPTION
# Brief Description

https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108
So...
I think that when we poke the scriptable object, it calls `OnValidate`, even though its in /Packages. So I just added a check to short circuit that change method if the object itself isn't writable.


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
