### PR TITLE
[BEAM-2552] Fix updating manifest button display

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Common/Components/ManifestButtonVisualElement/ManifestButtonVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/ManifestButtonVisualElement/ManifestButtonVisualElement.cs
@@ -72,8 +72,9 @@ namespace Beamable.Editor.UI.Components
 
 		private void HandleAvailableManifestsChanged(List<ISearchableElement> ids)
 		{
-			_manyManifests = ids?.Count > 1;
-			_nonDefaultManifest = ids?.Count == 1 && ids[0].DisplayName != DEFAULT_MANIFEST_ID;
+			var idsAmount = ids?.Count ?? 0;
+			_manyManifests = idsAmount > 1;
+			_nonDefaultManifest = idsAmount == 1 && ids[0].DisplayName != DEFAULT_MANIFEST_ID;
 
 			RefreshButtonVisibility();
 		}
@@ -86,7 +87,7 @@ namespace Beamable.Editor.UI.Components
 
 		private void HandleManifestChanged(ISearchableElement manifest)
 		{
-			_manifestLabel.text = Model.Current != null ? Model.Current.DisplayName : null;
+			_manifestLabel.text = Model.Current?.DisplayName;
 		}
 
 		private void OnButtonClicked(Rect visualElementBounds)

--- a/client/Packages/com.beamable/Editor/UI/Common/Models/ManifestModel.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/Models/ManifestModel.cs
@@ -1,6 +1,7 @@
 using Beamable.Common;
 using Beamable.Content;
 using Beamable.Editor.Content;
+using Beamable.Editor.Realms;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -26,18 +27,19 @@ namespace Beamable.Editor.UI.Common.Models
 
 		public void Initialize()
 		{
-			Default = new AvailableManifestModel() { id = DEFAULT_MANIFEST_ID };
+			Default = new AvailableManifestModel { id = DEFAULT_MANIFEST_ID };
 			RefreshAvailable();
 
 			var api = BeamEditorContext.Default;
+			ContentIO.OnManifestChanged -= HandleManifestChanged;
+			ContentIO.OnManifestsListFetched -= HandleManifestListFetched;
+			ContentIO.OnArchivedManifestsFetched -= HandleArchivedManifestListFetched;
 			ContentIO.OnManifestChanged += HandleManifestChanged;
 			ContentIO.OnManifestsListFetched += HandleManifestListFetched;
 			ContentIO.OnArchivedManifestsFetched += HandleArchivedManifestListFetched;
 
-			Current = new AvailableManifestModel() { id = ContentConfiguration.Instance.EditorManifestID };
+			Current = new AvailableManifestModel { id = ContentConfiguration.Instance.EditorManifestID };
 			OnElementChanged?.Invoke(Current);
-
-			api.OnRealmChange += _ => RefreshAvailable();
 			ContentPublisher.OnContentPublished += () => RefreshAvailable();
 		}
 

--- a/client/Packages/com.beamable/Editor/UI/Content/Components/BreadcrumbsVisualElement/BreadcrumbsVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/BreadcrumbsVisualElement/BreadcrumbsVisualElement.cs
@@ -87,8 +87,8 @@ namespace Beamable.Editor.Content.Components
 			Model_OnSelectedContentTypeBranchChanged(new List<TreeViewItem>());
 			Model.OnSelectedContentTypeBranchChanged += Model_OnSelectedContentTypeBranchChanged;
 			//
-			Model_OnSelectedContentChanged(new List<ContentItemDescriptor>());
-			Model.OnSelectedContentChanged += Model_OnSelectedContentChanged; ;
+			HandleSelectedContentChanged(new List<ContentItemDescriptor>());
+			Model.OnSelectedContentChanged += HandleSelectedContentChanged; ;
 
 			//
 			Model.OnFilterChanged += Model_OnFilterChanged;
@@ -179,7 +179,7 @@ namespace Beamable.Editor.Content.Components
 			RenderTokens();
 		}
 
-		private void Model_OnSelectedContentChanged(IList<ContentItemDescriptor> contentItemDescriptors)
+		private void HandleSelectedContentChanged(IList<ContentItemDescriptor> contentItemDescriptors)
 		{
 			// Set the Selected Content
 			_selectedContentItemDescriptor = contentItemDescriptors.FirstOrDefault();

--- a/client/Packages/com.beamable/Editor/UI/Content/ContentManagerWindow.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/ContentManagerWindow.cs
@@ -61,7 +61,6 @@ namespace Beamable.Editor.Content
 			if (ActiveContext == null) return;
 
 			_actionBarVisualElement?.RefreshPublishDropdownVisibility();
-			_explorerElement?.RefreshManifestButton();
 		}
 
 
@@ -86,10 +85,9 @@ namespace Beamable.Editor.Content
 			ContentIO.OnManifestChanged -= OnManifestChanged;
 		}
 
-		private void HandleRealmChange(RealmView realm) => Refresh();
+		private void HandleRealmChange(RealmView realm) => EditorApplication.delayCall += Refresh;
 		private void HandleUserChange(User user) => Refresh();
 		private void OnManifestChanged(string manifestId) => SoftReset();
-
 
 		public void Refresh()
 		{


### PR DESCRIPTION
# Brief Description

It does fix the visible issue but it does not fix the main issue: if we switch realm and create and initialize new ManifestModel and try to getAllManifestIDs from ContentIO it returns manifests for previously selected realm. I managed to reduce damage by adding delay in `ContentManagerWindow.HandleRealmChange`- now it works fine in that case.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
