### PR TITLE
SDF image - pixels per unit fix for unity 2018

### DIFF
--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Sdf/SdfImage.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Sdf/SdfImage.cs
@@ -162,14 +162,10 @@ namespace Beamable.UI.Sdf
 
 			var slicedSprite = NineSliceSourceSprite;
 
-#if UNITY_2019_1_OR_NEWER
-			var ppu = slicedSprite.pixelsPerUnit * pixelsPerUnitMultiplier;
-#else
-			var ppu = slicedSprite.pixelsPerUnit;
-#endif
-			
-			ImageMeshUtility.Calculate9SliceValue(slicedSprite, size, rectTransform.pivot, ppu,
-				out var positions, out var uvs, out var coords);
+			float ppu = GetPixelsPerUnit(slicedSprite);
+
+ImageMeshUtility.Calculate9SliceValue(slicedSprite, size, rectTransform.pivot, ppu,
+                                      out var positions, out var uvs, out var coords);
 
 			var bgRect = GetNormalizedSpriteRect(secondaryTexture);
 			bool isBackgroundSliced = IsNineSliceFromBackgroundTexture;
@@ -267,6 +263,15 @@ namespace Beamable.UI.Sdf
 				+ Mathf.Max(
 					Mathf.Abs(shadowOffset.x),
 					Mathf.Abs(shadowOffset.y)));
+		}
+
+		private float GetPixelsPerUnit(Sprite slicedSprite) {
+#if UNITY_2019_1_OR_NEWER
+			var ppu = slicedSprite.pixelsPerUnit * pixelsPerUnitMultiplier;
+#else
+			var ppu = slicedSprite.pixelsPerUnit;
+#endif
+			return ppu;
 		}
 
 		public enum ImageType


### PR DESCRIPTION
# Ticket

# Brief Description
There is no pixelsPerUnit multiplier in Unity 2018, so is shouldn't be controlled via BUSS.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
