### PR TITLE
VSP beam 2473 - auto include addressable types with link file

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added `RecoverWith` extension method overloads to `Promise<T>` that allow for configuring  a promise to recover from failure over multiple attempts.
+- `PreventAddressableCodeStripping` Core Configuration setting that automatically generates a link.xml file that will preserve addressable types.
 
 ### Changed
 - Changed behaviour of Add Style button in Buss Theme Manager

--- a/client/Packages/com.beamable/Editor/BeamableLinker.cs
+++ b/client/Packages/com.beamable/Editor/BeamableLinker.cs
@@ -16,6 +16,33 @@ namespace Beamable.Editor
 			"UnityUIExtensions"
 		};
 
+		[MenuItem(Paths.MENU_ITEM_PATH_WINDOW_BEAMABLE_UTILITIES + "/Generate Addressables Link File")]
+		public static void GenerateAddressablesLinkFile()
+		{
+			var linkPath = "Assets/Beamable/Resources/AddressablesLinker/link.xml";
+			var link = @"
+<linker>
+    <assembly fullname=""Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"" preserve=""all"">
+        <type fullname=""UnityEngine.ResourceManagement.ResourceProviders.LegacyResourcesProvider"" preserve=""all"" />
+        <type fullname=""UnityEngine.ResourceManagement.ResourceProviders.AssetBundleProvider"" preserve=""all"" />
+        <type fullname=""UnityEngine.ResourceManagement.ResourceProviders.BundledAssetProvider"" preserve=""all"" />
+        <type fullname=""UnityEngine.ResourceManagement.ResourceProviders.InstanceProvider"" preserve=""all"" />
+        <type fullname=""UnityEngine.ResourceManagement.AsyncOperations"" preserve=""all"" />
+    </assembly>
+    <assembly fullname=""Unity.Addressables, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"" preserve=""all"">
+        <type fullname=""UnityEngine.AddressableAssets.Addressables"" preserve=""all"" />
+    </assembly>
+</linker>
+";
+			var sb = new StringBuilder();
+			sb.Append(link);
+			var xml = sb.ToString();
+			var alreadyExists = (File.Exists(linkPath) && File.ReadAllText(linkPath) == xml);
+			if (alreadyExists) return;
+			Directory.CreateDirectory(Path.GetDirectoryName(linkPath));
+			File.WriteAllText(linkPath, xml);
+		}
+
 		[MenuItem(Paths.MENU_ITEM_PATH_WINDOW_BEAMABLE_UTILITIES + "/Generate Link File")]
 		public static void GenerateLinkFile()
 		{

--- a/client/Packages/com.beamable/Editor/BuildPreProcessor.cs
+++ b/client/Packages/com.beamable/Editor/BuildPreProcessor.cs
@@ -16,6 +16,11 @@ namespace Beamable.Editor
 			{
 				BeamableLinker.GenerateLinkFile();
 			}
+
+			if (CoreConfiguration.Instance.PreventAddressableCodeStripping)
+			{
+				BeamableLinker.GenerateAddressablesLinkFile();
+			}
 		}
 #else
         public async void OnPreprocessBuild(BuildReport report)

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Content/ContentService.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Content/ContentService.cs
@@ -55,11 +55,14 @@ namespace Beamable.Content
 		/// <param name="scope"></param>
 		/// <param name="callback"></param>
 		/// <returns></returns>
+#pragma warning disable 0809
 		[Obsolete("The ManifestSubscription doesn't support the scope field. Please use " + nameof(Subscribe) + " instead.")]
 		public override PlatformSubscription<ClientManifest> Subscribe(string scope, Action<ClientManifest> callback)
 		{
 			return base.Subscribe(callback);
 		}
+#pragma warning restore 0809
+
 
 		public bool TryGetContentId(string contentId, out ClientContentInfo clientInfo)
 		{

--- a/client/Packages/com.beamable/Runtime/Modules/CoreConfiguration.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/CoreConfiguration.cs
@@ -41,6 +41,11 @@ namespace Beamable
 				 "will not be deleted.")]
 		public bool PreventCodeStripping = true;
 
+		[Tooltip("by default, Beamable won't let Unity Addressables code files be stripped form the project on build. " +
+		         "When this setting is enabled, anything the project is built, a link.xml file will be generated in the Assets/beamable/Resources/AddressableLinker " +
+		         "folder. If you disable this setting, the link file won't be generated. However, any existing link file won't be deleted. ")]
+		public bool PreventAddressableCodeStripping = true;
+
 		public static CoreConfiguration Instance => Get<CoreConfiguration>();
 
 		public enum EventHandlerConfig { Guarantee, Replace, Add, }


### PR DESCRIPTION
# Brief Description
for VSP, they want us to automatically include the addressables linker file; which is fine by me. I've included it as an auto-creating link.xml file, controlled in the CoreConfiguration.
I also fixed a few random other issues.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
