### PR TITLE
fixed searching for field - used in inline style drawer

### DIFF
--- a/client/Packages/com.beamable/Editor/Utility/EditorGUIExtension.cs
+++ b/client/Packages/com.beamable/Editor/Utility/EditorGUIExtension.cs
@@ -62,12 +62,41 @@ namespace Beamable.Editor
 				}
 				else
 				{
-					fieldInfo = parentType?.GetField(pathParts[i], BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+					fieldInfo = parentType.FindField(pathParts[i]);
 					parentType = fieldInfo?.FieldType;
 				}
 			}
 
 			return fieldInfo;
+		}
+
+		public static FieldInfo FindField(this Type type, string fieldName, Type baseTypeLimit = null)
+		{
+			if (baseTypeLimit == null)
+			{
+				baseTypeLimit = typeof(object);
+			}
+
+			while (type != null)
+			{
+				var field = type.GetField(
+					fieldName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+				if (field != null)
+				{
+					return field;
+				}
+
+				if (type != baseTypeLimit)
+				{
+					type = type.BaseType;
+				}
+				else
+				{
+					type = null;
+				}
+			}
+
+			return null;
 		}
 
 		public static Type GetParentType(this SerializedProperty property)
@@ -76,7 +105,7 @@ namespace Beamable.Editor
 			var pathParts = property.propertyPath.Split('.');
 			for (int i = 0; i < pathParts.Length - 1; i++)
 			{
-				var fieldInfo = parentType.GetField(pathParts[i], BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+				var fieldInfo = parentType.FindField(pathParts[i]);
 				parentType = fieldInfo.FieldType;
 			}
 
@@ -97,7 +126,7 @@ namespace Beamable.Editor
 				}
 				else
 				{
-					var fieldInfo = parent?.GetType().GetField(pathParts[i], BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+					var fieldInfo = parent?.GetType().FindField(pathParts[i]);
 					parent = fieldInfo?.GetValue(parent);
 				}
 			}


### PR DESCRIPTION
# Brief Description
Searching for fields in inline style drawers was broken - it wasn't able to find private fields in base types. I fixed it.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
