### PR TITLE
beam 2662 - content sorting button positioning

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Common/Components/ManifestButtonVisualElement/ManifestButtonVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/ManifestButtonVisualElement/ManifestButtonVisualElement.cs
@@ -82,6 +82,7 @@ namespace Beamable.Editor.UI.Components
 		public void RefreshButtonVisibility()
 		{
 			visible = (_manyManifests && ContentConfiguration.Instance.EnableMultipleContentNamespaces) || _nonDefaultManifest;
+			EnableInClassList("hidden", !visible);
 			ContentConfiguration.Instance.multipleContentNamespacesSettingLocked = ContentConfiguration.Instance.EditorManifestID != DEFAULT_MANIFEST_ID;
 		}
 

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/ManifestButtonVisualElement/ManifestButtonVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/ManifestButtonVisualElement/ManifestButtonVisualElement.uss
@@ -31,6 +31,9 @@
     border-bottom-left-radius: 3px;
     border-top-left-radius: 3px;
 }
+#manifestButton.hidden {
+    width: 0px;
+}
 #manifestButton {
     justify-content: center;
 }


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2662

# Brief Description
When there are no content namespace options, the content sorter should be right aligned. I did that just by setting the width to 0 for the namespace button when its hidden.


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [X] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
