### PR TITLE
[BEAM-2310] Fix refreshing after adding property using Show All flow

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussStyleCardVisualElement/BussStyleCardVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussStyleCardVisualElement/BussStyleCardVisualElement.cs
@@ -425,6 +425,12 @@ namespace Beamable.Editor.UI.Components
 				property.Refresh();
 			}
 		}
+		
+		public bool CheckPropertyIsInStyle(VariableDatabase.PropertyReference reference)
+		{
+			var property = _properties.FirstOrDefault(p => p.PropertyProvider == reference.propertyProvider);
+			return property != null && property.PropertyIsInStyle;
+		}
 
 		// TODO: change this, card should be setup/refreshed by it's parent
 		private void OnSelectionChanged(GameObject gameObject)

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussThemeManager.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussThemeManager.cs
@@ -285,14 +285,23 @@ namespace Beamable.Editor.UI.Buss
 				}
 				else
 				{
+					var cardsToReloads = new List<BussStyleCardVisualElement>();
 					foreach (VariableDatabase.PropertyReference reference in _variableDatabase.DirtyProperties)
 					{
 						var card = _styleCardsVisualElements.FirstOrDefault(c => c.StyleRule == reference.styleRule);
 						if (card != null)
 						{
-							card.RefreshPropertyByReference(reference);
+							if (card.CheckPropertyIsInStyle(reference))
+								card.RefreshPropertyByReference(reference);
+							else if (!cardsToReloads.Contains(card))
+								cardsToReloads.Add(card);
 						}
 					}
+					
+					foreach (var card in cardsToReloads)
+						card.Refresh();
+
+					cardsToReloads.Clear();
 				}
 				_variableDatabase.FlushDirtyMarkers();
 			}


### PR DESCRIPTION
# Brief Description

When we change property that is not in style sheet we need to refresh all card (because of sorting etc.). Now it's working as before and it's don't affect performance stuff.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
