### PR TITLE
[Beam-2432]  Added error handling for new "ExpiredTokenError" response from auth flow

### DIFF
--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/PlatformRequester.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/PlatformRequester.cs
@@ -248,7 +248,7 @@ namespace Beamable.Api
 							   return Promise<T>.Failed(new NoConnectivityException(uri + " should not be cached and requires internet connectivity. Internet connection lost."));
 
 						   // if we get a 401 InvalidTokenError, let's refresh the token and retry the request.
-						   case PlatformRequesterException code when code?.Error?.error == "InvalidTokenError":
+						   case PlatformRequesterException code when code?.Error?.error == "InvalidTokenError" || code?.Error?.error == "ExpiredTokenError":
 							   Debug.LogError("Invalid token, trying again");
 							   return AuthService.LoginRefreshToken(Token.RefreshToken)
 							 .Map(rsp =>


### PR DESCRIPTION
# Brief Description
Added error handling for "ExpiredTokenError" (renews the auth automatically)

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
