### PR TITLE
Split build and up commands

### DIFF
--- a/build/bin/build-promote.sh
+++ b/build/bin/build-promote.sh
@@ -10,7 +10,8 @@ docker-compose --no-ansi -f docker/package.com.beamable.server/docker-compose.ym
 docker-compose --no-ansi -f docker/package.com.beamable.server/docker-compose.yml down # TODO: Ensure that this down command executes
 
 echo "Starting Microservice dependencies..."
-docker-compose --no-ansi -f docker/image.microservice/docker-compose.yml up --build --pull --exit-code-from microservice
+docker-compose --no-ansi -f docker/image.microservice/docker-compose.yml build --pull --no-cache # Fresh pull, no cache, builds
+docker-compose --no-ansi -f docker/image.microservice/docker-compose.yml up --exit-code-from microservice # Runs containers and checks the exit code
 docker-compose --no-ansi -f docker/image.microservice/docker-compose.yml down # TODO: Ensure that this down command executes
 
 export BEAMSERVICE_TAG=${ENVIRONMENT}_${VERSION:-0.0.0}


### PR DESCRIPTION
Build and up docker-compose commands split so we can tell the build to not use cache and also we can tell it to force pull.

# Brief Description

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
