### PR TITLE
[DEP-749] Corruption in Content Manager

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ContentVisualElement/ContentVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ContentVisualElement/ContentVisualElement.uss
@@ -10,7 +10,7 @@ ContentVisualElement #resizable{
 }
 
 ContentVisualElement #resizable *{
-    font-size: 11;
+    font-size: 11px;
 }
 
 ContentVisualElement > TemplateContainer {


### PR DESCRIPTION
# Brief Description

It's super hard to repro this bug. Potential bug fix may be related to the font size. I cannot find any 100% confirmation about that but as I remember I read somewhere about it. Most problem answers with corrupted TMP are related to playmode. 

[Ticket](https://disruptorbeam.atlassian.net/browse/DEP-749)

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
