### PR TITLE
[BEAM-2616] Fix finding new asmdef asset

### DIFF
--- a/client/Packages/com.beamable.server/Editor/MicroserviceEditor.cs
+++ b/client/Packages/com.beamable.server/Editor/MicroserviceEditor.cs
@@ -199,6 +199,7 @@ namespace Beamable.Server.Editor
 				if (!string.IsNullOrWhiteSpace(asmName) && additionalReferences != null &&
 				    additionalReferences.Count != 0)
 				{
+					// TODO TD000001 Code for adding dependencies to microservice require additional Assets refresh 
 					AssetDatabase.StopAssetEditing();
 					AssetDatabase.Refresh();
 					AssetDatabase.StartAssetEditing();


### PR DESCRIPTION
# Ticket

The issue was the fact that we just created assembly definition asset and we tried to find it in asset database even after we specified at the beggining of the method that we do not want to update asset database during that method run.

# Brief Description

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
