### PR TITLE
beam 2525 - split content tag on commas

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Microservice Manager buttons now highlight on hover.
 - Beamable third party context systems register with a default order of -1000.
 - Global style sheet is turned now into a list of global style sheets.
+- Content tags are split on `','` characters in addition to `' '`s.
 
 ### Fixed
 - StoreView prefab now works in landscape mode.

--- a/client/Packages/com.beamable/Editor/Modules/Content/UI/ContentObjectEditor.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/UI/ContentObjectEditor.cs
@@ -148,7 +148,7 @@ namespace Beamable.Editor.Content.UI
 
 		public string[] GetTagsFromString(string tagString)
 		{
-			return tagString?.Split(new[] { " " }, StringSplitOptions.RemoveEmptyEntries) ?? new string[0];
+			return tagString?.Split(new[] { " ", "," }, StringSplitOptions.RemoveEmptyEntries) ?? new string[0];
 		}
 	}
 #endif


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2525

# Brief Description
We were only splitting on spaces; so I added a comma to the splitter. 
![tags](https://user-images.githubusercontent.com/3848374/168623777-218c7a14-7a7d-4ac1-a8f2-7dab2e4940eb.gif)

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
