### PR TITLE
beam 2302 - mongo should assign id even when null

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- `StorageDocument` types are assigned ID values during replace operations
+
 ## [1.1.0]
 ### Added
 

--- a/client/Packages/com.beamable.server/Runtime/Common/Mocks/MongoDB/Bson/BsonIgnoreIfDefault.cs
+++ b/client/Packages/com.beamable.server/Runtime/Common/Mocks/MongoDB/Bson/BsonIgnoreIfDefault.cs
@@ -1,0 +1,19 @@
+#if !BEAMABLE_IGNORE_MONGO_MOCKS
+
+using System;
+
+namespace MongoDB.Bson.Serialization.Attributes
+{
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+	public class BsonIgnoreIfDefaultAttribute : Attribute, IBsonMemberMapAttribute
+	{
+		private bool _value;
+
+		public BsonIgnoreIfDefaultAttribute() => this._value = true;
+
+		public BsonIgnoreIfDefaultAttribute(bool value) => this._value = value;
+
+		public bool Value => this._value;
+	}
+}
+#endif

--- a/client/Packages/com.beamable.server/Runtime/Common/Mocks/MongoDB/Bson/BsonIgnoreIfDefault.cs.meta
+++ b/client/Packages/com.beamable.server/Runtime/Common/Mocks/MongoDB/Bson/BsonIgnoreIfDefault.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 23b9934e248d485aaa51ea6e42ec5b67
+timeCreated: 1645630565

--- a/client/Packages/com.beamable.server/Runtime/Common/Mocks/MongoDB/Bson/BsonIgnoreIfNull.cs
+++ b/client/Packages/com.beamable.server/Runtime/Common/Mocks/MongoDB/Bson/BsonIgnoreIfNull.cs
@@ -1,0 +1,20 @@
+#if !BEAMABLE_IGNORE_MONGO_MOCKS
+
+using System;
+
+namespace MongoDB.Bson.Serialization.Attributes
+{
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+	public class BsonIgnoreIfNullAttribute : Attribute, IBsonMemberMapAttribute
+	{
+		private bool _value;
+
+		public BsonIgnoreIfNullAttribute() => this._value = true;
+
+		public BsonIgnoreIfNullAttribute(bool value) => this._value = value;
+
+		public bool Value => this._value;
+
+	}
+}
+#endif

--- a/client/Packages/com.beamable.server/Runtime/Common/Mocks/MongoDB/Bson/BsonIgnoreIfNull.cs.meta
+++ b/client/Packages/com.beamable.server/Runtime/Common/Mocks/MongoDB/Bson/BsonIgnoreIfNull.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2d402f50448e4e8e83fa6e418ec949af
+timeCreated: 1645630609

--- a/client/Packages/com.beamable.server/Runtime/Common/StorageDocument.cs
+++ b/client/Packages/com.beamable.server/Runtime/Common/StorageDocument.cs
@@ -11,6 +11,8 @@ namespace Beamable.Server
 		[SerializeField]
 		[BsonRepresentation(BsonType.ObjectId)]
 		[BsonId]
+		[BsonIgnoreIfDefault]
+		[BsonIgnoreIfNull]
 		private string _id = null; // MongoDb driver will auto-set this.
 
 		/// <summary>


### PR DESCRIPTION
# Brief Description
The issue was that the `StorageDocument`'s id field wasn't getting set correctly during mongo replace or other upsert operations. According to this [stack post](https://stackoverflow.com/questions/34573234/when-i-use-replaceoneasync-and-isupsert-true-mongodb-adds-a-null-id-how-do-i), the Mongo driver thought that the `default` or `null` value of the id field was "set". The attributes I've added in this PR avoid that, and ask the driver to assign a valid ID no matter what. Pretty much, this PR says, "A null or default string is NOT a real id, and those values imply that no id has been assigned yet". 


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
