### PR TITLE
beam 2659 - content sorter styles

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Content/Components/BreadcrumbsVisualElement/BreadcrumbsVisualElement.light.uss
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/BreadcrumbsVisualElement/BreadcrumbsVisualElement.light.uss
@@ -2,3 +2,12 @@ BreadcrumbsVisualElement #mainVisualElement {
     background-color: #8d8d8d;
 }
 
+
+#contentSorter {
+    border-color: #6C6C6C;
+    background-color: #b4b4b4;
+}
+
+#contentSorter Image#dropDownIcon{
+    background-image: resource("Packages/com.beamable/Editor/UI/Content/Icons/dropdown Close Dark.png")
+}

--- a/client/Packages/com.beamable/Editor/UI/Content/Components/BreadcrumbsVisualElement/BreadcrumbsVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/BreadcrumbsVisualElement/BreadcrumbsVisualElement.uss
@@ -54,6 +54,10 @@ BreadcrumbsVisualElement #realmButton{
 	border-top-width: 1px;
 	border-bottom-width: 1px;
 	border-color:#8f8f8f;
+	background-image: none;
+}
+Button#contentSorter {
+	background-image: none;
 }
 
 #contentSorter > Label {


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2659

# Brief Description
There were missing styles to support the look & feel for light mode.

<img width="320" alt="image" src="https://user-images.githubusercontent.com/3848374/169108888-d0a15cb8-c7d6-4f8f-be8d-edae3ee8e01d.png">

<img width="309" alt="image" src="https://user-images.githubusercontent.com/3848374/169109710-0427ea6e-a880-41d4-96de-94e372926f80.png">

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
