### PR TITLE
beam 2399 - right base image

### DIFF
--- a/client/Packages/com.beamable.server/Editor/CodeGen/DockerfileGenerator.cs
+++ b/client/Packages/com.beamable.server/Editor/CodeGen/DockerfileGenerator.cs
@@ -139,7 +139,7 @@ EXPOSE 80 2222
 		private string GetWatchDockerFile()
 		{
 			var text = $@"
-FROM beamservice:latest AS build-env
+FROM {BASE_IMAGE}:{BASE_TAG} AS build-env
 RUN dotnet --version
 WORKDIR /subapp
 


### PR DESCRIPTION
# Ticket 
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2399

# Brief Description
Silly mistake- when we use a watch command, we generate a different dockerfile, and it wasn't using the correct base image. It was hard coded to use the development image.


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
