### PR TITLE
[BEAM-2484] 1.1 Blocker - Microservices start error on Windows

### DIFF
--- a/client/Packages/com.beamable.server/Editor/BeamServicesCodeWatcher.cs
+++ b/client/Packages/com.beamable.server/Editor/BeamServicesCodeWatcher.cs
@@ -143,18 +143,23 @@ namespace Beamable.Server.Editor
 		{
 			var config = MicroserviceConfiguration.Instance;
 			var currCodeHandles = config.ServiceCodeHandlesOnLastDomainReload;
-			var serviceToUpdate = currCodeHandles.First(h => h.ServiceName == serviceName);
 
-			var builtCodeHandles = serviceToUpdate.AsmDefInfo.References
-												  .Select(asmName => currCodeHandles.FirstOrDefault(c => c.AsmDefInfo.Name == asmName))
-												  .Where(handle => handle.CodeClass != BeamCodeClass.Invalid)
-												  .ToList();
+			if (currCodeHandles != null && currCodeHandles.Count > 0)
+			{
+				var serviceToUpdate = currCodeHandles.First(h => h.ServiceName == serviceName);
 
-			config.LastBuiltDockerImagesCodeHandles.Remove(serviceToUpdate);
-			config.LastBuiltDockerImagesCodeHandles.RemoveAll(h => builtCodeHandles.Contains(h));
+				var builtCodeHandles = serviceToUpdate.AsmDefInfo.References
+				                                      .Select(asmName => currCodeHandles.FirstOrDefault(
+					                                              c => c.AsmDefInfo.Name == asmName))
+				                                      .Where(handle => handle.CodeClass != BeamCodeClass.Invalid)
+				                                      .ToList();
 
-			config.LastBuiltDockerImagesCodeHandles.Add(serviceToUpdate);
-			config.LastBuiltDockerImagesCodeHandles.AddRange(builtCodeHandles);
+				config.LastBuiltDockerImagesCodeHandles.Remove(serviceToUpdate);
+				config.LastBuiltDockerImagesCodeHandles.RemoveAll(h => builtCodeHandles.Contains(h));
+
+				config.LastBuiltDockerImagesCodeHandles.Add(serviceToUpdate);
+				config.LastBuiltDockerImagesCodeHandles.AddRange(builtCodeHandles);
+			}
 		}
 
 		public void CheckForLocalChangesNotYetDeployed()


### PR DESCRIPTION
# Brief Description

My repro:
1. start docker & Unity
2. create MS (don't build/run)
2. restart Unity (docker is still active)
3. run previously created MS

Result: Error with empty code watcher reference after MS start.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
