### PR TITLE
beam 2800 - adds cid and pid to IBeamableRequester

### DIFF
--- a/cli/cli/Services/CliRequester.cs
+++ b/cli/cli/Services/CliRequester.cs
@@ -11,8 +11,8 @@ public class CliRequester : IBeamableRequester
 {
 	private readonly IAppContext _ctx;
 	public IAccessToken AccessToken => _ctx.Token;
-	private string Pid => AccessToken.Pid;
-	private string Cid => AccessToken.Cid;
+	public string Pid => AccessToken.Pid;
+	public string Cid => AccessToken.Cid;
 
 	public CliRequester(IAppContext ctx)
 	{

--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Content items sort option by `Recently updated` in Content Manager.
 - `Window/Beamable/Utilities/Change Environment` path to change the Beamable host parameters
 - Added "experimental" package status support to the `PackageVersion` utility
+- Adds `Cid` and `Pid` field to `IBeamableRequester` interface
 
 ### Changed
 - Fields of auto-properties with attribute SerializeField are now serialized for content classes under the name of the property.

--- a/client/Packages/com.beamable/Common/Runtime/Api/IBeamableRequester.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/IBeamableRequester.cs
@@ -38,6 +38,16 @@ namespace Beamable.Common.Api
 		IAccessToken AccessToken { get; }
 
 		/// <summary>
+		/// The customer id associated with this requester
+		/// </summary>
+		string Cid { get; }
+
+		/// <summary>
+		/// The project id associated with this requester
+		/// </summary>
+		string Pid { get; }
+
+		/// <summary>
 		/// Make an authorized request to the Beamable API.
 		/// </summary>
 		/// <param name="method">One of the common HTTP methods represented through the <see cref="Method"/> enum</param>

--- a/client/Packages/com.beamable/Common/Runtime/Api/Realms/RealmService.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/Realms/RealmService.cs
@@ -34,7 +34,7 @@ namespace Beamable.Common.Api.Realms
 
 		public Promise<List<RealmView>> GetGames()
 		{
-			if (string.IsNullOrEmpty(_requester.AccessToken.Cid))
+			if (string.IsNullOrEmpty(_requester.Cid))
 			{
 				return Promise<List<RealmView>>.Failed(new Exception("No Cid Available"));
 			}
@@ -59,24 +59,24 @@ namespace Beamable.Common.Api.Realms
 
 		public Promise<RealmView> GetRealm()
 		{
-			if (string.IsNullOrEmpty(_requester.AccessToken.Cid))
+			if (string.IsNullOrEmpty(_requester.Cid))
 			{
 				return Promise<RealmView>.Failed(new RealmServiceException("No Cid Available"));
 			}
 
-			if (string.IsNullOrEmpty(_requester.AccessToken.Pid))
+			if (string.IsNullOrEmpty(_requester.Pid))
 			{
 				return Promise<RealmView>.Successful(null);
 			}
 
-			return GetRealms().Map(all => { return all.Find(v => v.Pid == _requester.AccessToken.Pid); });
+			return GetRealms().Map(all => { return all.Find(v => v.Pid == _requester.Pid); });
 		}
 
 		private List<RealmView> ProcessProjects(List<ProjectViewDTO> projects)
 		{
 			var map = projects.Select(p => new RealmView
 			{
-				Cid = _requester.AccessToken.Cid,
+				Cid = _requester.Cid,
 				Pid = p.pid,
 				ProjectName = p.projectName,
 				Archived = p.archived,
@@ -128,7 +128,7 @@ namespace Beamable.Common.Api.Realms
 
 		public Promise<List<RealmView>> GetRealms(RealmView game = null)
 		{
-			var pid = game?.Pid ?? _requester.AccessToken.Pid ?? _requester.AccessToken?.Pid;
+			var pid = game?.Pid ?? _requester.Pid ?? _requester?.Pid;
 			return GetRealms(pid);
 		}
 

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/BeamableApiRequester.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/BeamableApiRequester.cs
@@ -25,6 +25,8 @@ namespace Core.Platform.SDK
 		public IAccessToken AccessToken => Token;
 		public string TimeOverride { get; set; }
 		public string Language { get; set; }
+		public string Cid => Token.Cid;
+		public string Pid => Token.Pid;
 
 		private bool _disposed;
 

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/PlatformRequester.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/PlatformRequester.cs
@@ -20,8 +20,8 @@ namespace Beamable.Api
 	{
 		AccessToken Token { get; set; }
 		string TimeOverride { get; set; }
-		string Cid { get; set; }
-		string Pid { get; set; }
+		new string Cid { get; set; }
+		new string Pid { get; set; }
 		string Language { get; set; }
 		IAuthApi AuthService { set; }
 		void DeleteToken();

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Platform/MockPlatformRequester.cs
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Platform/MockPlatformRequester.cs
@@ -14,6 +14,9 @@ namespace Beamable.Platform.Tests
 		public AuthService AuthApi { get; set; }
 		public IAccessToken AccessToken { get; set; }
 
+		public string Cid => AccessToken.Cid;
+		public string Pid => AccessToken.Pid;
+
 		public delegate Promise<T> RequestJsonFunction<T>(Method method, string uri, JsonSerializable.ISerializable body,
 		   bool includeAuthHeader = true);
 

--- a/microservice/microservice/dbmicroservice/MicroserviceRequester.cs
+++ b/microservice/microservice/dbmicroservice/MicroserviceRequester.cs
@@ -342,6 +342,8 @@ namespace Beamable.Server
 
       // TODO how do we handle Timeout errors?
       // TODO what does concurrency look like?
+      public string Cid => _requestContext.Cid;
+      public string Pid => _requestContext.Pid;
 
       public MicroserviceRequester(IMicroserviceArgs env, RequestContext requestContext, SocketRequesterContext socketContext)
       {


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2800

# Brief Description
I goofed when I moved the `RealmService` into the common library in order to access it from the CLI. When I did that, I changed its cid/pid access to use the access token's cid/pid. Turns out that was a mistake, because the client-code that uses stores the cid/pid differently, and not in the access token during init. So I added the Cid/Pid as top level properties, and leave it to the sub implementations for how to handle it.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
