### PR TITLE
beam 2431 - always pull dotnet 6 lts

### DIFF
--- a/build/bin/build-promote.sh
+++ b/build/bin/build-promote.sh
@@ -9,11 +9,8 @@ echo "Starting com.beamable.server package build"
 docker-compose --no-ansi -f docker/package.com.beamable.server/docker-compose.yml up --build --exit-code-from beamable_server
 docker-compose --no-ansi -f docker/package.com.beamable.server/docker-compose.yml down # TODO: Ensure that this down command executes
 
-echo "Pulling latest Dotnet LTS"
-docker pull mcr.microsoft.com/dotnet/sdk:6.0
-
 echo "Starting Microservice dependencies..."
-docker-compose --no-ansi -f docker/image.microservice/docker-compose.yml up --build --exit-code-from microservice
+docker-compose --no-ansi -f docker/image.microservice/docker-compose.yml up --build --pull --exit-code-from microservice
 docker-compose --no-ansi -f docker/image.microservice/docker-compose.yml down # TODO: Ensure that this down command executes
 
 export BEAMSERVICE_TAG=${ENVIRONMENT}_${VERSION:-0.0.0}


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2431

# Brief Description
Before we build the base image code, we should always fetch the most recent version of dotnet 6 LTS. This will stop us from accidently bundling an out of date version of dotnet 6.0 LTS with the base beam service. (there are some more details in the ticket)

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
