### PR TITLE
[BEAM-2388] 1.1 Blocker - error on exiting scene with Announcements Flow

### DIFF
--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/PlatformSubscribable.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/PlatformSubscribable.cs
@@ -242,10 +242,16 @@ namespace Beamable.Api
 			if (nextRefreshScopes.Count == 0)
 				return Promise<Unit>.Successful(PromiseBase.Unit);
 
+			
 			if (nextRefreshPromise == null)
 			{
 				nextRefreshPromise = new Promise<Unit>();
-				coroutineService.StartCoroutine(ExecuteRefresh());
+				
+				// Need this null-check to cover errors that happen when leaving play-mode (where this method can run after Unity has already destroyed the CoroutineService's GameObject).
+#if UNITY_EDITOR
+				if(coroutineService != null) 
+#endif
+					coroutineService.StartCoroutine(ExecuteRefresh());
 			}
 
 

--- a/client/Packages/com.beamable/Runtime/Modules/Announcements/Scripts/AnnouncementMainMenu.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/Announcements/Scripts/AnnouncementMainMenu.cs
@@ -37,7 +37,7 @@ namespace Beamable.Announcements
 
 		private void OnDestroy()
 		{
-			Subscription.Unsubscribe();
+			Subscription?.Unsubscribe();
 		}
 
 		public async void OnReadAll()


### PR DESCRIPTION
# Brief Description
- Fixed issue that caused AnnouncementPrefab to throw a null-ref OnDestroy when exiting playmode before Beamable's login was fully finished
- Fixed another issue in `PlatformSubscribable` that would also throw a null-ref under the same conditions

Fix 1:
![image](https://user-images.githubusercontent.com/92586258/158800391-b97dd851-b6d4-4bd8-99bb-4cb190a90871.png)

Fix 2:
![image](https://user-images.githubusercontent.com/92586258/158800811-9ffe07e7-2857-49c1-8e09-ba0b02d49bde.png)

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
