### PR TITLE
[BEAM-2419] Fast access to the admin flow triggers TMP error

### DIFF
--- a/client/Packages/com.beamable/Runtime/Modules/Console/ConsoleFlow.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/Console/ConsoleFlow.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.UI;
 using static Beamable.Common.Constants.URLs;
@@ -187,17 +188,10 @@ namespace Beamable.Console
 			// Hacky method to prevent NullReferenceException in UnityEngine.UI.InputField.GenerateCaret
 			// Delay prevents the user from interacting with the console before all UI components are configured
 			// Sadly, Unity won't fix this problem
-			StartCoroutine(Delay(0.1f, () =>
-			{
-				_isInitialized = true;
-				Log("Console ready");
-			}));
+			await Task.Delay(100);
 			
-			IEnumerator Delay(float delayTime, Action onDelayFinish)
-			{
-				yield return new WaitForSeconds(delayTime);
-				onDelayFinish?.Invoke();
-			}
+			_isInitialized = true;
+			Log("Console ready");
 		}
 
 		/// <summary>


### PR DESCRIPTION
# Brief Description

Hacky method to prevent `NullReferenceException` in `UnityEngine.UI.InputField.GenerateCaret`. Delay prevents the user from interacting with the console before all UI components are configured. Sadly, Unity won't fix this problem.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
