### PR TITLE
[BEAM-2657] Org alias and content namespaces should not accept only dashes

### DIFF
--- a/client/Packages/com.beamable/Common/Runtime/Api/AliasHelper.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/AliasHelper.cs
@@ -27,7 +27,14 @@ namespace Beamable.Common.Api
 		public static void ValidateAlias(string alias)
 		{
 			if (string.IsNullOrWhiteSpace(alias)) return;
-			if (IsCid(alias)) throw new ArgumentException(nameof(alias) + " is a cid");
+			if (IsCid(alias))
+			{
+				throw new ArgumentException(nameof(alias) + " is a cid");
+			}
+			if (alias.Contains(" "))
+			{
+				throw new ArgumentException(nameof(alias) + " cannot contain whitespaces");
+			}
 		}
 
 		/// <summary>

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/PrimaryButtonVisualElement/PrimaryButtonVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/PrimaryButtonVisualElement/PrimaryButtonVisualElement.cs
@@ -27,6 +27,7 @@ namespace Beamable.Editor.UI.Components
 		private List<FormConstraint> _constraints = new List<FormConstraint>();
 
 		private const string CLASS_NAME_REGEX = "^[A-Za-z_][A-Za-z0-9_]*$";
+		private const string ALIAS_AND_MANIFEST_NAME_REGEX = @"(^[0-9]*$)|(^[a-z][a-z0-9\-]*$)";
 
 		public string Text { get; private set; }
 
@@ -263,22 +264,8 @@ namespace Beamable.Editor.UI.Components
 		public static bool IsSlug(string slug)
 		{
 			if (slug == null) return false;
-			return slug.Length > 1 && GenerateSlug(slug).Equals(slug.Trim());
+			return slug.Length > 1 && Regex.IsMatch(slug, ALIAS_AND_MANIFEST_NAME_REGEX);
 		}
-
-		public static string GenerateSlug(string phrase)
-		{
-			string str = phrase.ToLower().Trim();
-			// invalid chars
-			str = Regex.Replace(str, @"^\d+", ""); // remove leading numbers..
-			str = Regex.Replace(str, @"[^a-z0-9\s-]", "");
-			// convert multiple spaces into one space
-			str = Regex.Replace(str, @"\s+", " ").Trim();
-			// cut and trim
-			str = Regex.Replace(str, @"\s", "-").Trim(); // hyphens
-			return str;
-		}
-
 		public static bool IsGameNameValid(string gameName, out string errorMessage)
 		{
 			errorMessage = string.Empty;

--- a/client/Packages/com.beamable/Tests/Editor/AliasHelperTests.cs
+++ b/client/Packages/com.beamable/Tests/Editor/AliasHelperTests.cs
@@ -34,6 +34,7 @@ namespace Beamable.Editor.Tests
 		[TestCase("a124")]
 		[TestCase("tuna-fish")]
 		[TestCase("a01a")]
+		[TestCase("a-b-c")]
 		[TestCase("")]
 		public void ValidAlias(string alias)
 		{
@@ -43,6 +44,15 @@ namespace Beamable.Editor.Tests
 
 		[TestCase("0123")]
 		[TestCase("123")]
+		[TestCase("t- test")]
+		[TestCase("t e s t")]
+		[TestCase("0 1 2 3")]
+		[TestCase("   test")]
+		[TestCase("   test-abc")]
+		[TestCase("   012-abc")]
+		[TestCase("   012-345")]
+		[TestCase("555test")]
+		[TestCase("555test-444-kek")]
 		public void InvalidAlias(string alias)
 		{
 			Assert.Throws<ArgumentException>(() =>


### PR DESCRIPTION
# [Ticket](https://disruptorbeam.atlassian.net/browse/BEAM-2657)

# Brief Description

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
