### PR TITLE
[BEAM-2673] Beam Assistant hint UI glitch

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/BeamableAssistant/BeamableAssistantWindow.uss
+++ b/client/Packages/com.beamable/Editor/UI/BeamableAssistant/BeamableAssistantWindow.uss
@@ -110,7 +110,7 @@ ScrollView > #unity-content-viewport > #unity-content-container {
 }
 
 #hintTypeBlank{
-    width: 80px;
+    max-width: 80px;
     height: 20px;
     flex: 1;
 }


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/jira/software/projects/BEAM/boards/108?selectedIssue=BEAM-2673

# Brief Description
The search field in Beam Assistant window was overlapping the "Hint ID" title text when the window was not wide enough.
Solved by making the title text margin flex.
Tested in Unity 2019, 2020 and 2021

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
