### PR TITLE
[BEAM-2665] MS Publish window logs clipping fix

### DIFF
--- a/client/Packages/com.beamable/Common/Runtime/Constants/Implementations/ServiceConstants.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Constants/Implementations/ServiceConstants.cs
@@ -34,7 +34,7 @@ namespace Beamable.Common
 				public const string STORAGE_IMAGE_CLASS = "storageImage";
 				public const string CHECKBOX_TOOLTIP = "Enable/disable the service";
 
-				public const float DEFAULT_ROW_HEIGHT = 55.0f;
+				public const float DEFAULT_ROW_HEIGHT = 56.0f;
 				public const int MAX_ROW = 6;
 				public static readonly Vector2 MIN_SIZE = new Vector2(900, 440);
 				public const float ROW_HEIGHT = 65;


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2665

# Brief Description
In some cases publish window was too small to fit all services and logs. In effect lower edge of logs element was disappearing. Fixed that by making window min size bigger.
Tested in Unity 2019, 2020 and 2021 light and dark modes.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
