### PR TITLE
[BEAM-2554] Microservice download returns a console error

### DIFF
--- a/client/Packages/com.beamable.server/Editor/MicroserviceConfiguration.asset
+++ b/client/Packages/com.beamable.server/Editor/MicroserviceConfiguration.asset
@@ -13,33 +13,3 @@ MonoBehaviour:
   m_Name: MicroserviceConfiguration
   m_EditorClassIdentifier: 
   Microservices: []
-  StorageObjects: []
-  ServiceCodeHandlesOnLastDomainReload: []
-  LastBuiltDockerImagesCodeHandles: []
-  ServiceDependencyChecksums: []
-  CustomContainerPrefix: 
-  AutoReferenceContent: 0
-  AutoBuildCommonAssembly: 1
-  ColorLogs: 1
-  EnableDockerBuildkit: 0
-  DockerDesktopCheckInMicroservicesWindow: 1
-  EnableHotModuleReload: 1
-  EnableAutoPrune: 1
-  RiderDebugTools:
-    HasValue: 0
-    Value:
-      RiderVersion: 2021.3.3
-      RiderToolsDownloadUrl: https://download.jetbrains.com/resharper/dotUltimate.2021.3.2/JetBrains.Rider.RemoteDebuggerUploads.linux-x64.2021.3.2.zip
-  WindowsDockerCommand: docker
-  UnixDockerCommand: /usr/local/bin/docker
-  WindowsDockerDesktopPath: C:\Program Files\Docker\Docker\Docker Desktop.exe
-  UnixDockerDesktopPath: /Applications/Docker.app/
-  ForwardContainerLogsToUnityConsole: 0
-  LogProcessLabelColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-  LogStandardOutColor: {r: 0, g: 0, b: 1, a: 1}
-  LogStandardErrColor: {r: 1, g: 0, b: 0, a: 1}
-  LogDebugLabelColor: {r: 0.25, g: 0.5, b: 1, a: 1}
-  LogInfoLabelColor: {r: 0, g: 0, b: 1, a: 1}
-  LogErrorLabelColor: {r: 1, g: 0, b: 0, a: 1}
-  LogWarningLabelColor: {r: 1, g: 0.6, b: 0.16, a: 1}
-  LogFatalLabelColor: {r: 1, g: 0, b: 0, a: 1}


### PR DESCRIPTION
# Brief Description

unity 2021 print error when asset name is different than asset name parameter in file

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
