### PR TITLE
beam 2361 - preserve beamcontext systems

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -12,13 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Changed behaviour of Add Style button in Buss Theme Manager
 - Add Style button moved above Buss Style Cards in Buss Theme Manager
+- Application will check if there are redundant files in content disk cache on each start. All files but the one needed will be deleted to free disk space.
+- All implementations of `[BeamContextSystem]` or `[RegisterBeamableDependencies]` will be preserved durring Unity code stripping
 
 ### Fixed 
 - Constant "Invalid token, trying again" errors in the Editor after 10 days.
 - Compilation error when using new `com.unity.inputsystem`
-
-### Changed
-- Application will check if there are redundant files in content disk cache on each start. All files but the one needed will be deleted to free disk space.
 
 ## [1.0.4]
 ### Fixed

--- a/client/Packages/com.beamable/Common/Runtime/Dependencies/RegisterBeamableDependenciesAttribute.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Dependencies/RegisterBeamableDependenciesAttribute.cs
@@ -13,7 +13,7 @@ namespace Beamable.Common.Dependencies
 	/// Add whatever services you want to on the builder instance. Any service you register will exist for each BeamContext.
 	/// </summary>
 	[AttributeUsage(validOn: AttributeTargets.Method)]
-	public class RegisterBeamableDependenciesAttribute : Attribute, IReflectionAttribute
+	public class RegisterBeamableDependenciesAttribute : BeamableReflection.PreserveAttribute, IReflectionAttribute
 	{
 		/// <summary>
 		/// Valid signatures on top of which you can place <see cref="RegisterBeamableDependenciesAttribute"/>s.

--- a/client/Packages/com.beamable/Common/Runtime/ReflectionCache/BeamContextSystemAttribute.cs
+++ b/client/Packages/com.beamable/Common/Runtime/ReflectionCache/BeamContextSystemAttribute.cs
@@ -1,7 +1,8 @@
 using System;
 
 [AttributeUsage(validOn: AttributeTargets.Class | AttributeTargets.Struct)]
-public class BeamContextSystemAttribute : Attribute
+public class BeamContextSystemAttribute : BeamableReflection.PreserveAttribute
 {
 
 }
+

--- a/client/Packages/com.beamable/Common/Runtime/ReflectionCache/PreserveAttribute.cs
+++ b/client/Packages/com.beamable/Common/Runtime/ReflectionCache/PreserveAttribute.cs
@@ -1,0 +1,20 @@
+using System;
+
+// the namespace is unique, "BeamableReflection" so that it doesn't collide with regular usage of the UnityEngine.Preserve in types that are in Beamable.
+namespace BeamableReflection
+{
+	/// <summary>
+	/// from Unity docs https://docs.unity3d.com/ScriptReference/Scripting.PreserveAttribute.html
+	/// <para>
+	/// For 3rd party libraries that do not want to take on a dependency on UnityEngine.dll, it is also possible to define their own PreserveAttribute. The code stripper will respect that too, and it will consider any attribute with the exact name "PreserveAttribute" as a reason not to strip the thing it is applied on, regardless of the namespace or assembly of the attribute.
+	/// </para>
+	///
+	/// The reason we need to use a custom PreserveAttribute is so that we can don't need to reference UnityEngine
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Delegate | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Struct,
+	                Inherited = false)]
+	public class PreserveAttribute : System.Attribute
+	{
+
+	}
+}

--- a/client/Packages/com.beamable/Common/Runtime/ReflectionCache/PreserveAttribute.cs.meta
+++ b/client/Packages/com.beamable/Common/Runtime/ReflectionCache/PreserveAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b5e9a29c8648418cb22affc2c314336
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Packages/com.beamable/Tests/Editor/PreserveAttributeTests.cs
+++ b/client/Packages/com.beamable/Tests/Editor/PreserveAttributeTests.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+using System.Reflection;
+
+namespace Beamable.Editor.Tests
+{
+	public class PreserveAttributeTests
+	{
+		[Test]
+		public void ContextClassesArePreserved()
+		{
+			var t = typeof(SampleClass);
+
+			var hasBeamablePreserve = null != t.GetCustomAttribute<BeamableReflection.PreserveAttribute>();
+			var hasUnityPreserve = null != t.GetCustomAttribute<UnityEngine.Scripting.PreserveAttribute>();
+
+			Assert.IsTrue(hasBeamablePreserve);
+			Assert.IsFalse(hasUnityPreserve);
+		}
+	}
+
+	[BeamContextSystem]
+	public class SampleClass
+	{
+
+	}
+}

--- a/client/Packages/com.beamable/Tests/Editor/PreserveAttributeTests.cs.meta
+++ b/client/Packages/com.beamable/Tests/Editor/PreserveAttributeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec0fb1bdd31a44ac5a6151a69f63b2f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Brief Description
Without doing this, if a customer makes their own context system, and enables code stripping, they would have had to realize that they'd need to create a link.xml file that keeps the type intact. Now, anything that subtypes a beamcontext system will automatically be saved.


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
