### PR TITLE
[BEAM-2426] inf loop fix

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Model/MicroservicesDataModel.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Model/MicroservicesDataModel.cs
@@ -175,7 +175,6 @@ namespace Beamable.Editor.UI.Model
 
 		public Dictionary<string, ServiceAvailability> GetAllServicesStatus()
 		{
-			RefreshLocal();
 			var getServiceStatus = new Func<bool, bool, ServiceAvailability>((isLocally, isRemotely) =>
 			{
 				if (isLocally && isRemotely)


### PR DESCRIPTION
# Brief Description

- removed unnecesarry refresh line (previously it was hack/fix for MS window refresh - without it we had a service visual element null at startup or domain reload), after discusion with @PedroRauizBeamable we decided to remove that line because there is another buckup fix that resolve that situation (https://github.com/beamable/BeamableProduct/blob/main/client/Packages/com.beamable.server/Editor/UI/Model/MicroservicesDataModel.cs#L303)

without that line there is no Unity inf loop and OS freeze

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
