### PR TITLE
beam 2265 - FindAssets using namespaced classes

### DIFF
--- a/client/Packages/com.beamable.server/Editor/AssemblyDefinitionHelper.cs
+++ b/client/Packages/com.beamable.server/Editor/AssemblyDefinitionHelper.cs
@@ -1,4 +1,5 @@
 using Beamable.Common;
+using Beamable.Editor;
 using Beamable.Serialization.SmallerJSON;
 using Beamable.Server.Editor.DockerCommands;
 using System;
@@ -282,7 +283,7 @@ namespace Beamable.Server.Editor
 		public static IEnumerable<AssemblyDefinitionAsset> EnumerateAssemblyDefinitionAssets()
 		{
 			// TODO: We could add a static cache here, because by definition, a recompile will be executed anytime a new ASMDEF shows up.
-			var assemblyDefGuids = AssetDatabase.FindAssets($"t:{nameof(AssemblyDefinitionAsset)}");
+			var assemblyDefGuids = BeamableAssetDatabase.FindAssets<AssemblyDefinitionAsset>();
 			foreach (var assemblyDefGuid in assemblyDefGuids)
 			{
 				var assemblyDefPath = AssetDatabase.GUIDToAssetPath(assemblyDefGuid);

--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed 
+- Beamable assets are loaded with their full name so asset types won't collide
+
 ## [1.0.0]
 ### Added
 - `BeamContext` classes and new player centric SDK types like `PlayerInventory`

--- a/client/Packages/com.beamable/Editor/BeamEditor.cs
+++ b/client/Packages/com.beamable/Editor/BeamEditor.cs
@@ -111,9 +111,10 @@ namespace Beamable
 
 			// Load up all Asset-based IReflectionSystem (injected via ReflectionSystemObject instances). This was made to solve a cross-package injection problem.
 			// It doubles as a no-code way for users to inject their own IReflectionSystem into our pipeline.
-			var reflectionCacheSystemGuids = AssetDatabase.FindAssets($"t:{nameof(ReflectionSystemObject)}", coreConfiguration.ReflectionSystemPaths
-																															  .Where(Directory.Exists)
-																															  .ToArray());
+			var reflectionCacheSystemGuids = BeamableAssetDatabase.FindAssets<ReflectionSystemObject>(
+				coreConfiguration.ReflectionSystemPaths
+				                 .Where(Directory.Exists)
+				                 .ToArray());
 
 			// Get ReflectionSystemObjects and sort them
 			var reflectionSystemObjects = reflectionCacheSystemGuids.Select(reflectionCacheSystemGuid =>

--- a/client/Packages/com.beamable/Editor/BeamableAssistant/BeamableToolbarExtender/BeamableToolbarExtender.cs
+++ b/client/Packages/com.beamable/Editor/BeamableAssistant/BeamableToolbarExtender/BeamableToolbarExtender.cs
@@ -85,7 +85,7 @@ namespace Beamable.Editor.ToolbarExtender
 
 				// Load and inject Beamable Menu Items (necessary due to multiple package split of SDK) --- sort them by specified order, and alphabetically when tied.
 				var menuItemsSearchInFolders = BeamEditor.CoreConfiguration.BeamableAssistantMenuItemsPath.Where(Directory.Exists).ToArray();
-				var menuItemsGuids = AssetDatabase.FindAssets($"t:{nameof(BeamableAssistantMenuItem)}", menuItemsSearchInFolders);
+				var menuItemsGuids = BeamableAssetDatabase.FindAssets<BeamableAssistantMenuItem>(menuItemsSearchInFolders);
 				_assistantMenuItems = menuItemsGuids.Select(guid => AssetDatabase.LoadAssetAtPath<BeamableAssistantMenuItem>(AssetDatabase.GUIDToAssetPath(guid))).ToList();
 				_assistantMenuItems.Sort((mi1, mi2) =>
 				{
@@ -96,7 +96,7 @@ namespace Beamable.Editor.ToolbarExtender
 				});
 
 				var toolbarButtonsSearchInFolders = BeamEditor.CoreConfiguration.BeamableAssistantToolbarButtonsPaths.Where(Directory.Exists).ToArray();
-				var toolbarButtonsGuids = AssetDatabase.FindAssets($"t:{nameof(BeamableToolbarButton)}", toolbarButtonsSearchInFolders);
+				var toolbarButtonsGuids = BeamableAssetDatabase.FindAssets<BeamableToolbarButton>(toolbarButtonsSearchInFolders);
 				var toolbarButtons = toolbarButtonsGuids.Select(guid => AssetDatabase.LoadAssetAtPath<BeamableToolbarButton>(AssetDatabase.GUIDToAssetPath(guid))).ToList();
 
 				var groupedBySide = toolbarButtons.GroupBy(btn => btn.GetButtonSide(api)).ToList();

--- a/client/Packages/com.beamable/Editor/BeamableAssistant/ReflectionCacheSystems/BeamHintReflectionCache.cs
+++ b/client/Packages/com.beamable/Editor/BeamableAssistant/ReflectionCacheSystems/BeamHintReflectionCache.cs
@@ -123,7 +123,7 @@ namespace Beamable.Editor.Reflection
 			{
 				_loadedTextMaps.Clear();
 
-				var beamHintTextMapGuids = AssetDatabase.FindAssets($"t:{nameof(BeamHintTextMap)}", hintConfigPaths
+				var beamHintTextMapGuids = BeamableAssetDatabase.FindAssets<BeamHintTextMap>(hintConfigPaths
 																									.Where(Directory.Exists)
 																									.ToArray());
 
@@ -152,7 +152,7 @@ namespace Beamable.Editor.Reflection
 			{
 				_loadedConfigs.Clear();
 
-				var beamHintDetailsConfigsGuids = AssetDatabase.FindAssets($"t:{nameof(BeamHintDetailsConfig)}", hintConfigPaths
+				var beamHintDetailsConfigsGuids = BeamableAssetDatabase.FindAssets<BeamHintDetailsConfig>(hintConfigPaths
 																												 .Where(Directory.Exists)
 																												 .ToArray());
 
@@ -325,7 +325,7 @@ namespace Beamable.Editor.Reflection
 				// Handle Beam Hint Domain providers
 				if (attributeType.Equals(BEAM_HINT_DOMAIN_PROVIDER_ATTRIBUTE))
 				{
-					// TODO: Store domains in whatever way makes it easier for users to get the list of domains they are interested in. 
+					// TODO: Store domains in whatever way makes it easier for users to get the list of domains they are interested in.
 					foreach (var domainFields in cachedMemberAttributes.Select(result => result.Info).Cast<FieldInfo>())
 					{
 						var providerName = domainFields.DeclaringType?.FullName ?? string.Empty;
@@ -342,7 +342,7 @@ namespace Beamable.Editor.Reflection
 				// Handle Beam Hint Id providers
 				if (attributeType.Equals(BEAM_HINT_ID_PROVIDER_ATTRIBUTE))
 				{
-					// TODO: Store domains in whatever way makes it easier for users to get the list of domains they are interested in. 
+					// TODO: Store domains in whatever way makes it easier for users to get the list of domains they are interested in.
 					foreach (var idField in cachedMemberAttributes.Select(result => result.Info).Cast<FieldInfo>())
 					{
 						var providerName = idField.DeclaringType?.FullName ?? string.Empty;
@@ -373,7 +373,7 @@ namespace Beamable.Editor.Reflection
 						var attribute = (BeamHintDetailConverterAttribute)cachedMemberAttribute.Attribute;
 						var methodInfo = (MethodInfo)cachedMemberAttribute.Info;
 
-						// Cache a built delegate to be called as a converter. 
+						// Cache a built delegate to be called as a converter.
 						if (attribute.DelegateType == typeof(DefaultConverter))
 						{
 							var cachedDelegate = Delegate.CreateDelegate(attribute.DelegateType, methodInfo) as DefaultConverter;
@@ -385,7 +385,7 @@ namespace Beamable.Editor.Reflection
 			}
 
 			/// <summary>
-			/// Generates a <see cref="ConverterData{T}"/> tying together all references mapped by a <see cref="BeamHintDetailConverterAttribute"/>. 
+			/// Generates a <see cref="ConverterData{T}"/> tying together all references mapped by a <see cref="BeamHintDetailConverterAttribute"/>.
 			/// </summary>
 			private ConverterData<T> BuildConverterData<T>(BeamHintType type, string domain, string idRegex, string userOverrideHintDetailConfigId, string hintDetailConfigId, T cachedDelegate)
 				where T : Delegate

--- a/client/Packages/com.beamable/Editor/Modules/Content/ContentIO.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/ContentIO.cs
@@ -431,8 +431,8 @@ namespace Beamable.Editor.Content
 
 		private ContentObject Find(ContentObject content)
 		{
-			var assetGuids = AssetDatabase.FindAssets(
-				$"t:{content.GetType().Name}",
+			var assetGuids = BeamableAssetDatabase.FindAssets(
+				content.GetType(),
 				new[] { Directories.DATA_DIR }
 			);
 			foreach (var guid in assetGuids)
@@ -456,8 +456,7 @@ namespace Beamable.Editor.Content
 				yield break; // there is no folder, therefore, no content. Nothing to search for.
 			}
 
-			var assetGuids = AssetDatabase.FindAssets(
-				$"t:{typeof(TContent).Name}",
+			var assetGuids = BeamableAssetDatabase.FindAssets<TContent>(
 				new[] { Directories.DATA_DIR }
 			);
 			var contentType = ContentRegistry.TypeToName(typeof(TContent));
@@ -527,8 +526,8 @@ namespace Beamable.Editor.Content
 
 			foreach (var contentType in ContentRegistry.GetContentTypes()) // TODO check hierarchy types.
 			{
-				var assetGuids = AssetDatabase.FindAssets(
-					$"t:{contentType.Name}",
+				var assetGuids = BeamableAssetDatabase.FindAssets(
+					contentType,
 					new[] { Directories.DATA_DIR }
 				);
 				var typeName = ContentRegistry.TypeToName(contentType);
@@ -639,8 +638,8 @@ namespace Beamable.Editor.Content
 		{
 			foreach (var nextContentType in ContentRegistry.GetContentTypes()) // TODO check heirarchy types.
 			{
-				var assetGuids = AssetDatabase.FindAssets(
-					$"t:{nextContentType.Name}",
+				var assetGuids = BeamableAssetDatabase.FindAssets(
+					nextContentType,
 					new[] { Directories.DATA_DIR }
 				);
 

--- a/client/Packages/com.beamable/Editor/Modules/Theme/Style/ThemeSelectorEditor.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Theme/Style/ThemeSelectorEditor.cs
@@ -19,7 +19,7 @@ namespace Beamable.Editor.Style
 		{
 			if (_configuration == null) return;
 
-			string[] guids = AssetDatabase.FindAssets($"t:{typeof(ThemeObject)}");
+			string[] guids = BeamableAssetDatabase.FindAssets<ThemeObject>();
 			string[] names = new string[guids.Length + 1];
 			names[guids.Length] = "New...";
 			ThemeObject[] styles = new ThemeObject[guids.Length];

--- a/client/Packages/com.beamable/Editor/Modules/Theme/ThemeConfigurationPropertyDrawer.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Theme/ThemeConfigurationPropertyDrawer.cs
@@ -17,7 +17,7 @@ namespace Beamable.Editor.Modules.Theme
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
 			var rect = new Rect(position.x + 5, position.y, position.width - 5, position.height);
-			string[] guids = AssetDatabase.FindAssets($"t:{typeof(ThemeObject)}");
+			string[] guids = BeamableAssetDatabase.FindAssets<ThemeObject>();
 			string[] names = new string[guids.Length + 1];
 			names[guids.Length] = "New...";
 			ThemeObject[] styles = new ThemeObject[guids.Length];

--- a/client/Packages/com.beamable/Editor/UI/Common/MediaQueryObjectPropertyDrawer.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/MediaQueryObjectPropertyDrawer.cs
@@ -11,7 +11,7 @@ namespace Beamable.Editor.Style
 	{
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
-			var guids = AssetDatabase.FindAssets($"t:{typeof(MediaQueryObject)}");
+			var guids = BeamableAssetDatabase.FindAssets<MediaQueryObject>();
 			var names = new string[guids.Length + 1];
 			names[0] = "<none>";
 

--- a/client/Packages/com.beamable/Editor/Utility/BeamableAssetDatabase.cs
+++ b/client/Packages/com.beamable/Editor/Utility/BeamableAssetDatabase.cs
@@ -1,0 +1,27 @@
+using System;
+using UnityEditor;
+using UnityEngine.Assertions;
+
+namespace Beamable.Editor
+{
+	public static class BeamableAssetDatabase
+	{
+		/// <summary>
+		/// A sugar on top of <see cref="AssetDatabase.FindAssets"/> that uses the type's full name,
+		/// so that we don't collide with client namespaces or common types.
+		/// </summary>
+		/// <param name="searchInFolders">The folders where the search will start.</param>
+		/// <returns>
+		///   <para>Array of matching asset. Note that GUIDs will be returned.</para>
+		/// </returns>
+		public static string[] FindAssets(Type t, string[] searchInFolders=null)
+		{
+			Assert.IsNotNull(t, "Cannot find assets for null type");
+			var fullName = t.FullName;
+			return AssetDatabase.FindAssets($"t:{fullName}", searchInFolders);
+		}
+
+		/// <inheritdoc cref="FindAssets"/>
+		public static string[] FindAssets<T>(string[] searchInFolders=null) => FindAssets(typeof(T), searchInFolders);
+	}
+}

--- a/client/Packages/com.beamable/Editor/Utility/BeamableAssetDatabase.cs.meta
+++ b/client/Packages/com.beamable/Editor/Utility/BeamableAssetDatabase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1be0538911c644131bae279447d973e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Ticket 
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2265

# Brief Description
The issue was that if a customer had a class with the same name, or such that our class was a suffix of theirs, our `.FindAsset` calls would accidentally load their class in an unintended location. 

So I created a small utility wrapper for the `AssetData.FindAssets` function that uses the `FullName` of the given type, and mapped all our old usages of `FindAssets` that were using the `"t:{nameof(T)}"` syntax to use the new one. 

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
