### PR TITLE
[BEAM-2396] 1.1 Blocker - Microservices and Microstorages aren't appearing in MMV2 on first creation consistently

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Model/MicroservicesDataModel.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Model/MicroservicesDataModel.cs
@@ -65,6 +65,7 @@ namespace Beamable.Editor.UI.Model
 
 		public Action<ServiceManifest> OnServerManifestUpdated;
 		public Action<GetStatusResponse> OnStatusUpdated;
+		public Guid InstanceId = Guid.NewGuid();
 
 		public void RefreshLocal()
 		{
@@ -174,6 +175,7 @@ namespace Beamable.Editor.UI.Model
 
 		public Dictionary<string, ServiceAvailability> GetAllServicesStatus()
 		{
+			RefreshLocal();
 			var getServiceStatus = new Func<bool, bool, ServiceAvailability>((isLocally, isRemotely) =>
 			{
 				if (isLocally && isRemotely)


### PR DESCRIPTION
# Brief Description
hacky fix for 1.1 release to ensure the deserialized model instance is always up-to-date with the latest created C#MSs when the window is refreshed after adding a new C#MS.

- Real fix is to stop using EditorWindow's serialization and/or Singleton-Access Pattern for surviving domain reload and providing "get-or-create"-style access to these systems globally
  - Delaying it to 1.2 so we have the time to properly fix our Editor Env initialization flow, so we can stop playing whack-a-mole with deserialization issues.
- Added Guid to Model to help debugging any "missing serialized data issues" that may be caused by the 2 instances that currently get created on domain reload.


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
