### PR TITLE
[BEAM-2482] Fix issue with RecoverWithFalloff test (happens only in github runners)

### DIFF
--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Promises/PromisePlayModeTests.cs
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Promises/PromisePlayModeTests.cs
@@ -1,5 +1,6 @@
 ﻿using Beamable;
 using Beamable.Common;
+using Beamable.Coroutines;
 using NUnit.Framework;
 using System;
 using System.Collections;
@@ -8,17 +9,33 @@ using System.Diagnostics;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.TestTools;
+using Object = UnityEngine.Object;
 
 namespace Beamable.Tests.Runtime.PromiseTests
 {
 	public class PromisePlayModeTests
 	{
+		private CoroutineService _coroutineService;
+		
+		
+		[SetUp]
+		public void SetUp()
+		{
+			_coroutineService = new GameObject("__CoroutineService__").AddComponent<CoroutineService>();
+		}
+
+		[TearDown]
+		public void Teardown()
+		{
+			Object.DestroyImmediate(_coroutineService.gameObject);
+		}
+
 		[UnityTest]
 		public IEnumerator RecoverWithFalloff_ShouldThrowAfterMaxAttempts()
 		{
 			var attemptCounter = 0;
 			var expectedExceptionReceived = false;
-			var retryAttemptFalloffTimers = new[] { .1f, .5f, 1, 2 };
+			var retryAttemptFalloffTimers = new[] { .1f, .25f, .5f, .75f };
 
 			// Ignoring this so the test has the opportunity to succeed ----> When we call CompleteError in our fake work promise, it will fail immediately,
 			// before the RecoverWith has the chance to attach any callbacks.
@@ -36,7 +53,7 @@ namespace Beamable.Tests.Runtime.PromiseTests
 					return newPromise;
 				});
 				return fakeWork;
-			}, retryAttemptFalloffTimers).Error(err => expectedExceptionReceived = err.Message == $"ExceptionDuringRecovery {retryAttemptFalloffTimers.Length - 1}");
+			}, retryAttemptFalloffTimers, _coroutineService).Error(err => expectedExceptionReceived = err.Message == $"ExceptionDuringRecovery {retryAttemptFalloffTimers.Length - 1}");
 
 			mainPromise.CompleteError(new Exception("UnexpectedException"));
 			yield return recoveringPromise.ToYielder();
@@ -52,7 +69,7 @@ namespace Beamable.Tests.Runtime.PromiseTests
 			var attemptCounter = -1;
 			var attemptToSucceedAt = 2;
 			var successWasAchieved = false;
-			var retryAttemptFalloffTimers = new[] { .1f, .5f, 1, 2 };
+			var retryAttemptFalloffTimers = new[] { .1f, .25f, .5f, .75f };
 
 			// Ignoring this so the test has the opportunity to succeed ----> When we call CompleteError in our fake work promise, it will fail immediately,
 			// before the RecoverWith has the chance to attach any callbacks.
@@ -74,7 +91,7 @@ namespace Beamable.Tests.Runtime.PromiseTests
 				});
 
 				return fakeWork;
-			}, retryAttemptFalloffTimers).Then(_ => successWasAchieved = true);
+			}, retryAttemptFalloffTimers, _coroutineService).Then(_ => successWasAchieved = true);
 
 			mainPromise.CompleteError(new Exception("UnexpectedException"));
 			yield return recoveringPromise.ToYielder();
@@ -88,7 +105,7 @@ namespace Beamable.Tests.Runtime.PromiseTests
 		{
 			var attemptCounter = 0;
 			var expectedExceptionReceived = false;
-			var retryAttemptFalloffTimers = new[] { .1f, .5f, 1, 2 };
+			var retryAttemptFalloffTimers = new[] { .1f, .25f, .5f, .75f };
 
 			// Ignoring this so the test has the opportunity to succeed ----> When we call CompleteError in our fake work promise, it will fail immediately,
 			// before the RecoverWith has the chance to attach any callbacks.
@@ -109,7 +126,7 @@ namespace Beamable.Tests.Runtime.PromiseTests
 					return newPromise;
 				});
 				return fakeWork;
-			}, retryAttemptFalloffTimers, maxRetries).Error(err =>
+			}, retryAttemptFalloffTimers, _coroutineService, maxRetries).Error(err =>
 			{
 				// We expect the last exception we receive to be the maximum number of retries (minus one since attempts are 0-indexed).
 				expectedExceptionReceived = err.Message == $"ExceptionDuringRecovery {maxRetries - 1}";


### PR DESCRIPTION
# Brief Description
PromisePlayModeTests now use their own instance of CoroutineService instead of the BeamContext.Default one

- This is supposed to fix a weird issue that happens when trying to use the BeamContext.Default from a github test runner.
- Also, reduced falloff times so that the tests don't take as long as they did

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
