### PR TITLE
[BEAM-2404 & BEAM-2405] detached logs serialization issues

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Model/MicroservicesDataModel.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Model/MicroservicesDataModel.cs
@@ -300,6 +300,8 @@ namespace Beamable.Editor.UI.Model
 
 		public void OnAfterDeserialize()
 		{
+			_instance = this;
+			
 			void AddModels<T>(List<T> models, List<IBeamableService> listToPopulate) where T : ServiceModelBase
 			{
 				foreach (var service in models.ToArray())
@@ -343,6 +345,7 @@ namespace Beamable.Editor.UI.Model
 			}
 			AddModels(_localMicroserviceModels, AllLocalServices);
 			AddModels(_localStorageModels, AllLocalServices);
+			
 		}
 	}
 


### PR DESCRIPTION
# Brief Description
upon deserialization after domain reload, set the deserialized C#MS model as it's `_instance` variable; Also fixes BEAM-2405.

- This has to do with a current issue we have with the way our Editor-time data models are initialized.
- The architectural fix for this type of problem will happen at a later release (1.2 being the most likely).
- This does fix the immediate problem though.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
