### PR TITLE
beam 2424- assume user without admin creds

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When exiting Unity, all related Microservices and Microstorage containers are closed
 - Microservice client code is generated in a dockerized dotnet runtime instead of Unity
 - Added docstrings to `StatsService.SearchStats` to clarify correct usage of the `Criteria` parameter.
+- `AssumeUser` takes an optional boolean parameter to disable the Admin access token check
 
 ### Fixed
 - Fixed issue that caused the `ReflectionCache` to run an extra unnecessary time when a `.cs` or `.asmdef` file were changed.

--- a/client/Packages/com.beamable.server/SharedRuntime/Microservice.cs
+++ b/client/Packages/com.beamable.server/SharedRuntime/Microservice.cs
@@ -88,11 +88,32 @@ namespace Beamable.Server
 			_scopeGenerator = scopeGenerator;
 		}
 
-
-		protected RequestHandlerData AssumeUser(long userId)
+		/// <summary>
+		/// Build a request context and collection of services that represents another player.
+		/// <para>
+		/// This can be used to take API actions on behalf of another player. For example, if
+		/// you needed to modify another player's currency, you could use this method's return object
+		/// to access an <see cref="IMicroserviceInventoryApi"/> and make a call.
+		/// </para>
+		/// </summary>
+		/// <param name="userId">The user id of the player for whom you'd like to make actions on behalf of</param>
+		/// <param name="requireAdminUser">
+		/// By default, this method can only be called by a user with admin access token.
+		/// <para> If you pass in false for this parameter, then any user's request can assume another user.
+		/// <b> This can be dangerous, and you should be careful that the code you write cannot be exploited. </b>
+		/// </para>
+		/// </param>
+		/// <returns>
+		/// A <see cref="RequestHandlerData"/> object that contains a request context, and a collection of services to execute SDK calls against.
+		/// </returns>
+		protected RequestHandlerData AssumeUser(long userId, bool requireAdminUser=true)
 		{
 			// require admin privs.
-			Context.CheckAdmin();
+			if (requireAdminUser)
+			{
+				Context.CheckAdmin();
+			}
+
 			var newCtx = new RequestContext(
 			   Context.Cid, Context.Pid, Context.Id, Context.Status, userId, Context.Path, Context.Method, Context.Body,
 			   Context.Scopes);

--- a/microservice/microserviceTests/microservice/SimpleMicroservice.cs
+++ b/microservice/microserviceTests/microservice/SimpleMicroservice.cs
@@ -133,6 +133,13 @@ namespace microserviceTests.microservice
       }
 
       [ClientCallable]
+      public async Task TestAssumeUser(long otherId, bool force)
+      {
+         var ctx = AssumeUser(otherId, force);
+         await ctx.Requester.Request<EmptyResponse>(Method.GET, "x");
+      }
+
+      [ClientCallable]
       public async Task<User> GetUserViaAccessToken(TokenResponse tokenResponse)
       {
          try

--- a/microservice/microserviceTests/microservice/TestSocket.cs
+++ b/microservice/microserviceTests/microservice/TestSocket.cs
@@ -71,6 +71,11 @@ namespace Beamable.Microservice.Tests.Socket
             return And(matcher, MessageMatcher.WithDelete());
         }
 
+        public static TestSocketMessageMatcher WithFrom(this TestSocketMessageMatcher matcher, long fromId)
+        {
+            return And(matcher, MessageMatcher.WithFrom(fromId));
+        }
+
         public static TestSocketMessageMatcher WithBody<T>(this TestSocketMessageMatcher matcher,
            Func<T, bool> bodyMatcher)
         {
@@ -241,6 +246,11 @@ namespace Beamable.Microservice.Tests.Socket
         public static TestSocketMessageMatcher WithMethod(Method method)
         {
             return req => method.ToString().ToLower().Equals(req.method?.ToLower());
+        }
+
+        public static TestSocketMessageMatcher WithFrom(long from)
+        {
+            return req => req.from == from;
         }
 
         public static TestSocketMessageMatcher WithPost()
@@ -433,6 +443,21 @@ namespace Beamable.Microservice.Tests.Socket
             };
         }
 
