### PR TITLE
[BEAM-2602] Toolbox don't refresh after user login/logout

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Login/UI/LoginWindow.cs
+++ b/client/Packages/com.beamable/Editor/UI/Login/UI/LoginWindow.cs
@@ -92,6 +92,7 @@ namespace Beamable.Editor.Login.UI
 
 		public static LoginWindow Instance { get; private set; }
 		public static bool IsInstantiated { get { return Instance != null; } }
+		public static bool IsDomainReloaded { get { return Instance != null && Instance.LoginManager?.OnComplete?.IsCompleted == false; } }
 		private VisualElement _windowRoot;
 
 		public LoginManager LoginManager;

--- a/client/Packages/com.beamable/Editor/UI/NoUser/NoUserVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/NoUser/NoUserVisualElement.cs
@@ -37,6 +37,14 @@ namespace Beamable.Editor.NoUser
 				});
 			};
 			this.Add(_root);
+			
+			if (LoginWindow.IsDomainReloaded) // domain reload fix when LoginWindow was opened
+			{
+				LoginWindow.CheckLogin().Then(_ =>
+				{
+					OnLoginCheckComplete?.Invoke();
+				});
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Ticket
Domain reload case during async method CheckLogin call.

My repro:

- open login view
- change code/reload domain (login view is still visible)
- after login/logout toolbox view don't refresh

# Brief Description

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
