### PR TITLE
Int32 parse error in Stats Search

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -17,10 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - When exiting Unity, all related Microservices and Microstorage containers are closed
 - Microservice client code is generated in a dockerized dotnet runtime instead of Unity
+- Added docstrings to `StatsService.SearchStats` to clarify correct usage of the `Criteria` parameter.
 
 ### Fixed
 - Fixed issue that caused the `ReflectionCache` to run an extra unnecessary time when a `.cs` or `.asmdef` file were changed.
 - Fixed issue on Re-Import All with `BeamableAssistantWindow` opened that required reopening the window for it to work.
+- Fixed issue that caused `StatsService.SearchStats` to fail whenever a match occurred.
 
 ## [1.0.2]
 ### Fixed

--- a/client/Packages/com.beamable.server/SharedRuntime/Api/Stats/IMicroserviceStatsApi.cs
+++ b/client/Packages/com.beamable.server/SharedRuntime/Api/Stats/IMicroserviceStatsApi.cs
@@ -65,6 +65,14 @@ namespace Beamable.Server.Api.Stats
 		Promise<Dictionary<string, string>> GetStats(string domain, string access, string type, long userId,
 		   string[] stats);
 
+		/// <summary>
+		/// Queries the player base for matches against specific stats defined by the given <paramref name="criteria"/>.
+		/// </summary>
+		/// <param name="domain">"game" or "player".</param>
+		/// <param name="access">"public" or "private"</param>
+		/// <param name="type">Should always be "player" (exists for legacy reasons).</param>
+		/// <param name="criteria">List of all <see cref="Criteria"/> that must match.</param>
+		/// <returns>The list of DBIDs for all users that match ALL of the criteria provided.</returns>
 		Promise<StatsSearchResponse> SearchStats(string domain, string access, string type, List<Criteria> criteria);
 	}
 }

--- a/client/Packages/com.beamable/Common/Runtime/Api/Stats/AbsStatsApi.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/Stats/AbsStatsApi.cs
@@ -141,15 +141,43 @@ namespace Beamable.Common.Api.Stats
 	[Serializable]
 	public class StatsSearchResponse
 	{
-		public int[] ids;
+		public long[] ids;
 	}
 
+	/// <summary>
+	/// A definition of a comparison (<see cref="Rel"/>) to be run against the specified <see cref="Stat"/>.  
+	/// </summary>
 	public class Criteria
 	{
+		/// <summary>
+		/// The stat to compare against (LHS of the comparison).
+		/// </summary>
 		public string Stat { get; }
+		
+		/// <summary>
+		/// A string representing the comparision to be executed.
+		/// <list type="bullet">
+		/// <item>Equality: "equal" OR "eq".</item>
+		/// <item>Non-Equality: "notequal" OR "neq".</item>
+		/// <item>Less Than: "lessthan" OR "lt".</item>
+		/// <item>Less Than or Equal: "lessthanequal" OR "lte".</item>
+		/// <item>Greater Than: "greaterthan" OR "gt".</item>
+		/// <item>Greater Than or Equal: "greaterthanequal" OR "gte".</item>
+		/// <item>In: "in".</item>
+		/// <item>Not In: "notin" OR "nin".</item>
+		/// </list>
+		/// </summary>
 		public string Rel { get; }
+		
+		/// <summary>
+		/// The RHS of the comparison.
+		/// </summary>
 		public string Value { get; }
 
+		
+		/// <param name="stat"><see cref="Stat"/></param>
+		/// <param name="rel"><see cref="Rel"/></param>
+		/// <param name="value"><see cref="Value"/></param>
 		public Criteria(string stat, string rel, string value)
 		{
 			Stat = stat;


### PR DESCRIPTION
# Brief Description

- fixed issue causing SearchStats API to always fail when a criteria match was found; 
- added docstrings around Criteria type to clarify usage; 

# Checklist
* [x] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