+        public static WebsocketRequest ClientCallableAsAdmin(string serviceName, string methodName, int reqId, int dbid, params object[] args)
+        {
+            return new WebsocketRequest
+            {
+                id = reqId,
+                path = $"{serviceName}/{methodName}",
+                body = new
+                {
+                    payload = args
+                },
+                from = dbid,
+                method = "post",
+                scopes = new[]{"*"}
+            };
+        }
 
         public static WebsocketRequest ClientCallablePayloadArgs(string serviceName, string methodName, int reqId, int dbid, string payloadArgs)
         {

--- a/microservice/microserviceTests/microservice/dbmicroservice/BeamableMicroServiceTests/AssumeUserTests.cs
+++ b/microservice/microserviceTests/microservice/dbmicroservice/BeamableMicroServiceTests/AssumeUserTests.cs
@@ -1,0 +1,122 @@
+using System.Threading.Tasks;
+using Beamable.Common;
+using Beamable.Common.Api;
+using Beamable.Common.Api.Content;
+using Beamable.Microservice.Tests.Socket;
+using Beamable.Server;
+using microserviceTests.microservice.Util;
+using NUnit.Framework;
+
+namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTests;
+
+[TestFixture]
+public class AssumeUserTests
+{
+	[SetUp]
+	[TearDown]
+	public void ResetContentInstance()
+	{
+		ContentApi.Instance = new Promise<IContentApi>();
+	}
+
+
+	[TestCase(true)]
+	[TestCase(false)]
+	[NonParallelizable]
+	public async Task AssumeUserAsAdmin(bool forceCheck)
+	{
+		LoggingUtil.Init();
+		TestSocket testSocket = null;
+		var ms = new BeamableMicroService(new TestSocketProvider(socket =>
+		{
+			testSocket = socket;
+			socket.AddStandardMessageHandlers()
+				.AddMessageHandler(
+					MessageMatcher
+						.WithReqId(-5)
+						.WithFrom(2),
+					MessageResponder.Success(new EmptyResponse()),
+					MessageFrequency.OnlyOnce())
+				.AddMessageHandler(
+					MessageMatcher
+						.WithReqId(1)
+						.WithStatus(200),
+					MessageResponder.NoResponse(),
+					MessageFrequency.OnlyOnce()
+				);
+		}));
+
+		await ms.Start<SimpleMicroservice>(new TestArgs());
+		Assert.IsTrue(ms.HasInitialized);
+
+		testSocket.SendToClient(ClientRequest.ClientCallableAsAdmin("micro_simple", "TestAssumeUser", 1, 0, 2, forceCheck));
+
+		// simulate shutdown event...
+		await ms.OnShutdown(this, null);
+		Assert.IsTrue(testSocket.AllMocksCalled());
+	}
+
+	[Test]
+	[NonParallelizable]
+	public async Task AssumeUserAsNormal_WithNoCheck()
+	{
+		LoggingUtil.Init();
+		TestSocket testSocket = null;
+		var ms = new BeamableMicroService(new TestSocketProvider(socket =>
+		{
+			testSocket = socket;
+			socket.AddStandardMessageHandlers()
+				.AddMessageHandler(
+					MessageMatcher
+						.WithReqId(-5)
+						.WithFrom(2),
+					MessageResponder.Success(new EmptyResponse()),
+					MessageFrequency.OnlyOnce())
+				.AddMessageHandler(
+					MessageMatcher
+						.WithReqId(1)
+						.WithStatus(200),
+					MessageResponder.NoResponse(),
+					MessageFrequency.OnlyOnce()
+				);
+		}));
+
+		await ms.Start<SimpleMicroservice>(new TestArgs());
+		Assert.IsTrue(ms.HasInitialized);
+
+		testSocket.SendToClient(ClientRequest.ClientCallable("micro_simple", "TestAssumeUser", 1, 0, 2, false));
+
+		// simulate shutdown event...
+		await ms.OnShutdown(this, null);
+		Assert.IsTrue(testSocket.AllMocksCalled());
+	}
+
+	[Test]
+	[NonParallelizable]
+	public async Task AssumeUserAsNormal_WithCheck()
+	{
+		LoggingUtil.Init();
+		TestSocket testSocket = null;
+		var ms = new BeamableMicroService(new TestSocketProvider(socket =>
+		{
+			testSocket = socket;
+			socket.AddStandardMessageHandlers()
+				.AddMessageHandler(
+					MessageMatcher
+						.WithReqId(1)
+						.WithStatus(403),
+					MessageResponder.NoResponse(),
+					MessageFrequency.OnlyOnce()
+				);
+		}));
+
+		await ms.Start<SimpleMicroservice>(new TestArgs());
+		Assert.IsTrue(ms.HasInitialized);
+
+		testSocket.SendToClient(ClientRequest.ClientCallable("micro_simple", "TestAssumeUser", 1, 0, 2, true));
+
+		// simulate shutdown event...
+		await ms.OnShutdown(this, null);
+		Assert.IsTrue(testSocket.AllMocksCalled());
+	}
+}


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2424

# Brief Description
Basically, the `AssumeUser` call required that you were executing as an admin. However, there are many use cases where a game server may want one non-admin player to modify someone else's data. 
1. I've added a flag on the method that ignores the check, but defaulted it to `true` to maintain current behaviour. 
2. I added some tests to ensure that once you assume, the next request with the return value goes out with the assumed dbid.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
