### PR TITLE
[BEAM-2373] Add RecoverWithBackoff function as promise extension

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `RecoverWith` extension method overloads to `Promise<T>` that allow for configuring  a promise to recover from failure over multiple attempts.
+
 ### Changed
 - Changed behaviour of Add Style button in Buss Theme Manager
 - Add Style button moved above Buss Style Cards in Buss Theme Manager

--- a/client/Packages/com.beamable/Runtime/PromiseExtensions.cs
+++ b/client/Packages/com.beamable/Runtime/PromiseExtensions.cs
@@ -58,6 +58,71 @@ namespace Beamable
 
 			return result;
 		}
+		
+		public static Promise<T> WaitForSeconds<T>(this Promise<T> promise, float seconds, CoroutineService service)
+		{
+			var result = new Promise<T>();
+			IEnumerator Wait()
+			{
+				yield return Yielders.Seconds(seconds);
+				promise.Then(x => result.CompleteSuccess(x));
+			};
+
+			service.StartCoroutine(Wait());
+			return result;
+		}
+
+		/// <summary>
+		/// This has the same behaviour as <see cref="RecoverWith{T}(Beamable.Common.Promise{T},System.Func{System.Exception,int,Beamable.Common.Promise{T}},float[],CoroutineService,System.Nullable{int})"/>.
+		/// However, it's configured to automatically use the <see cref="BeamContext.Default"/>'s <see cref="CoroutineService"/>.
+		/// </summary>
+		public static Promise<T> RecoverWith<T>(this Promise<T> promise, Func<Exception, int, Promise<T>> callback, float[] falloffSeconds, int? maxRetries = null)
+		{
+			return RecoverWith(promise, callback, falloffSeconds, BeamContext.Default.CoroutineService, maxRetries);
+		}
+
+		/// <summary>
+		/// Returns a promise configured to be attempted multiple times --- waiting for the amount of seconds defined by <paramref name="falloffSeconds"/> for each attempt. If <paramref name="maxRetries"/>
+		/// is greater than the number of items in <paramref name="falloffSeconds"/>, it will reuse the final item of the array for every attempt over the array's size.  
+		/// </summary>
+		/// <param name="promise">The promise to recover from in case of failure.</param>
+		/// <param name="callback">A callback that returns a promise based on which attempt you are making and the error that happened in the previous attempt or original promise.</param>
+		/// <param name="falloffSeconds">An array defining, for each attempt, the amount of seconds to wait before attempting again.</param>
+		/// <param name="service">The <see cref="CoroutineService"/> that we'll use to wait before attempting again.</param>
+		/// <param name="maxRetries">The maximum number of retry attempts we can make. If this number is larger than <paramref name="falloffSeconds"/>'s length, the final falloff value is used for
+		/// every attempt over the length.</param>
+		/// <typeparam name="T">The result value type of the promise.</typeparam>
+		public static Promise<T> RecoverWith<T>(this Promise<T> promise, Func<Exception, int, Promise<T>> callback, float[] falloffSeconds, CoroutineService service, int? maxRetries = null)
+		{
+			var result = new Promise<T>();
+
+			var attempt = -1;
+			maxRetries = maxRetries ?? falloffSeconds.Length;
+
+			promise.Then(value => result.CompleteSuccess(value))
+			       .Error(HandleError);
+
+			void HandleError(Exception err)
+			{
+				attempt += 1;
+				if(attempt >= maxRetries)
+				{
+					result.CompleteError(err);
+					return;
+				}
+
+				// Will reuse the last fall-off value in cases where maxRetries is larger than falloffSeconds.Length.
+				var idx = Mathf.Clamp(attempt, 0, falloffSeconds.Length - 1);
+				var delay = falloffSeconds[idx];
+				var delayPromise = Promise.Success.WaitForSeconds(delay, service);
+				_ = delayPromise.FlatMap(_ => callback(err, attempt)
+				                              .Then(v => result.CompleteSuccess(v))
+				                              .Error(HandleError)
+										);
+			}
+
+			return result;
+		}
 
 		public static CustomYieldInstruction ToYielder<T>(this Promise<T> self)
 		{

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Promises.meta
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Promises.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ae7beb48438e3114b8fb2c7e8ce27877
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Promises/PromisePlayModeTests.cs
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Promises/PromisePlayModeTests.cs
@@ -1,0 +1,128 @@
+﻿using Beamable;
+using Beamable.Common;
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Beamable.Tests.Runtime.PromiseTests
+{
+	public class PromisePlayModeTests
+	{
+		[UnityTest]
+		public IEnumerator RecoverWithFalloff_ShouldThrowAfterMaxAttempts()
+		{
+			var attemptCounter = 0;
+			var expectedExceptionReceived = false;
+			var retryAttemptFalloffTimers = new[] {.1f, .5f, 1, 2};
+
+			// Ignoring this so the test has the opportunity to succeed ----> When we call CompleteError in our fake work promise, it will fail immediately,
+			// before the RecoverWith has the chance to attach any callbacks.
+			PromiseBase.SetPotentialUncaughtErrorHandler((promise, err) => { });
+
+			var mainPromise = new Promise();
+			var recoveringPromise = mainPromise.RecoverWith((exception, attempt) =>
+			{
+				attemptCounter += 1;
+
+				var fakeWork = Promise.Success.WaitForSeconds(.00001f).FlatMap(_ =>
+				{
+					var newPromise = new Promise();
+					newPromise.CompleteError(new Exception($"ExceptionDuringRecovery {attempt}"));
+					return newPromise;
+				});
+				return fakeWork;
+			}, retryAttemptFalloffTimers).Error(err => expectedExceptionReceived = err.Message == $"ExceptionDuringRecovery {retryAttemptFalloffTimers.Length - 1}");
+
+			mainPromise.CompleteError(new Exception("UnexpectedException"));
+			yield return recoveringPromise.ToYielder();
+
+			Assert.IsTrue(expectedExceptionReceived);
+			Assert.AreEqual(retryAttemptFalloffTimers.Length, attemptCounter);
+		}
+
+		[UnityTest]
+		public IEnumerator RecoverWithFalloff_ShouldSucceedAfterAttempts()
+		{
+			// Start at -1 as attempts are counted as indices (this is meant to make it simpler to write code that uses attempts to index into some array of messages and the like)
+			var attemptCounter = -1;
+			var attemptToSucceedAt = 2;
+			var successWasAchieved = false;
+			var retryAttemptFalloffTimers = new[] {.1f, .5f, 1, 2};
+			
+			// Ignoring this so the test has the opportunity to succeed ----> When we call CompleteError in our fake work promise, it will fail immediately,
+			// before the RecoverWith has the chance to attach any callbacks.
+			PromiseBase.SetPotentialUncaughtErrorHandler((promise, err) => { });
+
+			var mainPromise = new Promise();
+			var recoveringPromise = mainPromise.RecoverWith((exception, attemptIdx) =>
+			{
+				attemptCounter += 1;
+
+				var fakeWork = Promise.Success.WaitForSeconds(.00001f).FlatMap(_ =>
+				{
+					var newPromise = new Promise();
+					if (attemptIdx < attemptToSucceedAt)
+						newPromise.CompleteError(new Exception($"ExceptionDuringRecovery {attemptIdx}"));
+					else
+						newPromise.CompleteSuccess();
+					return newPromise;
+				});
+
+				return fakeWork;
+			}, retryAttemptFalloffTimers).Then(_ => successWasAchieved = true);
+
+			mainPromise.CompleteError(new Exception("UnexpectedException"));
+			yield return recoveringPromise.ToYielder();
+
+			Assert.IsTrue(successWasAchieved);
+			Assert.AreEqual(attemptToSucceedAt, attemptCounter);
+		}
+		
+		[UnityTest]
+		public IEnumerator RecoverWithFalloff_ShouldReuseFallOffValueThenThrow()
+		{
+			var attemptCounter = 0;
+			var expectedExceptionReceived = false;
+			var retryAttemptFalloffTimers = new[] {.1f, .5f, 1, 2};
+
+			// Ignoring this so the test has the opportunity to succeed ----> When we call CompleteError in our fake work promise, it will fail immediately,
+			// before the RecoverWith has the chance to attach any callbacks.
+			PromiseBase.SetPotentialUncaughtErrorHandler((promise, err) => { });
+
+			var stopwatch = new Stopwatch();
+			var mainPromise = new Promise();
+
+			int maxRetries = 5;
+			var recoveringPromise = mainPromise.RecoverWith((exception, attempt) =>
+			{
+				attemptCounter += 1;
+
+				var fakeWork = Promise.Success.WaitForSeconds(.00001f).FlatMap(_ =>
+				{
+					var newPromise = new Promise();
+					newPromise.CompleteError(new Exception($"ExceptionDuringRecovery {attempt}"));
+					return newPromise;
+				});
+				return fakeWork;
+			}, retryAttemptFalloffTimers, maxRetries).Error(err =>
+			{
+				// We expect the last exception we receive to be the maximum number of retries (minus one since attempts are 0-indexed).
+				expectedExceptionReceived = err.Message == $"ExceptionDuringRecovery {maxRetries - 1}";
+			});
+
+			stopwatch.Start();
+			mainPromise.CompleteError(new Exception("UnexpectedException"));
+			yield return recoveringPromise.ToYielder();
+			stopwatch.Stop();
+
+			Assert.IsTrue(expectedExceptionReceived);
+			Assert.AreEqual(retryAttemptFalloffTimers.Length + 1, attemptCounter);
+		}
+
+	}
+}

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Promises/PromisePlayModeTests.cs.meta
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Promises/PromisePlayModeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e279a9838aa3fc438a1cc4cd616770b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Brief Description

- Added recover with promise extension method for recovery with falloff retries (with test coverage)

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
