### PR TITLE
beam 2762 - allow disposing services to access services up to the end

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Beamable third party context systems register with a default order of -1000.
 - Global style sheet is turned now into a list of global style sheets.
 - Content tags are split on `','` characters in addition to `' '`s.
+- A `IBeamableDisposable`'s `OnDispose` method can now resolve services from the `IDependencyProvider` that is being disposed.
 
 ### Fixed
 - StoreView prefab now works in landscape mode.

--- a/client/Packages/com.beamable/Common/Runtime/Dependencies/DependencyProvider.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Dependencies/DependencyProvider.cs
@@ -136,6 +136,7 @@ namespace Beamable.Common.Dependencies
 		private Dictionary<Type, object> ScopeCache { get; set; } = new Dictionary<Type, object>();
 
 		private bool _destroyed;
+		private bool _isDestroying;
 
 		public bool IsDisposed => _destroyed;
 		public IEnumerable<ServiceDescriptor> TransientServices => Transients.Values;
@@ -220,9 +221,8 @@ namespace Beamable.Common.Dependencies
 		// ReSharper disable Unity.PerformanceAnalysis
 		public async Promise Dispose()
 		{
-			if (_destroyed) return; // don't dispose twice!
-
-			_destroyed = true;
+			if (_isDestroying || _destroyed) return; // don't dispose twice!
+			_isDestroying = true;
 			var disposalPromises = new List<Promise<Unit>>();
 
 			// remove from parent.
@@ -265,11 +265,13 @@ namespace Beamable.Common.Dependencies
 
 			SingletonCache.Clear();
 			ScopeCache.Clear();
+			_destroyed = true;
 		}
 
 		public void Hydrate(IDependencyProviderScope other)
 		{
 			_destroyed = other.IsDisposed;
+			_isDestroying = false;
 			Transients = other.TransientServices.ToDictionary(desc => desc.Interface);
 			Scoped = other.ScopedServices.ToDictionary(desc => desc.Interface);
 			Singletons = other.SingletonServices.ToDictionary(desc => desc.Interface);


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2672

# Brief Description
The issue described in the ticket was happening because as the `BeamContext` was being torn apart via the "RESET" command, it was calling `OnDispose` on a bunch of various deps. Part of the pubnub teardown now uses the DI system to pull out a player specific `Subscription` class. The issue is that it modifies some state on that object _as part of its teardown_, but the old code would throw an exception when anything tried to resolve a service from a context that was destroyed.
But this felt like a design flaw, because technically, the scope isn't _quite_ destroyed; its just on its way out.

So I made it so that calls to `GetService` are still allowed until the _end_ of the dispose call.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
