### PR TITLE
Replace TryGetComponent with GetComponent

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussStyleListVisualElement/BussStyleListVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussStyleListVisualElement/BussStyleListVisualElement.cs
@@ -194,9 +194,9 @@ namespace Beamable.Editor.UI.Buss
 		{
 			BussElement element = null;
 			var gameObject = Selection.activeGameObject;
-			if (gameObject != null && gameObject.TryGetComponent<BussElement>(out var el))
+			if (gameObject != null)
 			{
-				element = el;
+				element = gameObject.GetComponent<BussElement>();
 			}
 
 			foreach (var styleCard in _styleCardsVisualElements)


### PR DESCRIPTION
# Brief Description
TryGetComponent was used, which is not implemented in Unity 2018. This commit fixes it.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
