### PR TITLE
beam 2395 - name validations on action

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue that caused the `ReflectionCache` to run an extra unnecessary time when a `.cs` or `.asmdef` file were changed.
 - Fixed issue on Re-Import All with `BeamableAssistantWindow` opened that required reopening the window for it to work.
 - Fixed issue that caused `StatsService.SearchStats` to fail whenever a match occurred.
+- Cannot create invalid service name before validation occurs
 
 ## [1.0.2]
 ### Fixed

--- a/client/Packages/com.beamable.server/Editor/UI/Components/ServiceBaseVisualElement/CreateServiceBaseVisualElement.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/ServiceBaseVisualElement/CreateServiceBaseVisualElement.cs
@@ -71,9 +71,9 @@ namespace Beamable.Editor.Microservice.UI.Components
 			_nameTextField = Root.Q<TextField>("microserviceNewTitle");
 			_nameTextField.SetValueWithoutNotify(NewServiceName);
 
-			_isNameValid = _nameTextField.AddErrorLabel("Name", PrimaryButtonVisualElement.IsValidClassName);
+			_isNameValid = _nameTextField.AddErrorLabel("Name", PrimaryButtonVisualElement.IsValidClassName, .01);
 			_isNameSizedRight = _nameTextField.AddErrorLabel(
-				"Length", txt => PrimaryButtonVisualElement.IsBetweenCharLength(txt, MAX_NAME_LENGTH));
+				"Length", txt => PrimaryButtonVisualElement.IsBetweenCharLength(txt, MAX_NAME_LENGTH), .01);
 			_createBtn.AddGateKeeper(_isNameValid);
 
 			Root.Q("foldContainer").visible = false;
@@ -116,6 +116,10 @@ namespace Beamable.Editor.Microservice.UI.Components
 
 		private void HandleContinueButtonClicked()
 		{
+			if (!_createBtn.CheckGateKeepers())
+			{
+				return;
+			}
 			var additionalReferences = _serviceCreateDependentService?.GetReferences();
 			_createBtn.SetText("Creating...");
 			_createBtn.Load(new Promise()); // spin forever, because a re-compile will save us!

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/PrimaryButtonVisualElement/PrimaryButtonVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/PrimaryButtonVisualElement/PrimaryButtonVisualElement.cs
@@ -63,6 +63,16 @@ namespace Beamable.Editor.UI.Components
 			Button.text = text;
 		}
 
+		public bool CheckGateKeepers()
+		{
+			foreach (var constraint in _constraints)
+			{
+				constraint.Check(true);
+			}
+
+			return Button.enabledSelf;
+		}
+
 		public void AddGateKeeper(params FormConstraint[] constraints)
 		{
 			foreach (var constraint in constraints)

--- a/client/Packages/com.beamable/Editor/UI/Common/UIElementExtensions.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/UIElementExtensions.cs
@@ -163,7 +163,7 @@ namespace Beamable.Editor
 			return Check;
 		}
 
-		public static FormConstraint AddErrorLabel(this TextField self, string name, FormErrorCheckWithInput checker)
+		public static FormConstraint AddErrorLabel(this TextField self, string name, FormErrorCheckWithInput checker, double debounceTime=.25)
 		{
 			var constraint = new FormConstraint
 			{
@@ -193,7 +193,7 @@ namespace Beamable.Editor
 			{
 				// wait up to .25 seconds.
 				var time = EditorApplication.timeSinceStartup;
-				nextCheckTime = time + .25;
+				nextCheckTime = time + debounceTime;
 				Debounce();
 			}
 


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2395

# Brief Description
Before, you could speed jam a bad name into the Create Microservice name textbox and hit enter before the validation occured.
I've
1. made it so that validation ALWAYS occurs when you hit enter, and if its invalid, cancels the create process
2. made the debounce configurable, and configured this debounce to be almost instant. The reason we'd have a debounce at all is so that we don't spam validation rules when a user types; but the operation we are doing here it isn't expensive at all.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
