### PR TITLE
[BEAM-2513] User can enter previous dates on Event and Listing Schedule

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Schedules/EventDatesScheduleModel.cs
+++ b/client/Packages/com.beamable/Editor/UI/Schedules/EventDatesScheduleModel.cs
@@ -2,6 +2,7 @@
 using Beamable.Editor.UI.Components;
 using Beamable.Editor.UI.Validation;
 using System;
+using System.Collections.Generic;
 
 namespace Beamable.Editor.Models.Schedules
 {
@@ -16,6 +17,8 @@ namespace Beamable.Editor.Models.Schedules
 
 		public override WindowMode Mode => WindowMode.Dates;
 
+		private Action<bool, string> _refreshConfirmButtonCallback;
+
 		public EventDatesScheduleModel(LabeledTextField descriptionComponent,
 			LabeledHourPickerVisualElement startTimeComponent,
 			LabeledCalendarVisualElement calendarComponent, LabeledCheckboxVisualElement neverExpiresComponent,
@@ -29,11 +32,15 @@ namespace Beamable.Editor.Models.Schedules
 			_activeToDateComponent = activeToDateComponent;
 			_activeToHourComponent = activeToHourComponent;
 
+			_refreshConfirmButtonCallback = refreshConfirmButtonCallback;
+			
 			Validator = new ComponentsValidator(refreshConfirmButtonCallback);
-			Validator.RegisterRule(new AtLeastOneDaySelectedRule(_calendarComponent.Label),
-				_calendarComponent);
+			Validator.RegisterRule(new AtLeastOneDaySelectedRule(_calendarComponent.Label), _calendarComponent);
+			
+			_calendarComponent.Calendar.OnValueChanged -= AdditionalValidation;
+			_calendarComponent.Calendar.OnValueChanged += AdditionalValidation;
 		}
-
+		
 		public override Schedule GetSchedule()
 		{
 			Schedule newSchedule = new Schedule();
@@ -45,6 +52,12 @@ namespace Beamable.Editor.Models.Schedules
 				_calendarComponent.SelectedDays);
 
 			return newSchedule;
+		}
+
+		private void AdditionalValidation(List<string> selectedDays)
+		{
+			AdditionalScheduleValidation.ValidatePastDates(selectedDays, _refreshConfirmButtonCallback);
+			Validator.ForceValidationCheck();
 		}
 	}
 }

--- a/client/Packages/com.beamable/Editor/UI/Schedules/ListingDatesScheduleModel.cs
+++ b/client/Packages/com.beamable/Editor/UI/Schedules/ListingDatesScheduleModel.cs
@@ -2,6 +2,7 @@
 using Beamable.Editor.UI.Components;
 using Beamable.Editor.UI.Validation;
 using System;
+using System.Collections.Generic;
 
 namespace Beamable.Editor.Models.Schedules
 {
@@ -15,6 +16,8 @@ namespace Beamable.Editor.Models.Schedules
 		private readonly LabeledCheckboxVisualElement _allDayComponent;
 		private readonly LabeledHourPickerVisualElement _periodFromHourComponent;
 		private readonly LabeledHourPickerVisualElement _periodToHourComponent;
+		
+		private Action<bool, string> _refreshConfirmButtonCallback;
 
 		public ListingDatesScheduleModel(LabeledTextField descriptionComponent,
 			LabeledCalendarVisualElement calendarComponent, LabeledCheckboxVisualElement neverExpiresComponent,
@@ -31,8 +34,13 @@ namespace Beamable.Editor.Models.Schedules
 			_periodFromHourComponent = periodFromHourComponent;
 			_periodToHourComponent = periodToHourComponent;
 
+			_refreshConfirmButtonCallback = refreshConfirmButton;
+			
 			Validator = new ComponentsValidator(refreshConfirmButton);
 			Validator.RegisterRule(new AtLeastOneDaySelectedRule(_calendarComponent.Label), _calendarComponent);
+			
+			_calendarComponent.Calendar.OnValueChanged -= AdditionalValidation;
+			_calendarComponent.Calendar.OnValueChanged += AdditionalValidation;
 		}
 
 		public override WindowMode Mode => WindowMode.Dates;
@@ -69,6 +77,12 @@ namespace Beamable.Editor.Models.Schedules
 			}
 
 			return newSchedule;
+		}
+
+		private void AdditionalValidation(List<string> selectedDays)
+		{
+			AdditionalScheduleValidation.ValidatePastDates(selectedDays, _refreshConfirmButtonCallback);
+			Validator.ForceValidationCheck();
 		}
 	}
 }

--- a/client/Packages/com.beamable/Editor/UI/Validation/AdditionalScheduleValidation.cs
+++ b/client/Packages/com.beamable/Editor/UI/Validation/AdditionalScheduleValidation.cs
@@ -1,0 +1,33 @@
+﻿using Beamable.Editor.UI.Validation;
+using System;
+using System.Collections.Generic;
+
+namespace Beamable.Editor.Models.Schedules
+{
+	public static class AdditionalScheduleValidation
+	{
+		/// <summary>
+		/// The validation will fail if the scheduled dates contain past dates (before DateTime.UtcNow)
+		/// </summary>
+		public static void ValidatePastDates(List<string> selectedDays, Action<bool, string> refreshConfirmButton)
+		{
+			int todayTimeStamp = int.Parse(DateTime.UtcNow.ToString("yyyyMMdd"));
+			
+			foreach (var selectedDay in selectedDays)
+			{
+				var splitted = selectedDay.Split('-');
+				var year = splitted[2];
+				var month = splitted[1].Length == 1 ? $"0{splitted[1]}" : splitted[1];
+				var day = splitted[0].Length == 1 ? $"0{splitted[0]}" : splitted[0];
+				var timeStamp = int.Parse($"{year}{month}{day}");
+
+				if (timeStamp < todayTimeStamp)
+				{
+					refreshConfirmButton?.Invoke(false, "Date cannot be past");
+					return;
+				}
+			}
+			refreshConfirmButton?.Invoke(true, string.Empty);
+		}
+	}
+}

--- a/client/Packages/com.beamable/Editor/UI/Validation/AdditionalScheduleValidation.cs.meta
+++ b/client/Packages/com.beamable/Editor/UI/Validation/AdditionalScheduleValidation.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 66d64d88a1d144e4a6e8a8c6f077a889
+timeCreated: 1654171940


### PR DESCRIPTION
# [Ticket](https://disruptorbeam.atlassian.net/browse/BEAM-2513)

# Brief Description
It's not the best solution but the current validation architecture is a huge blocker in this case. At the moment I think it's fine enough but I created a tech debt ticket to fix it in the near future.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [x] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
