### PR TITLE
[BEAM-2574] 1.2 Blocker - MMV2 - No visual info that service is currently running 

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Components/ServiceBaseVisualElement/ServiceBaseVisualElement.dark.uss
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/ServiceBaseVisualElement/ServiceBaseVisualElement.dark.uss
@@ -81,6 +81,11 @@
     background-image: resource("Packages/com.beamable.server/Editor/UI/Icons/Start all L.png");
 }
 
+.building #buildImage,
+.running #buildImage {
+    background-image: resource("Packages/com.beamable.server/Editor/UI/Icons/PlayButton_Active_L.png");
+}
+
 
 .foldIcon {
     background-image: resource("Packages/com.beamable.server/Editor/UI/Icons/fold_light_dark.png");


### PR DESCRIPTION
# Brief Description
Added missing style to uss dark. We don't currently have a different icon for dark mode --- as such, for 1.2, I say we use the Light one for now.

### Building:
![image](https://user-images.githubusercontent.com/92586258/168287986-641671db-71fb-4562-a5d4-2496a92d4771.png)

### Started:
![image](https://user-images.githubusercontent.com/92586258/168288041-e4c53b84-a6c6-4216-9404-6b27a0aa1839.png)



# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
