### PR TITLE
[BEAM-2392] UX - add keyboard shortcut capability to CMV2

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ContentListVisualElement/ContentListVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ContentListVisualElement/ContentListVisualElement.cs
@@ -44,7 +44,6 @@ namespace Beamable.Editor.Content.Components
 		private VisualElement _mainVisualElement;
 		private HeaderVisualElement _headerVisualElement;
 		private ExtendedListView _listView;
-		// private List<ContentItemDescriptor> _contentItemDescriptorList;
 		private List<HeaderSizeChange> _headerSizeChanges;
 		private bool _isKeyboardInputBlocked;
 
@@ -180,8 +179,7 @@ namespace Beamable.Editor.Content.Components
 		{
 			ContentVisualElement contentVisualElement = (ContentVisualElement)elem;
 
-			contentVisualElement.ContentItemDescriptor =
-				Model.FilteredContents[index]; //_contentItemDescriptorList[index];
+			contentVisualElement.ContentItemDescriptor = Model.FilteredContents[index];
 			contentVisualElement.OnRightMouseButtonClicked -= ContentVisualElement_OnRightMouseButtonClicked;
 			contentVisualElement.OnRightMouseButtonClicked += ContentVisualElement_OnRightMouseButtonClicked;
 			contentVisualElement.Refresh();


### PR DESCRIPTION
# Brief Description
Right now user can use keybinds to duplicate and delete `ContentItems` in `Content Manager`. 

Duplication => Action key (windows = ctrl, mac = command) + D
Deletion => Delete

![Unity_ZgprZNNpdu](https://user-images.githubusercontent.com/18366601/162425054-5b8b7394-ed8f-49bd-b1b3-613d7f173487.gif)

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
