### PR TITLE
beam 2321 - adds facebook reference to platform

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed 
 - Constant "Invalid token, trying again" errors in the Editor after 10 days.
+- Beamable.Platform assembly definition references Facebook.Unity dll if it exists
 
 ## [1.0.1]
 ### Added

--- a/client/Packages/com.beamable/Runtime/Core/Platform/Beamable.Platform.asmdef
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/Beamable.Platform.asmdef
@@ -17,7 +17,9 @@
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [],
+    "precompiledReferences": [
+        "Facebook.Unity.dll"
+    ],
     "autoReferenced": true,
     "defineConstraints": []
 }


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2321

# Brief Description
The facebook library has a hard reference when IOS and FACEBOOK are enabled. In the past, this dependency was then "auto" loaded when in the user's project. However, we turned off automatic references so that our code doesn't "automatically" reference dlls pulled in by user code and collide. 
So in this case, we just had to add the Facebook.Unity.dll reference to Beamable.Platform explicitly. In Unity, if dll references aren't found, thats "okay", it'll just say "missing reference" on the assembly definition, but won't trigger any warnings in the console.

This means, if the user doesn't have Facebook's SDK installed, everything is fine... Until they switch to IOS and desire Facebook; then our code will say, "I need Facebook's types!". Then the user can install the SDK, and our Beamable.Platform will go, "great"!


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
