### PR TITLE
VSP - Feature/beam 2480 - support whats new 

### DIFF
--- a/client/Packages/com.beamable/Common/Runtime/Constants/Implementations/ToolboxConstants.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Constants/Implementations/ToolboxConstants.cs
@@ -15,6 +15,7 @@
 					public const string IS_PACKAGE_WHATSNEW_ANNOUNCEMENT_IGNORED = "IsPackageWhatsNewAnnouncementIgnored";
 					public const string NEWEST_VERSION_NUMBER = "NewestVersionNumber";
 					public const string NEWEST_SERVER_VERSION_NUMBER = "NewestServerVersionNumber";
+					public const string VSP_IGNORED_PACKAGE_VERSION = "VspIgnoredPackageVersion";
 				}
 			}
 		}

--- a/client/Packages/com.beamable/Common/Runtime/Environment/PackageVersion.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Environment/PackageVersion.cs
@@ -137,6 +137,19 @@ namespace Beamable.Common
 			return sb.ToString();
 		}
 
+		public static bool TryFromSemanticVersionString(string semanticVersion, out PackageVersion version)
+		{
+			try
+			{
+				version = semanticVersion;
+				return true;
+			}
+			catch
+			{
+				version = new PackageVersion(0, 0, 0);
+				return false;
+			}
+		}
 		public static PackageVersion FromSemanticVersionString(string semanticVersion)
 		{
 			var major = -1;

--- a/client/Packages/com.beamable/Editor/3rdParty/UnityVSP/BeamableVsp.cs
+++ b/client/Packages/com.beamable/Editor/3rdParty/UnityVSP/BeamableVsp.cs
@@ -1,5 +1,8 @@
 using Beamable;
 using Beamable.Common;
+using Beamable.Common.Api;
+using Beamable.Editor;
+using System;
 
 namespace UnityEditor.VspAttribution.Beamable
 {
@@ -17,13 +20,35 @@ namespace UnityEditor.VspAttribution.Beamable
 				cid);
 		}
 
-		public static PackageVersion GetLatestVersion()
+		public static async Promise<VspMetadata> GetLatestVersion()
 		{
-#if !UNITY_EDITOR
-			return BeamableEnvironment.SdkVersion;
-#endif
+			var api = await EditorAPI.Instance;
+			var res = await api.Requester.ManualRequest<VspVersionResponse>(Method.GET, "http://beamable-vsp.beamable.com/vsp-meta.json");
+			var metadata = new VspMetadata {storeUrl = res.storeUrl};
+			try
+			{
+				PackageVersion version = res.version;
+				metadata.version = version;
+			}
+			catch
+			{
+				metadata.version = new PackageVersion(0,0,0);
+			}
 
-			return "";
+			return metadata;
+		}
+
+		[Serializable]
+		public class VspVersionResponse
+		{
+			public string version;
+			public string storeUrl;
+		}
+
+		public class VspMetadata
+		{
+			public PackageVersion version;
+			public string storeUrl;
 		}
 	}
 }


### PR DESCRIPTION
# Brief Description
For the VSP, we'll install as a local package, not through the registry. This means we need to re-implement the "Is there a new version?" check. 

The asset store doesn't have an API for this, so we'll maintain a file on S3 that tells us what the latest version is. This approach just forks the decision for when to show that banner; if you're VSP, check the file, and use that data to drive the rest. 

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
