### PR TITLE
beam 2378 - prune null error, runimage requires descriptor

### DIFF
--- a/client/Packages/com.beamable.server/Editor/DockerCommands/RunImageCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/RunImageCommand.cs
@@ -19,7 +19,7 @@ namespace Beamable.Server.Editor.DockerCommands
 		public const string ENV_MONGO_INITDB_ROOT_PASSWORD = "MONGO_INITDB_ROOT_PASSWORD";
 
 		public RunStorageCommand(StorageObjectDescriptor storage)
-		   : base(storage.ImageName, storage.ContainerName)
+		   : base(storage.ImageName, storage.ContainerName, storage)
 		{
 			_storage = storage;
 			var config = MicroserviceConfiguration.Instance.GetStorageEntry(storage.Name);
@@ -78,7 +78,7 @@ namespace Beamable.Server.Editor.DockerCommands
 		public Promise<bool> IsAvailable { get; private set; } = new Promise<bool>();
 
 		public RunStorageToolCommand(StorageObjectDescriptor storage)
-		: base(storage.ToolImageName, storage.LocalToolContainerName)
+		: base(storage.ToolImageName, storage.LocalToolContainerName, storage)
 		{
 			var config = MicroserviceConfiguration.Instance.GetStorageEntry(storage.Name);
 			Environment = new Dictionary<string, string>
@@ -257,7 +257,7 @@ namespace Beamable.Server.Editor.DockerCommands
 		public Action<string> OnStandardErr;
 
 		public RunImageCommand(string imageName, string containerName,
-		   IDescriptor descriptor = null,
+		   IDescriptor descriptor,
 		   Dictionary<string, string> env = null,
 		   Dictionary<uint, uint> ports = null,
 		   Dictionary<string, string> namedVolumes = null,
@@ -349,6 +349,7 @@ namespace Beamable.Server.Editor.DockerCommands
 				return;
 			}
 
+			if (_descriptor == null) return;
 			Task.Run(async () =>
 			{
 				await Task.Delay(500);


### PR DESCRIPTION
# Ticket 
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?assignee=5f344c62323607003855295d&selectedIssue=BEAM-2378

# Brief Description
The `pruneImage` requires an `IDescriptor` , but the initial `runImage` command allowed it to be null. In no case did we _not_ have a descriptor to pass along; so, I figured I'd just pass it along.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
