### PR TITLE
[BEAM-2724] VSP - Double click non downloaded content item causes null

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ContentListVisualElement/ContentListVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ContentListVisualElement/ContentListVisualElement.cs
@@ -243,8 +243,7 @@ namespace Beamable.Editor.Content.Components
 		{
 			if (string.IsNullOrEmpty(contentItemDescriptor.AssetPath))
 			{
-				Debug.LogError(new Exception("ListView_OnItemChosen() Error : " +
-											 "no AssetPath for " + contentItemDescriptor.Name));
+				Debug.LogWarning($"The selected content=[{contentItemDescriptor.Name}] does not exist locally. First, download the content from the server to be able to edit it.");
 				return;
 			}
 


### PR DESCRIPTION
# [Ticket](https://disruptorbeam.atlassian.net/browse/BEAM-2724)

# Brief Description
I changed the log type from error to warning and adjusted description to inform users, that they need to fetch content first to be able to edit it.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
