### PR TITLE
beam 2527 - token expiration never set

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- `AccessTokenStorage` no longer throws `ArgumentOutOfRangeException` when starting in offline mode
+
 ## [1.1.1]
 ### Fixed
 - The namespace for `PropertySourceTracker` no longer invalidates the usage of `UnityEditor.Editor` as a type reference

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/AccessToken.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/AccessToken.cs
@@ -42,6 +42,7 @@ namespace Beamable.Api
 			if (expiresAt >= long.MaxValue - 1)
 			{
 				_neverExpires = true;
+				ExpiresAt = DateTime.MaxValue;
 			}
 			else
 			{

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/AccessTokenStorage.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/AccessTokenStorage.cs
@@ -60,10 +60,20 @@ namespace Beamable.Api
 			AliasHelper.ValidateCid(cid);
 			PlayerPrefs.SetString($"{_prefix}{cid}.access_token", token.Token);
 			PlayerPrefs.SetString($"{_prefix}{cid}.refresh_token", token.RefreshToken);
-			PlayerPrefs.SetString(
-			   $"{_prefix}{cid}.expires",
-			   token.ExpiresAt.ToFileTimeUtc().ToString()
-			);
+			try
+			{
+				PlayerPrefs.SetString(
+					$"{_prefix}{cid}.expires",
+					token.ExpiresAt.ToFileTimeUtc().ToString()
+				);
+			}
+			catch (ArgumentOutOfRangeException)
+			{
+				Debug.LogWarning($"Wasn't able to set the expiration time of the token in playerprefs. ExpiresAt=[{token.ExpiresAt}]. " +
+				                 "This is a non-fatal error, because if the token is expired, it will be re-issued after the first auth failure, "+
+				                 "and the original request will be reattempted.");
+			}
+
 			StoreDeviceRefreshToken(cid, null, token);
 			PlayerPrefs.Save();
 			return Promise<Unit>.Successful(PromiseBase.Unit);


### PR DESCRIPTION
# Brief Description
Ali found the root cause of https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2527 ; which is that in the case when a token is set to never expire, it was never setting the value of `ExpiresAt`, which made later operations fail. 

I opted to SET the value to something reasonable, instead of trying to add in null-checking anywhere in the future. Also, its sort of hard to add null checking, because `DateTime` is a value type anyway.


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
