### PR TITLE
beam 2769 - removed warnings and disabled nullable

### DIFF
--- a/cli/cli/CommandContext.cs
+++ b/cli/cli/CommandContext.cs
@@ -9,7 +9,7 @@ public abstract class AppCommand<TArgs> : Command
 {
 	private List<Action<BindingContext, TArgs>> _bindingActions = new List<Action<BindingContext, TArgs>>();
 
-	protected AppCommand(string name, string? description = null) : base(name, description)
+	protected AppCommand(string name, string description = null) : base(name, description)
 	{
 	}
 
@@ -103,7 +103,7 @@ public interface ICommandFactory
 
 }
 
-public class CommandFactory<T> : ICommandFactory where T : Command
+public class CommandFactory : ICommandFactory
 {
 
 }

--- a/cli/cli/DependencyInjectionExtensions.cs
+++ b/cli/cli/DependencyInjectionExtensions.cs
@@ -22,7 +22,7 @@ public static class DependencyInjectionExtensions
 		collection.AddSingleton<ICommandFactory>(provider =>
 		{
 			// TODO: Benchmark this init. Even if its 2ms, thats too slow for when the CLI grows to cover the entire Beamable backend. (2ms * 100 commands = too long)
-			var factory = new CommandFactory<TCommand>();
+			var factory = new CommandFactory();
 			var root = provider.GetRequiredService<TBaseCommand>();
 			var command = provider.GetRequiredService<TCommand>();
 

--- a/cli/cli/Services/IAppContext.cs
+++ b/cli/cli/Services/IAppContext.cs
@@ -1,11 +1,8 @@
 using Beamable.Common;
 using Beamable.Common.Api;
 using Beamable.Common.Api.Auth;
-using Newtonsoft.Json;
 using Serilog.Events;
-using System.CommandLine;
 using System.CommandLine.Binding;
-using System.Diagnostics;
 
 namespace cli;
 
@@ -13,9 +10,9 @@ public interface IAppContext
 {
 	public bool IsDryRun { get; }
 	public LogEventLevel LogLevel { get; }
-	public string? Cid { get; }
-	public string? Pid { get; }
-	public string? Host { get; }
+	public string Cid { get; }
+	public string Pid { get; }
+	public string Host { get; }
 	public string WorkingDirectory { get; }
 	public IAccessToken Token { get; }
 
@@ -34,13 +31,11 @@ public class DefaultAppContext : IAppContext
 {
 	private readonly DryRunOption _dryRunOption;
 	private readonly CidOption _cidOption;
-	private readonly PasswordOption _passwordOption;
 	private readonly PidOption _pidOption;
 	private readonly PlatformOption _platformOption;
 	private readonly AccessTokenOption _accessTokenOption;
 	private readonly RefreshTokenOption _refreshTokenOption;
 	private readonly LogOption _logOption;
-	private readonly UsernameOption _usernameOption;
 	private readonly ConfigService _configService;
 	private readonly CliEnvironment _environment;
 	public bool IsDryRun { get; private set; }
@@ -48,11 +43,11 @@ public class DefaultAppContext : IAppContext
 	public IAccessToken Token => _token;
 	private CliToken _token;
 
-	private string? _cid, _pid, _host;
+	private string _cid, _pid, _host;
 
-	public string? Cid => _cid;
-	public string? Pid => _pid;
-	public string? Host => _host;
+	public string Cid => _cid;
+	public string Pid => _pid;
+	public string Host => _host;
 
 	public string WorkingDirectory { get; private set; }
 	public LogEventLevel LogLevel { get; private set; }
@@ -125,7 +120,7 @@ public class DefaultAppContext : IAppContext
 		_token.RefreshToken = response.refresh_token;
 	}
 
-	private bool TryGetSetting(out string? value, BindingContext context, ConfigurableOption option, string? defaultValue = null)
+	private bool TryGetSetting(out string value, BindingContext context, ConfigurableOption option, string defaultValue = null)
 	{
 		// Try to get from option
 		value = context.ParseResult.GetValueForOption(option);

--- a/cli/cli/cli.csproj
+++ b/cli/cli/cli.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
 
     <PackageId>Beamable.Tools</PackageId>
     <AssemblyName>Beamable.Tools</AssemblyName>

--- a/microservice/beamable.tooling.common/UnityJsonContractResolver.cs
+++ b/microservice/beamable.tooling.common/UnityJsonContractResolver.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -41,7 +38,7 @@ namespace Beamable.Server.Common
             BaseConverter = baseConverter;
         }
 
-        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             if (value is ISerializationCallbackReceiver receiver)
             {
@@ -50,7 +47,7 @@ namespace Beamable.Server.Common
             BaseConverter.WriteJson(writer, value, serializer);
         }
 
-        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             var result = BaseConverter.ReadJson(reader, objectType, existingValue, serializer);
             if (result is ISerializationCallbackReceiver receiver)
@@ -122,7 +119,7 @@ namespace Beamable.Server.Common
             return validFields.Cast<MemberInfo>().ToList();
         }
 
-        protected override JsonConverter? ResolveContractConverter(Type objectType)
+        protected override JsonConverter ResolveContractConverter(Type objectType)
         {
             var baseConverter = base.ResolveContractConverter(objectType);
             if (objectType.IsSubclassOf(typeof(ISerializationCallbackReceiver)))

--- a/microservice/beamable.tooling.common/beamable.tooling.common.csproj
+++ b/microservice/beamable.tooling.common/beamable.tooling.common.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+        <Nullable>disable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2769

# Brief Description
Basically, I removed the <nullable> option in the csproj, and a lot of warnings went away. I know we aren't using the latest and greatest, but I think we are okay. 

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
