### PR TITLE
beam 2543 - change toolbar extender logic around preview packages

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -16,18 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Latest update` field for content item in Content Manager.
 - Content items sort option by `Recently updated` in Content Manager.
 - `Window/Beamable/Utilities/Change Environment` path to change the Beamable host parameters
+- Added "experimental" package status support to the `PackageVersion` utility
 
 ### Changed
 - Fields of auto-properties with attribute SerializeField are now serialized for content classes under the name of the property.
 - List of available to create `ContentTypes` in `Content Manager` contextual menu is now ordered alphabetically
 - The Beamable host URL is no longer sourced from `config-defaults.txt`. Instead, it comes from the `BeamableEnvironment` class. 
+- Changed `PackageVersion` to accept "preview" prefix strings instead of requiring a direct match of the string "preview"
 
-## [1.2.4]
-no changes
-
-## [1.2.3]
-### Changed
-- Content query strings are no longer case sensitive
+### Fixed
+- Beamable button in Unity toolbar should be in correct position for production packages
 
 ## [1.2.4]
 no changes

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Environment/PackageVersionTests/FromSemanticVersionStringTests.cs
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Environment/PackageVersionTests/FromSemanticVersionStringTests.cs
@@ -9,14 +9,15 @@ namespace Beamable.Tests.Runtime.Environment.PackageVersionTests
 		[Test]
 		public void CanParse_Prod()
 		{
-			var version = PackageVersion.FromSemanticVersionString("0.17.1");
-			Assert.AreEqual(0, version.Major);
+			var version = PackageVersion.FromSemanticVersionString("1.17.1");
+			Assert.AreEqual(1, version.Major);
 			Assert.AreEqual(17, version.Minor);
 			Assert.AreEqual(1, version.Patch);
 			Assert.AreEqual(0, version.RC);
 			Assert.AreEqual(0, version.NightlyTime);
 			Assert.AreEqual(false, version.IsNightly);
 			Assert.AreEqual(false, version.IsReleaseCandidate);
+			Assert.AreEqual(false, version.IsExperimental);
 			Assert.AreEqual(false, version.IsPreview);
 		}
 
@@ -31,6 +32,7 @@ namespace Beamable.Tests.Runtime.Environment.PackageVersionTests
 			Assert.AreEqual(0, version.NightlyTime);
 			Assert.AreEqual(false, version.IsNightly);
 			Assert.AreEqual(false, version.IsReleaseCandidate);
+			Assert.AreEqual(false, version.IsExperimental);
 			Assert.AreEqual(false, version.IsPreview);
 		}
 
@@ -45,48 +47,114 @@ namespace Beamable.Tests.Runtime.Environment.PackageVersionTests
 			Assert.AreEqual(0, version.NightlyTime);
 			Assert.AreEqual(false, version.IsNightly);
 			Assert.AreEqual(false, version.IsReleaseCandidate);
+			Assert.AreEqual(false, version.IsExperimental);
 			Assert.AreEqual(false, version.IsPreview);
 		}
 
 		[Test]
 		public void CanParse_RC()
 		{
-			var version = PackageVersion.FromSemanticVersionString("0.16.0-PREVIEW.RC3");
-			Assert.AreEqual(0, version.Major);
+			var version = PackageVersion.FromSemanticVersionString("1.16.0-PREVIEW.RC3");
+			Assert.AreEqual(1, version.Major);
 			Assert.AreEqual(16, version.Minor);
 			Assert.AreEqual(0, version.Patch);
 			Assert.AreEqual(3, version.RC);
 			Assert.AreEqual(0, version.NightlyTime);
 			Assert.AreEqual(false, version.IsNightly);
 			Assert.AreEqual(true, version.IsReleaseCandidate);
+			Assert.AreEqual(false, version.IsExperimental);
 			Assert.AreEqual(true, version.IsPreview);
 		}
 
 		[Test]
 		public void CanParse_RC2()
 		{
-			var version = PackageVersion.FromSemanticVersionString("0.16.3-PREVIEW.RC19");
-			Assert.AreEqual(0, version.Major);
+			var version = PackageVersion.FromSemanticVersionString("1.16.3-PREVIEW.RC19");
+			Assert.AreEqual(1, version.Major);
 			Assert.AreEqual(16, version.Minor);
 			Assert.AreEqual(3, version.Patch);
 			Assert.AreEqual(19, version.RC);
 			Assert.AreEqual(0, version.NightlyTime);
 			Assert.AreEqual(false, version.IsNightly);
 			Assert.AreEqual(true, version.IsReleaseCandidate);
+			Assert.AreEqual(false, version.IsExperimental);
 			Assert.AreEqual(true, version.IsPreview);
 		}
 
 		[Test]
 		public void CanParse_Nightly()
 		{
-			var version = PackageVersion.FromSemanticVersionString("0.0.0-PREVIEW.NIGHTLY-202101081800");
-			Assert.AreEqual(0, version.Major);
+			var version = PackageVersion.FromSemanticVersionString("1.0.0-PREVIEW.NIGHTLY-202101081800");
+			Assert.AreEqual(1, version.Major);
 			Assert.AreEqual(0, version.Minor);
 			Assert.AreEqual(0, version.Patch);
 			Assert.AreEqual(0, version.RC);
 			Assert.AreEqual(202101081800, version.NightlyTime);
 			Assert.AreEqual(true, version.IsNightly);
 			Assert.AreEqual(false, version.IsReleaseCandidate);
+			Assert.AreEqual(false, version.IsExperimental);
+			Assert.AreEqual(true, version.IsPreview);
+		}
+
+		[Test]
+		public void CanParse_Exp_Implicit_0Major()
+		{
+			var version = PackageVersion.FromSemanticVersionString("0.1.2");
+			Assert.AreEqual(0, version.Major);
+			Assert.AreEqual(1, version.Minor);
+			Assert.AreEqual(2, version.Patch);
+			Assert.AreEqual(0, version.RC);
+			Assert.AreEqual(0, version.NightlyTime);
+			Assert.AreEqual(false, version.IsNightly);
+			Assert.AreEqual(false, version.IsReleaseCandidate);
+			Assert.AreEqual(true, version.IsExperimental);
+			Assert.AreEqual(false, version.IsPreview);
+		}
+
+		[Test]
+		public void CanParse_Exp_Explicit()
+		{
+			var version = PackageVersion.FromSemanticVersionString("1.1.2-exp.12");
+			Assert.AreEqual(1, version.Major);
+			Assert.AreEqual(1, version.Minor);
+			Assert.AreEqual(2, version.Patch);
+			Assert.AreEqual(0, version.RC);
+			Assert.AreEqual(0, version.NightlyTime);
+			Assert.AreEqual(false, version.IsNightly);
+			Assert.AreEqual(false, version.IsReleaseCandidate);
+			Assert.AreEqual(false, version.IsPreview);
+			Assert.AreEqual(true, version.IsExperimental);
+
+		}
+
+		[Test]
+		public void CanParse_Preview()
+		{
+			var version = PackageVersion.FromSemanticVersionString("1.1.2-pre");
+			Assert.AreEqual(1, version.Major);
+			Assert.AreEqual(1, version.Minor);
+			Assert.AreEqual(2, version.Patch);
+			Assert.AreEqual(0, version.RC);
+			Assert.AreEqual(0, version.NightlyTime);
+			Assert.AreEqual(false, version.IsNightly);
+			Assert.AreEqual(false, version.IsReleaseCandidate);
+			Assert.AreEqual(false, version.IsExperimental);
+			Assert.AreEqual(true, version.IsPreview);
+		}
+
+
+		[Test]
+		public void CanParse_Preview_WithSuffix()
+		{
+			var version = PackageVersion.FromSemanticVersionString("1.1.2-pre.32");
+			Assert.AreEqual(1, version.Major);
+			Assert.AreEqual(1, version.Minor);
+			Assert.AreEqual(2, version.Patch);
+			Assert.AreEqual(0, version.RC);
+			Assert.AreEqual(0, version.NightlyTime);
+			Assert.AreEqual(false, version.IsNightly);
+			Assert.AreEqual(false, version.IsReleaseCandidate);
+			Assert.AreEqual(false, version.IsExperimental);
 			Assert.AreEqual(true, version.IsPreview);
 		}
 	}


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2543

# Brief Description
It seems to be the case that the `verified` version strings are _only_ used by Unity, and that we don't have a chance of getting verified, maybe ever, lol. 
But also, they clearly don't use the verified field to decide if there are preview packages in use, because in this screenshot, there aren't any preview packages declared.
<img width="943" alt="image" src="https://user-images.githubusercontent.com/3848374/176280224-d9ac866d-e36e-4f0a-bd4c-e3c0d147533e.png">

So, I changed the logic in our detection to say, "if there are any packages with versions that would be preview _according to Unity's [docs_](https://docs.unity3d.com/Manual/upm-lifecycle.html), then its a preview". 


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
