### PR TITLE
[BEAM-2495] GroupLoadingBarUpdater null after Storage Start & domain reload …

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Common/Components/LoadingBarElement/Updater/GroupLoadingBarUpdater.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/LoadingBarElement/Updater/GroupLoadingBarUpdater.cs
@@ -41,7 +41,7 @@ namespace Beamable.Editor.UI.Components
 			{
 				if (child == null)
 					continue;
-				;
+
 				if (child.LoadingBar != null)
 					child.LoadingBar.OnUpdated += HandleUpdates;
 


### PR DESCRIPTION
# Brief Description

Error/null appears after select more than 1 service & domain reload.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
