### PR TITLE
beam 2301 - fixes invalid token issue in editor

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed 
+- Constant "Invalid token, trying again" errors in the Editor after 10 days.
 - Beamable assets are loaded with their full name so asset types won't collide
 
 ### Added

--- a/client/Packages/com.beamable/Editor/EditorAPI.cs
+++ b/client/Packages/com.beamable/Editor/EditorAPI.cs
@@ -90,7 +90,7 @@ namespace Beamable.Editor
 
 		private Promise<EditorAPI> Initialize()
 		{
-			// Apply the defined configuration for how users want to uncaught promises (with no .Error callback attached) in Beamable promises. 
+			// Apply the defined configuration for how users want to uncaught promises (with no .Error callback attached) in Beamable promises.
 			if (!Application.isPlaying)
 			{
 				var promiseHandlerConfig = CoreConfiguration.Instance.DefaultUncaughtPromiseHandlerConfiguration;
@@ -155,7 +155,7 @@ namespace Beamable.Editor
 			ApplyConfig(alias, cid, pid, platform);
 			BeamableFacebookImporter.SetFlag();
 
-			return _accessTokenStorage.LoadTokenForCustomer(CidOrAlias).FlatMap(token =>
+			return _accessTokenStorage.LoadTokenForCustomer(Cid).FlatMap(token =>
 			{
 				if (token == null)
 				{


### PR DESCRIPTION
# Brief Description
The issue was that we were LOADING an access token with `CidOrAlias` field, which was an alias... bleh.. and then we were SAVING it with the `cid`, so the tokens were misaligned. Bleck.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
