### PR TITLE
beam 2427 - force hide the stop bar when the task finishes, no matter what

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Components/ServiceBaseVisualElement/ServiceBaseVisualElement.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/ServiceBaseVisualElement/ServiceBaseVisualElement.cs
@@ -267,7 +267,12 @@ namespace Beamable.Editor.Microservice.UI.Components
 		}
 		protected virtual void SetupProgressBarForStop(Task task)
 		{
-			new StopImageLogParser(_loadingBar, Model) { OnFailure = OnStopFailed };
+			var parser = new StopImageLogParser(_loadingBar, Model) { OnFailure = OnStopFailed };
+			task?.ContinueWith(_ =>
+			{
+				_loadingBar.Hidden = true;
+				parser.Kill();
+			});
 		}
 		private void OnStopFailed()
 		{


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2428

# Brief Description
Yup, just auto nuking the loading bar for stopping.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
