### PR TITLE
beam 2418 - null on storage creation

### DIFF
--- a/client/Packages/com.beamable.server/Editor/AssemblyDefinitionHelper.cs
+++ b/client/Packages/com.beamable.server/Editor/AssemblyDefinitionHelper.cs
@@ -288,6 +288,7 @@ namespace Beamable.Server.Editor
 			{
 				var assemblyDefPath = AssetDatabase.GUIDToAssetPath(assemblyDefGuid);
 				var assemblyDef = AssetDatabase.LoadAssetAtPath<AssemblyDefinitionAsset>(assemblyDefPath);
+				if (assemblyDef == null) continue;
 				yield return assemblyDef;
 			}
 		}


### PR DESCRIPTION
#TIcket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2418

# Brief Description
This is a sort of silly attempt, but we should be null checking the info itself before enumerating over it. On my local tests, this actually... fixes it... But I'm convinced it'll work totally without a build test. 

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
