### PR TITLE
VSP - beam 2466 - adds comments to cloud data

### DIFF
--- a/client/Packages/com.beamable/Common/Runtime/Api/CloudData/CloudDataApi.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/CloudData/CloudDataApi.cs
@@ -3,20 +3,55 @@ using System.Collections.Generic;
 
 namespace Beamable.Common.Api.CloudData
 {
+	/// <summary>
+	/// A message containing the player's <see cref="CloudMetaData"/> data, in the <see cref="meta"/> list
+	/// </summary>
 	[Serializable]
 	public class GetCloudDataManifestResponse
 	{
+		/// <summary>
+		/// A message describing the state of the message. If the message was received correctly, the value will be "ok"
+		/// </summary>
 		public string result;
+
+		/// <summary>
+		/// A list of cloud data entries
+		/// </summary>
 		public List<CloudMetaData> meta;
 	}
 
+	/// <summary>
+	/// A CloudMetaData represents a piece of game data that can be overridden by the server, or by specific cohorts for players.
+	/// This structure is the metadata about the game data itself. You can use the <see cref="uri"/> field to resolve the data.
+	/// </summary>
 	[Serializable]
 	public class CloudMetaData
 	{
+		/// <summary>
+		/// The unique id of this particular cloud data reference
+		/// </summary>
 		public long sid;
+
+		/// <summary>
+		/// The version of the cloud data reference. If you update the cloud data from the portal, this version increases.
+		/// </summary>
 		public long version;
+
+		/// <summary>
+		/// The name of the base game cloud data that this player cloud data refers to. Every player cloud data must be attached to a base game piece of data.
+		/// </summary>
 		public string @ref;
+
+		/// <summary>
+		/// A uri that points to the data for the cloud data. You can use the <see cref="IHttpRequester"/> to request this data.
+		/// </summary>
 		public string uri;
+
+		/// <summary>
+		/// The player may be in a special cohort that changes the default uri and resulting data.
+		/// The <see cref="CohortEntry.trial"/> is <inheritdoc cref="CohortEntry.trial"/>
+		/// The <see cref="CohortEntry.cohort"/> is <inheritdoc cref="CohortEntry.cohort"/>
+		/// </summary>
 		public CohortEntry cohort;
 
 		public bool IsDefault => string.IsNullOrEmpty(cohort?.trial) && string.IsNullOrEmpty(cohort?.cohort);
@@ -25,21 +60,28 @@ namespace Beamable.Common.Api.CloudData
 	[Serializable]
 	public class CohortEntry
 	{
+		/// <summary>
+		/// The name of the trial. Blank if there is no trial. A trial can have many cohorts.
+		/// </summary>
 		public string trial;
+
+		/// <summary>
+		/// the name of the cohort. Blank if there is no assigned cohort.
+		/// </summary>
 		public string cohort;
 	}
 
 	/// <summary>
 	/// This type defines the %Client main entry point for the %A/B %Testing feature.
-	/// 
+	///
 	/// [img beamable-logo]: https://landen.imgix.net/7udgo2lvquge/assets/xgh89bz1.png?w=400 "Beamable Logo"
-	/// 
+	///
 	/// #### Related Links
 	/// - See the <a target="_blank" href="https://docs.beamable.com/docs/abtesting-feature">A/B Testing</a> feature documentation
 	/// - See Beamable.API script reference
-	/// 
+	///
 	/// ![img beamable-logo]
-	/// 
+	///
 	/// </summary>
 	public class CloudDataApi : ICloudDataApi
 	{

--- a/client/Packages/com.beamable/Common/Runtime/Api/CloudData/ICloudDataApi.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/CloudData/ICloudDataApi.cs
@@ -2,19 +2,31 @@ namespace Beamable.Common.Api.CloudData
 {
 	/// <summary>
 	/// This type defines the %Client main entry point for the %A/B %Testing feature.
-	/// 
+	///
 	/// [img beamable-logo]: https://landen.imgix.net/7udgo2lvquge/assets/xgh89bz1.png?w=400 "Beamable Logo"
-	/// 
+	///
 	/// #### Related Links
 	/// - See the <a target="_blank" href="https://docs.beamable.com/docs/abtesting-feature">A/B Testing</a> feature documentation
 	/// - See Beamable.API script reference
-	/// 
+	///
 	/// ![img beamable-logo]
-	/// 
+	///
 	/// </summary>
 	public interface ICloudDataApi
 	{
+		/// <summary>
+		/// This method will return the cloud data for the entire game.
+		/// It cannot be called by a player. You must be an admin user to execute this method.
+		/// </summary>
+		/// <returns></returns>
 		Promise<GetCloudDataManifestResponse> GetGameManifest();
+
+		/// <summary>
+		/// Get the current player's cloud trial data.
+		/// The <see cref="GetCloudDataManifestResponse"/> will include data for the player's assigned cohorts.
+		/// Remember, if that list is empty, it may be because the cohorts only work for game.private stats conditions.
+		/// </summary>
+		/// <returns>A <see cref="GetCloudDataManifestResponse"/> promise representing the player's cloud trial data.</returns>
 		Promise<GetCloudDataManifestResponse> GetPlayerManifest();
 	}
 }


### PR DESCRIPTION
# Brief Description
The VSP guys were confused about the cloud data list wasn't including their cohort. Its because the stat they'd used wasn't a game.private stat. 

In general, I added a bunch of comments to this pattern.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
