### PR TITLE
[BEAM-2339] UIRefAttribute namespace error Unity 2018

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Common/Attributes/UIRefAttribute.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/Attributes/UIRefAttribute.cs
@@ -3,7 +3,11 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using Beamable.Common;
 using Beamable.Editor.UI.Common;
+#if UNITY_2018
+using UnityEngine.Experimental.UIElements;
+#elif UNITY_2019_1_OR_NEWER
 using UnityEngine.UIElements;
+#endif
 
 namespace Beamable.Editor.UI.Components
 {


### PR DESCRIPTION
# Brief Description

`Packages\com.beamable\Editor\UI\Common\Attributes\UIRefAttribute.cs(6,19): error CS0234: The type or namespace name 'UIElements' does not exist in the namespace 'UnityEngine' (are you missing an assembly reference?)`

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
