### PR TITLE
[Beam-2671] 1.2 Blocker - New Leaderboard Flow NRE on playmode 

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Config/BeamableSettingsProvider.cs
+++ b/client/Packages/com.beamable/Editor/UI/Config/BeamableSettingsProvider.cs
@@ -1,3 +1,4 @@
+using Beamable.Editor.UI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,19 +18,17 @@ namespace Beamable.Editor.Config
 {
 	public static class BeamableSettingsProvider
 	{
-
 		[MenuItem(
-		   MenuItems.Windows.Paths.MENU_ITEM_PATH_WINDOW_BEAMABLE + "/" +
-		   Commons.OPEN + " " +
-		   MenuItems.Windows.Names.CONFIG_MANAGER,
-		   priority = MenuItems.Windows.Orders.MENU_ITEM_PATH_WINDOW_PRIORITY_2
+			MenuItems.Windows.Paths.MENU_ITEM_PATH_WINDOW_BEAMABLE + "/" +
+			Commons.OPEN + " " +
+			MenuItems.Windows.Names.CONFIG_MANAGER,
+			priority = MenuItems.Windows.Orders.MENU_ITEM_PATH_WINDOW_PRIORITY_2
 		)]
 		public static void Open()
 		{
 			ConfigManager.Initialize(forceCreation: true);
 			SettingsService.OpenProjectSettings("Project/Beamable");
 		}
-
 
 		[SettingsProvider]
 		public static SettingsProvider CreateBeamableProjectSettings()
@@ -47,23 +46,18 @@ namespace Beamable.Editor.Config
 							if (ConfigManager.MissingAnyConfiguration)
 							{
 								var createButton = new Button(() =>
-						   {
-							   Open();
-							   SettingsService.NotifySettingsProviderChanged();
-						   })
 								{
-									text = "Create Beamable Config Files"
-								};
+									Open();
+									SettingsService.NotifySettingsProviderChanged();
+								}) {text = "Create Beamable Config Files"};
 								var missingConfigs =
-							  string.Join(",\n", ConfigManager.MissingConfigurations.Select(d => $" - {d.Name}"));
-								var lbl = new Label()
-								{
-									text = $"Welcome to Beamable! These configurations need to be created:\n{missingConfigs}"
-								};
+									string.Join(",\n", ConfigManager.MissingConfigurations.Select(d => $" - {d.Name}"));
+								var lbl = new Label() {text = $"Welcome to Beamable! These configurations need to be created:\n{missingConfigs}"};
 								lbl.AddTextWrapStyle();
 								rootElement.Add(lbl);
 								rootElement.Add(createButton);
 							}
+
 							var options = ConfigManager.GenerateOptions();
 
 							var scroller = new ScrollView();
@@ -78,7 +72,7 @@ namespace Beamable.Editor.Config
 							AssetDatabase.Refresh();
 						}
 					},
-					keywords = new HashSet<string>(new[] { "Beamable" })
+					keywords = new HashSet<string>(new[] {"Beamable"})
 				};
 
 				return provider;
@@ -90,40 +84,56 @@ namespace Beamable.Editor.Config
 			}
 		}
 
+		public static SettingsProvider[] provider;
+
 		[SettingsProviderGroup]
 		public static SettingsProvider[] CreateBeamableProjectModuleSettings()
 		{
-			try
-			{
-				ConfigManager.Initialize(); // re-initialize every time the window is activated, so that we make sure the SO's always exist.
+			DelayCall(false);
 
-				var providers = ConfigManager.ConfigObjects.Select(config =>
+			void DelayCall(bool notifyIfFound)
+			{
+				if (!BeamEditor.IsInitialized)
 				{
-					var options = ConfigManager.GenerateOptions(config);
-					var provider = new SettingsProvider($"Project/Beamable/{options[0].Module}", SettingsScope.Project)
+					EditorApplication.delayCall += () => DelayCall(true);
+					return;
+				}
+
+				try
+				{
+					ConfigManager.Initialize(); // re-initialize every time the window is activated, so that we make sure the SO's always exist.
+
+					var providers = ConfigManager.ConfigObjects.Select(config =>
 					{
-						activateHandler = (searchContext, rootElement) =>
-					{
-						options = ConfigManager.GenerateOptions(config);
-						var scroller = new ScrollView();
-						rootElement.AddStyleSheet($"{BASE_UI_PATH}/ConfigWindow.uss");
-						rootElement.Add(scroller);
-						ConfigWindow.CreateFields(scroller, null, options, false);
-					},
+						var options = ConfigManager.GenerateOptions(config);
+						var settingsProvider = new SettingsProvider($"Project/Beamable/{options[0].Module}", SettingsScope.Project)
+						{
+							activateHandler = (searchContext, rootElement) =>
+							{
+								options = ConfigManager.GenerateOptions(config);
+								var scroller = new ScrollView();
+								rootElement.AddStyleSheet($"{BASE_UI_PATH}/ConfigWindow.uss");
+								rootElement.Add(scroller);
+								ConfigWindow.CreateFields(scroller, null, options, false);
+							},
+							keywords = new HashSet<string>(options.Select(o => o.Name))
+						};
 
-						keywords = new HashSet<string>(options.Select(o => o.Name))
-					};
+						return settingsProvider;
+					}).ToArray();
 
-					return provider;
-				}).ToArray();
+					provider = providers;
+				}
+				catch (Exception ex)
+				{
+					Debug.LogException(ex);
+				}
 
-				return providers;
+				if (notifyIfFound)
+					SettingsService.NotifySettingsProviderChanged();
 			}
-			catch (Exception ex)
-			{
-				Debug.LogException(ex);
-				return null;
-			}
+
+			return provider;
 		}
 	}
 }


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2671

# Brief Description
Fixed issue with BeamableSettingsProvider that caused NRE when domain reloading with Settings window opened.

Wasn't actually a Leaderboard problem --- just happened to be thrown while it was on the scene. Real problem was caused because the Settings window was open when entered play-mode. It's that damn "AssetDatabase is not available at the time of Unity Editor callbacks error" again... Solve was similar, but requires a redraw trigger of the settings window when it opens it up.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
