### PR TITLE
[BEAM-2759] Content Reflection Cache breaks on builds

### DIFF
--- a/client/Packages/com.beamable/Common/Runtime/Content/ContentTypeReflectionCache.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Content/ContentTypeReflectionCache.cs
@@ -81,19 +81,23 @@ namespace Beamable.Common.Content
 
 				validationResults.SplitValidationResults(out var valid, out var warnings, out var errors);
 
+#if UNITY_EDITOR
 				// Warning level validations that happen for the content type attribute.
 				if (warnings.Count > 0)
 				{
 					var hint = new BeamHintHeader(BeamHintType.Hint, BeamHintDomains.BEAM_CONTENT_CODE_MISUSE, BeamHintIds.ID_CONTENT_TYPE_ATTRIBUTE_MISSING);
 					_hintStorage.AddOrReplaceHint(hint, warnings);
 				}
+#endif
 
+#if UNITY_EDITOR
 				// Error level validations that happen for the content type attribute.
 				if (errors.Count > 0)
 				{
 					var hint = new BeamHintHeader(BeamHintType.Validation, BeamHintDomains.BEAM_CONTENT_CODE_MISUSE, BeamHintIds.ID_INVALID_CONTENT_TYPE_ATTRIBUTE);
 					_hintStorage.AddOrReplaceHint(hint, errors);
 				}
+#endif
 
 				contentTypeAttributePairs.AddRange(valid.Select(a => a.Pair));
 			}
@@ -106,12 +110,14 @@ namespace Beamable.Common.Content
 
 				validationResults.SplitValidationResults(out var valid, out _, out var errors);
 
+#if UNITY_EDITOR
 				// Error validation for attributes placed on invalid classes/types over which they have no effect.
 				if (errors.Count > 0)
 				{
 					var hint = new BeamHintHeader(BeamHintType.Validation, BeamHintDomains.BEAM_CONTENT_CODE_MISUSE, BeamHintIds.ID_INVALID_CONTENT_FORMERLY_SERIALIZED_AS_ATTRIBUTE);
 					_hintStorage.AddOrReplaceHint(hint, errors);
 				}
+#endif
 
 				formerContentTypeAttributePairs.AddRange(valid.Where(a => a.Pair.Attribute != null).Select(a => a.Pair));
 			}
@@ -127,19 +133,23 @@ namespace Beamable.Common.Content
 																						 out _,
 																						 out var errors);
 
+#if UNITY_EDITOR
 				// Print out any errors due to incorrect names
 				if (errors.Count > 0)
 				{
 					var hint = new BeamHintHeader(BeamHintType.Validation, BeamHintDomains.BEAM_CONTENT_CODE_MISUSE, BeamHintIds.ID_INVALID_CONTENT_TYPE_ATTRIBUTE);
 					_hintStorage.AddOrReplaceHint(hint, errors);
 				}
+#endif
 
+#if UNITY_EDITOR
 				// Print out any errors due to name collisions.
 				if (nameValidationResults.PerNameCollisions.Count > 0)
 				{
 					var hint = new BeamHintHeader(BeamHintType.Validation, BeamHintDomains.BEAM_CONTENT_CODE_MISUSE, BeamHintIds.ID_CONTENT_TYPE_NAME_COLLISION);
 					_hintStorage.AddOrReplaceHint(hint, nameValidationResults.PerNameCollisions);
 				}
+#endif
 
 				var contentTypeToClassDict = new Dictionary<string, Type>();
 				var classToContentTypeDict = new Dictionary<Type, string>();

--- a/client/Packages/com.beamable/Runtime/Beam.cs
+++ b/client/Packages/com.beamable/Runtime/Beam.cs
@@ -30,6 +30,7 @@ using Beamable.Common.Api.Notifications;
 using Beamable.Common.Api.Presence;
 using Beamable.Common.Api.Tournaments;
 using Beamable.Common.Assistant;
+using Beamable.Common.Content;
 using Beamable.Common.Dependencies;
 using Beamable.Common.Reflection;
 using Beamable.Config;
@@ -95,7 +96,11 @@ namespace Beamable
 				ReflectionCache.RegisterTypeProvider(reflectionSystemObject.TypeProvider);
 				ReflectionCache.RegisterReflectionSystem(reflectionSystemObject.System);
 			}
-
+			// Add non-ScriptableObject-based Reflection-Cache systems into the pipeline.
+			var contentReflectionCache = new ContentTypeReflectionCache();
+			ReflectionCache.RegisterTypeProvider(contentReflectionCache);
+			ReflectionCache.RegisterReflectionSystem(contentReflectionCache);
+			
 			// Also initializes the Reflection Cache system with it's IBeamHintGlobalStorage instance when in the editor. When not in the editor, the storage should really not
 			// be used and
 			// Finally, calls the Generate Reflection cache


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2759

# Brief Description
registered content in Beam.cs's reflection cache; added UNITY_EDITOR defines around hint storage;

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
