### PR TITLE
beam 2371- adds null check before getting builder

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Components/PublishPopup/PublishWindow.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/PublishPopup/PublishWindow.cs
@@ -148,7 +148,7 @@ namespace Beamable.Editor.Microservice.UI.Components
 			throw new NotImplementedException();
 		}
 
-		public override IBeamableBuilder Builder =>
+		protected override IBeamableBuilder GetBuilder() =>
 			throw new NotImplementedException("Accumulator doesn't have builder");
 	}
 }

--- a/client/Packages/com.beamable.server/Editor/UI/Model/MicroserviceModel.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Model/MicroserviceModel.cs
@@ -43,7 +43,7 @@ namespace Beamable.Editor.UI.Model
 		public string AssemblyQualifiedMicroserviceTypeName => _assemblyQualifiedMicroserviceTypeName;
 
 		public MicroserviceBuilder ServiceBuilder { get; protected set; }
-		public override IBeamableBuilder Builder => ServiceBuilder;
+		protected override IBeamableBuilder GetBuilder() => ServiceBuilder;
 		public override IDescriptor Descriptor => ServiceDescriptor;
 		public ServiceReference RemoteReference { get; protected set; }
 		public ServiceStatus RemoteStatus { get; protected set; }

--- a/client/Packages/com.beamable.server/Editor/UI/Model/MongoStorageModel.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Model/MongoStorageModel.cs
@@ -37,7 +37,8 @@ namespace Beamable.Editor.UI.Model
 		public string AssemblyQualifiedStorageTypeName => _assemblyQualifiedStorageTypeName;
 
 		public MongoStorageBuilder ServiceBuilder { get; protected set; }
-		public override IBeamableBuilder Builder => ServiceBuilder;
+		protected override IBeamableBuilder GetBuilder() => ServiceBuilder;
+
 		public override IDescriptor Descriptor => ServiceDescriptor;
 		public override bool IsRunning => ServiceBuilder?.IsRunning ?? false;
 		public StorageConfigurationEntry Config { get; protected set; }

--- a/client/Packages/com.beamable.server/Editor/UI/Model/ServiceModelBase.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Model/ServiceModelBase.cs
@@ -38,7 +38,30 @@ namespace Beamable.Editor.UI.Model
 		}
 
 		public abstract IDescriptor Descriptor { get; }
-		public abstract IBeamableBuilder Builder { get; }
+		public IBeamableBuilder Builder => GetOrCreateBuilder();
+		protected abstract IBeamableBuilder GetBuilder();
+		private IBeamableBuilder GetOrCreateBuilder()
+		{
+			var builder = GetBuilder();
+			if (builder == null)
+			{
+				if (Descriptor == null)
+				{
+					throw new Exception(
+						"Cannot get builder, because the model hasn't been initialized with a descriptor.");
+				}
+				Refresh(Descriptor);
+			}
+
+			builder = GetBuilder();
+			if (builder == null)
+			{
+				throw new Exception("Could not create the builder. It is null after a call to Refresh");
+			}
+
+			return builder;
+		}
+
 		public ServiceType ServiceType => Descriptor.ServiceType;
 		public string Name => Descriptor.Name;
 		public bool IsSelected


### PR DESCRIPTION
# Brief Description
Sometimes, the builder would be null when we accessed it. So I figured, if it is, lets just create it.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
