### PR TITLE
beam 2725 - fix currency hud bug

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Beamable button in Unity toolbar should be in correct position for production packages
+- CurrencyHUD no longer throws null reference error when associated currency content has no addressable icon. 
 
 ## [1.2.4]
 no changes

--- a/client/Packages/com.beamable/Runtime/UI/Scripts/AddressableSpriteLoader.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/AddressableSpriteLoader.cs
@@ -87,13 +87,14 @@ namespace Beamable.UI.Scripts
 
 		/// <summary>
 		/// Given a sprite asset reference, fetch its texture.
+		/// If the given <see cref="AssetReferenceSprite"/> isn't valid or doesn't exist, the resulting texture will be null.
 		/// </summary>
 		/// <param name="reference">The addressable sprite.</param>
 		/// <returns>The 2D texture of that sprite.</returns>
 		public static Promise<Texture2D> LoadTexture(this AssetReferenceSprite reference)
 		{
 			if (!reference.RuntimeKeyIsValid())
-				return Promise<Texture2D>.Failed(null);
+				return Promise<Texture2D>.Successful(null);
 
 			var sprite = LoadSprite(reference);
 			return sprite?.Map(s =>


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2725

# Brief Description
We used to return a failed promise, which sort of makes logical sense, but because we were `awaiting` it, we would have needed to try/catch to receive the exception, and then interpret it. In this case, interpreting the exception was just, "use a null texture anyway", so I figured it'd save everyone some angst if we just returned a successful promise with a null texture.

Now in this picture, notice that
1. the game is running, there is valid currency value in the game view's Currency HUD
2. the content has no addressable icon, and therefor, the icon is a null white sprite
3. there are no errors in the console
<img width="943" alt="image" src="https://user-images.githubusercontent.com/3848374/176951397-4b033978-0166-48d0-b8e0-f63cc12d2b92.png">


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
