### PR TITLE
[BEAM-2390] 1.1 Blocker - duplicate Toolbox window causes UI error

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Toolbox/ToolboxWindow.cs
+++ b/client/Packages/com.beamable/Editor/UI/Toolbox/ToolboxWindow.cs
@@ -40,7 +40,7 @@ namespace Beamable.Editor.Toolbox.UI
 					ToolboxWindow.Instance.Close();
 				}
 
-				DestroyImmediate(ToolboxWindow.Instance);
+				ToolboxWindow.Instance.Close();
 			}
 
 			// Create Beamable ContentManagerWindow and dock it next to Unity Hierarchy Window


### PR DESCRIPTION
# Brief Description
Calling close instead of destroy --- not doing so makes Unity's internal editor code think there's still a window and it just freaks out.

- Internally, close does some cleanup and then calls `DestroyImmediate`

For reference:
![image](https://user-images.githubusercontent.com/92586258/158670832-d2f147c7-1bdd-4f89-978b-f8952ba4b8a5.png)


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
