### PR TITLE
beam 2279 - adds overridable deviceId service

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed 
 - Beamable assets are loaded with their full name so asset types won't collide
 
+### Added
+- `IDeviceIdResolver` is now a dependency of the `AuthService`, and can be overriden to produce different device ids other than `SystemInfo.deviceUniqueIdentifier`
+
+
 ## [1.0.0]
 ### Added
 - `BeamContext` classes and new player centric SDK types like `PlayerInventory`

--- a/client/Packages/com.beamable/Editor/Modules/Account/EditorAuthService.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Account/EditorAuthService.cs
@@ -12,7 +12,7 @@ namespace Beamable.Editor.Modules.Account
 
 	public class EditorAuthService : AuthService, IEditorAuthApi
 	{
-		public EditorAuthService(IBeamableRequester requester) : base(requester, new DefaultAuthSettings
+		public EditorAuthService(IBeamableRequester requester) : base(requester, new DefaultDeviceIdResolver(), new DefaultAuthSettings
 		{
 			PasswordResetCodeType = CodeType.PIN
 		})

--- a/client/Packages/com.beamable/Runtime/Beam.cs
+++ b/client/Packages/com.beamable/Runtime/Beam.cs
@@ -133,6 +133,7 @@ namespace Beamable
 			DependencyBuilder.AddSingleton(BeamableEnvironment.Data);
 			DependencyBuilder.AddSingleton<IUserContext>(provider => provider.GetService<IPlatformService>());
 			DependencyBuilder.AddSingleton<IConnectivityService, ConnectivityService>();
+			DependencyBuilder.AddSingleton<IDeviceIdResolver, DefaultDeviceIdResolver>();
 			DependencyBuilder.AddSingleton<IAuthService, AuthService>();
 			DependencyBuilder.AddScoped<IInventoryApi, InventoryService>(
 				provider => provider.GetService<InventoryService>());

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Auth/DeviceIdResolver.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Auth/DeviceIdResolver.cs
@@ -1,0 +1,24 @@
+using Beamable.Common;
+using UnityEngine;
+
+namespace Beamable.Api.Auth
+{
+	public interface IDeviceIdResolver
+	{
+		/// <summary>
+		/// Retrieve an id that is unique to the hardware device executing the game.
+		/// In most cases, this will be the <see cref="SystemInfo.deviceUniqueIdentifier"/>
+		/// </summary>
+		/// <returns>A unique device id</returns>
+		Promise<string> GetDeviceId();
+	}
+
+	public class DefaultDeviceIdResolver : IDeviceIdResolver
+	{
+		public Promise<string> GetDeviceId()
+		{
+			return Promise<string>.Successful(SystemInfo.deviceUniqueIdentifier);
+		}
+	}
+
+}

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Auth/DeviceIdResolver.cs.meta
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Auth/DeviceIdResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25665e05ade5f43d8b70923f22617c48
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Platform/Auth/AuthServiceTests/AuthServiceTestBase.cs
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Platform/Auth/AuthServiceTests/AuthServiceTestBase.cs
@@ -16,13 +16,20 @@ namespace Beamable.Platform.Tests.Auth.AuthServiceTests
 		protected MockPlatformAPI _requester;
 		protected AuthService _service;
 		protected User _sampleUser;
+		protected IDeviceIdResolver _deviceIdResolver;
 
 		[SetUp]
 		public void Init()
 		{
 			_requester = new MockPlatformAPI();
 			_sampleUser = new User();
-			_service = new AuthService(_requester);
+			_deviceIdResolver = CreateDeviceIdResolver();
+			_service = new AuthService(_requester, _deviceIdResolver);
+		}
+
+		protected virtual IDeviceIdResolver CreateDeviceIdResolver()
+		{
+			return new DefaultDeviceIdResolver();
 		}
 
 		[TearDown]

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Platform/Auth/AuthServiceTests/CustomDeviceIdTests.cs
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Platform/Auth/AuthServiceTests/CustomDeviceIdTests.cs
@@ -1,0 +1,51 @@
+using Beamable.Api.Auth;
+using Beamable.Common;
+using Beamable.Common.Api;
+using Beamable.Common.Api.Auth;
+using NUnit.Framework;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine.TestTools;
+
+namespace Beamable.Platform.Tests.Auth.AuthServiceTests
+{
+	public class CustomDeviceIdTests : AuthServiceTestBase
+	{
+		private TestDeviceIdResolver _resolver;
+
+		protected override IDeviceIdResolver CreateDeviceIdResolver()
+		{
+			_resolver = new TestDeviceIdResolver();
+			return _resolver;
+		}
+
+		[UnityTest]
+		public IEnumerator CustomProvider()
+		{
+			var deviceId = "tunafish";
+			_resolver.DeviceId = deviceId;
+
+			var getDeviceId = _deviceIdResolver.GetDeviceId();
+			yield return getDeviceId.AsYield();
+			Assert.AreEqual(deviceId, getDeviceId.GetResult());
+
+			var mockReq = _requester.MockRequest<TokenResponse>(Method.POST, $"{TOKEN_URL}")
+			                        .WithJsonFieldMatch("grant_type", "device")
+			                        .WithJsonFieldMatch("device_id", deviceId);
+
+			var req = _service.LoginDeviceId();
+			yield return req.AsYield();
+
+			Assert.AreEqual(1, mockReq.CallCount);
+		}
+
+		public class TestDeviceIdResolver : IDeviceIdResolver
+		{
+			public string DeviceId { get; set; } = "unset";
+			public Promise<string> GetDeviceId()
+			{
+				return Promise<string>.Successful(DeviceId);
+			}
+		}
+	}
+}

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Platform/Auth/AuthServiceTests/CustomDeviceIdTests.cs.meta
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Platform/Auth/AuthServiceTests/CustomDeviceIdTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9866aa2a3ea434586af878dbf8a30c57
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2279

# Brief Description
We need a way to override what `deviceId` is used for the auth service. This PR adds a service that's sole job is to produce the deviceId, and has a default implementation that returns the old `SystemInfo` version. However, using the `RegisterBeamableDependencies` attribute, its possible now to override the implementation of this service and use whatever type of resolution you want. 

The sample usage would look like this
```csharp

[BeamContextSystem]
public class MyCode
{
	[RegisterBeamableDependencies]
	public static void Configure(IDependencyBuilder builder)
	{
		builder.RemoveIfExists<IDeviceIdResolver>();
		builder.AddSingleton<IDeviceIdResolver, MyCustomDeviceIdResolver>();
	}
}

public class MyCustomDeviceIdResolver : IDeviceIdResolver
{
	public Promise<string> GetDeviceId()
	{
		throw new System.NotImplementedException();
	}
}
```


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
