### PR TITLE
[BEAM-2498] GitHub RC 8 Tests failing due to indirect BeamContext calls in extension methods

### DIFF
--- a/client/Packages/com.beamable/Runtime/PromiseExtensions.cs
+++ b/client/Packages/com.beamable/Runtime/PromiseExtensions.cs
@@ -45,6 +45,10 @@ namespace Beamable
 			t.ContinueWith(_ => _uncaughtTasks.Remove(t));
 		}
 
+		/// <summary>
+		/// Returns a promise that will complete successfully in <paramref name="seconds"/>.
+		/// Don't use this version when writing tests, instead use <see cref="WaitForSeconds{T}(Beamable.Common.Promise{T},float,CoroutineService)"/>.
+		/// </summary>
 		public static Promise<T> WaitForSeconds<T>(this Promise<T> promise, float seconds)
 		{
 			var result = new Promise<T>();
@@ -59,6 +63,9 @@ namespace Beamable
 			return result;
 		}
 
+		/// <summary>
+		/// Returns a promise that will complete successfully in <paramref name="seconds"/> by kicking off a coroutine via the given Coroutine <paramref name="service"/>.
+		/// </summary>
 		public static Promise<T> WaitForSeconds<T>(this Promise<T> promise, float seconds, CoroutineService service)
 		{
 			var result = new Promise<T>();

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Promises/PromisePlayModeTests.cs
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Promises/PromisePlayModeTests.cs
@@ -46,7 +46,7 @@ namespace Beamable.Tests.Runtime.PromiseTests
 			{
 				attemptCounter += 1;
 
-				var fakeWork = Promise.Success.WaitForSeconds(.00001f).FlatMap(_ =>
+				var fakeWork = Promise.Success.WaitForSeconds(.00001f, _coroutineService).FlatMap(_ =>
 				{
 					var newPromise = new Promise();
 					newPromise.CompleteError(new Exception($"ExceptionDuringRecovery {attempt}"));
@@ -80,7 +80,7 @@ namespace Beamable.Tests.Runtime.PromiseTests
 			{
 				attemptCounter += 1;
 
-				var fakeWork = Promise.Success.WaitForSeconds(.00001f).FlatMap(_ =>
+				var fakeWork = Promise.Success.WaitForSeconds(.00001f, _coroutineService).FlatMap(_ =>
 				{
 					var newPromise = new Promise();
 					if (attemptIdx < attemptToSucceedAt)
@@ -119,7 +119,7 @@ namespace Beamable.Tests.Runtime.PromiseTests
 			{
 				attemptCounter += 1;
 
-				var fakeWork = Promise.Success.WaitForSeconds(.00001f).FlatMap(_ =>
+				var fakeWork = Promise.Success.WaitForSeconds(.00001f, _coroutineService).FlatMap(_ =>
 				{
 					var newPromise = new Promise();
 					newPromise.CompleteError(new Exception($"ExceptionDuringRecovery {attempt}"));


### PR DESCRIPTION
# Brief Description
Call correct overload (not dependent on BeamContext.Default) in Promise tests and added documentation explaining which overload to use in test envs

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
