### PR TITLE
beam 2807 - uncaught promise handler in C#MS

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Failed promises no longer log exception info after an exception handler is registered on the same execution cycle.
+- "Connection is closed" log exception no longer prints incorrectly.
+
 ## [1.2.4]
 ### Added
 - Microservices now support private declarations of `Callable` methods.

--- a/microservice/microservice/dbmicroservice/EasyWebSocket.cs
+++ b/microservice/microservice/dbmicroservice/EasyWebSocket.cs
@@ -1,1 +1,446 @@
-﻿#if DB_MICROSERVICEusing System;using System.Net.WebSockets;using System.Text;using System.Threading;using System.Threading.Tasks;using Beamable.Common;using Serilog;namespace Beamable.Server{    public class EasyWebSocketProvider : IConnectionProvider    {        public IConnection Create(string host)        {            var ws = EasyWebSocket.Create(host);            return ws;        }    }    public class EasyWebSocket : IConnection    {        private const int ReceiveChunkSize = 1024;        private const int SendChunkSize = 1024;        private readonly ClientWebSocket _ws;        private readonly Uri _uri;        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();        private readonly CancellationToken _cancellationToken;        private Action<EasyWebSocket> _onConnected;        private Action<EasyWebSocket, string, long> _onMessage;        private Action<EasyWebSocket, bool> _onDisconnected;        private long messageNumber = 0;        public WebSocketState State => _ws.State;        protected EasyWebSocket(string uri)        {            _ws = new ClientWebSocket();            _ws.Options.KeepAliveInterval = TimeSpan.FromSeconds(20);            _uri = new Uri(uri);            _cancellationToken = _cancellationTokenSource.Token;        }        /// <summary>        /// Creates a new instance.        /// </summary>        /// <param name="uri">The URI of the WebSocket server.</param>        /// <returns></returns>        public static EasyWebSocket Create(string uri)        {            return new EasyWebSocket(uri);        }        /// <summary>        /// Connects to the WebSocket server.        /// </summary>        /// <returns></returns>        public IConnection Connect()        {            var connectAsync = ConnectAsync();            connectAsync.Wait(_cancellationToken);            return this;        }        /// <summary>        /// Set the Action to call when the connection has been established.        /// </summary>        /// <param name="onConnect">The Action to call.</param>        /// <returns></returns>        public IConnection OnConnect(Action<IConnection> onConnect)        {            _onConnected += onConnect;            return this;        }        /// <summary>        /// Set the Action to call when the connection has been terminated.        /// </summary>        /// <param name="onDisconnect">The Action to call</param>        /// <returns></returns>        public IConnection OnDisconnect(Action<IConnection, bool> onDisconnect)        {            _onDisconnected += onDisconnect;            return this;        }        /// <summary>        /// Set the Action to call when a messages has been received.        /// </summary>        /// <param name="onMessage">The Action to call.</param>        /// <returns></returns>        public IConnection OnMessage(Action<IConnection, string, long> onMessage)        {            _onMessage = onMessage;            return this;        }        /// <summary>        /// Send a message to the WebSocket server.        /// </summary>        /// <param name="message">The message to send</param>        public Promise SendMessage(string message)        {            return SendMessageAsync(message);        }        /// <summary>        /// Terminate the socket in a friendly way.        /// </summary>        public async Task Close()        {            await _ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "shutting down", CancellationToken.None);        }        private async Promise SendMessageAsync(string message)        {            if (_ws.State != WebSocketState.Open)            {                throw new Exception("Connection is not open.");            }            var messageBuffer = Encoding.UTF8.GetBytes(message);            var messagesCount = (int)Math.Ceiling((double)messageBuffer.Length / SendChunkSize);            for (var i = 0; i < messagesCount; i++)            {                var offset = (SendChunkSize * i);                var count = SendChunkSize;                var lastMessage = ((i + 1) == messagesCount);                if ((count * (i + 1)) > messageBuffer.Length)                {                    count = messageBuffer.Length - offset;                }                await _ws.SendAsync(new ArraySegment<byte>(messageBuffer, offset, count), WebSocketMessageType.Text, lastMessage, _cancellationToken);            }        }        private async Task ConnectAsync()        {            try            {                await _ws.ConnectAsync(_uri, _cancellationToken);                CallOnConnected();            }            catch (Exception)            {                CallOnDisconnected(false);            }            StartListen();        }        private async void StartListen()        {            var buffer = new byte[ReceiveChunkSize];            try            {                while (_ws.State == WebSocketState.Open)                {                    var stringResult = new StringBuilder();                    WebSocketReceiveResult result;                    do                    {                        result = await _ws.ReceiveAsync(new ArraySegment<byte>(buffer), _cancellationToken);                        if (result.MessageType == WebSocketMessageType.Close)                        {                            await                                _ws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);                            CallOnDisconnected(true);                        }                        else                        {                            var str = Encoding.UTF8.GetString(buffer, 0, result.Count);                            stringResult.Append(str);                        }                    } while (!result.EndOfMessage);                    CallOnMessage(stringResult);                }            }            catch (Exception)            {                CallOnDisconnected(false);            }            finally            {                _ws.Dispose();                // attempt to reconnect....            }        }        private void CallOnMessage(StringBuilder stringResult)        {            if (_onMessage != null)            {                var next = Interlocked.Increment(ref messageNumber);                RunInTask(() => _onMessage(this, stringResult.ToString(), next));            }        }        private void CallOnDisconnected(bool wasClean)        {            if (_onDisconnected != null)                RunInTask(() => _onDisconnected(this, wasClean));        }        private void CallOnConnected()        {            if (_onConnected != null)                RunInTask(() => _onConnected(this));        }        private static void RunInTask(Action action)        {            Task.Factory.StartNew(action);        }    }}#endif
+﻿#if DB_MICROSERVICE
+
+using System;
+
+using System.Net.WebSockets;
+
+using System.Text;
+
+using System.Threading;
+
+using System.Threading.Tasks;
+using Beamable.Common;
+using Serilog;
+
+
+namespace Beamable.Server
+
+{
+
+    public class EasyWebSocketProvider : IConnectionProvider
+
+    {
+
+        public IConnection Create(string host)
+
+        {
+
+            var ws = EasyWebSocket.Create(host);
+
+            return ws;
+
+        }
+    }
+
+
+    public class EasyWebSocket : IConnection
+
+    {
+
+        private const int ReceiveChunkSize = 1024;
+
+        private const int SendChunkSize = 1024;
+
+
+
+        private readonly ClientWebSocket _ws;
+
+        private readonly Uri _uri;
+
+        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+
+        private readonly CancellationToken _cancellationToken;
+
+
+
+        private Action<EasyWebSocket> _onConnected;
+
+        private Action<EasyWebSocket, string, long> _onMessage;
+
+        private Action<EasyWebSocket, bool> _onDisconnected;
+
+
+
+        private long messageNumber = 0;
+
+
+        public WebSocketState State => _ws.State;
+
+
+        protected EasyWebSocket(string uri)
+
+        {
+
+            _ws = new ClientWebSocket();
+
+
+
+            _ws.Options.KeepAliveInterval = TimeSpan.FromSeconds(20);
+
+            _uri = new Uri(uri);
+
+            _cancellationToken = _cancellationTokenSource.Token;
+
+        }
+
+
+
+        /// <summary>
+
+        /// Creates a new instance.
+
+        /// </summary>
+
+        /// <param name="uri">The URI of the WebSocket server.</param>
+
+        /// <returns></returns>
+
+        public static EasyWebSocket Create(string uri)
+
+        {
+
+            return new EasyWebSocket(uri);
+
+        }
+
+
+
+        /// <summary>
+
+        /// Connects to the WebSocket server.
+
+        /// </summary>
+
+        /// <returns></returns>
+
+        public IConnection Connect()
+
+        {
+            var connectAsync = ConnectAsync();
+            connectAsync.Wait(_cancellationToken);
+            return this;
+
+        }
+
+
+        /// <summary>
+
+        /// Set the Action to call when the connection has been established.
+
+        /// </summary>
+
+        /// <param name="onConnect">The Action to call.</param>
+
+        /// <returns></returns>
+
+        public IConnection OnConnect(Action<IConnection> onConnect)
+
+        {
+
+            _onConnected += onConnect;
+
+            return this;
+
+        }
+
+
+
+        /// <summary>
+
+        /// Set the Action to call when the connection has been terminated.
+
+        /// </summary>
+
+        /// <param name="onDisconnect">The Action to call</param>
+
+        /// <returns></returns>
+
+        public IConnection OnDisconnect(Action<IConnection, bool> onDisconnect)
+
+        {
+
+            _onDisconnected += onDisconnect;
+
+            return this;
+
+        }
+
+
+
+        /// <summary>
+
+        /// Set the Action to call when a messages has been received.
+
+        /// </summary>
+
+        /// <param name="onMessage">The Action to call.</param>
+
+        /// <returns></returns>
+
+        public IConnection OnMessage(Action<IConnection, string, long> onMessage)
+
+        {
+
+            _onMessage = onMessage;
+
+            return this;
+
+        }
+
+
+
+        /// <summary>
+
+        /// Send a message to the WebSocket server.
+
+        /// </summary>
+
+        /// <param name="message">The message to send</param>
+
+        public Task SendMessage(string message)
+        {
+            return SendMessageAsync(message);
+        }
+
+
+
+        /// <summary>
+
+        /// Terminate the socket in a friendly way.
+
+        /// </summary>
+
+        public async Task Close()
+
+        {
+
+            await _ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "shutting down", CancellationToken.None);
+
+        }
+
+
+
+        private async Task SendMessageAsync(string message)
+        {
+            if (_ws.State != WebSocketState.Open)
+            {
+                throw new Exception($"Connection is not open. state=[{_ws.State}]");
+            }
+
+
+            var messageBuffer = Encoding.UTF8.GetBytes(message);
+
+            var messagesCount = (int)Math.Ceiling((double)messageBuffer.Length / SendChunkSize);
+
+
+
+            for (var i = 0; i < messagesCount; i++)
+
+            {
+
+                var offset = (SendChunkSize * i);
+
+                var count = SendChunkSize;
+
+                var lastMessage = ((i + 1) == messagesCount);
+
+
+
+                if ((count * (i + 1)) > messageBuffer.Length)
+
+                {
+
+                    count = messageBuffer.Length - offset;
+
+                }
+
+
+
+                await _ws.SendAsync(new ArraySegment<byte>(messageBuffer, offset, count), WebSocketMessageType.Text, lastMessage, _cancellationToken);
+
+            }
+
+        }
+
+
+
+        private async Task ConnectAsync()
+
+        {
+
+            try
+
+            {
+
+                await _ws.ConnectAsync(_uri, _cancellationToken);
+
+                CallOnConnected();
+
+            }
+
+            catch (Exception)
+
+            {
+
+                CallOnDisconnected(false);
+
+            }
+
+
+
+            StartListen();
+
+        }
+
+
+
+        private async void StartListen()
+
+        {
+
+            var buffer = new byte[ReceiveChunkSize];
+
+
+
+            try
+
+            {
+
+                while (_ws.State == WebSocketState.Open)
+
+                {
+
+                    var stringResult = new StringBuilder();
+
+
+
+
+
+                    WebSocketReceiveResult result;
+
+                    do
+
+                    {
+
+                        result = await _ws.ReceiveAsync(new ArraySegment<byte>(buffer), _cancellationToken);
+
+
+
+                        if (result.MessageType == WebSocketMessageType.Close)
+
+                        {
+
+
+
+                            await
+
+                                _ws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+
+                            CallOnDisconnected(true);
+
+                        }
+
+                        else
+
+                        {
+
+                            var str = Encoding.UTF8.GetString(buffer, 0, result.Count);
+
+                            stringResult.Append(str);
+
+                        }
+
+
+
+                    } while (!result.EndOfMessage);
+
+
+
+                    CallOnMessage(stringResult);
+
+
+
+                }
+
+            }
+
+            catch (Exception)
+
+            {
+
+                CallOnDisconnected(false);
+
+            }
+
+            finally
+
+            {
+
+                _ws.Dispose();
+
+                // attempt to reconnect....
+
+            }
+
+        }
+
+
+
+        private void CallOnMessage(StringBuilder stringResult)
+
+        {
+
+            if (_onMessage != null)
+
+            {
+
+                var next = Interlocked.Increment(ref messageNumber);
+
+                RunInTask(() => _onMessage(this, stringResult.ToString(), next));
+
+            }
+
+        }
+
+
+
+        private void CallOnDisconnected(bool wasClean)
+
+        {
+
+            if (_onDisconnected != null)
+
+                RunInTask(() => _onDisconnected(this, wasClean));
+
+        }
+
+
+
+        private void CallOnConnected()
+
+        {
+
+            if (_onConnected != null)
+
+                RunInTask(() => _onConnected(this));
+
+        }
+
+
+
+        private static void RunInTask(Action action)
+
+        {
+
+            Task.Factory.StartNew(action);
+
+        }
+
+
+
+    }
+
+}
+
+#endif
+

--- a/microservice/microservice/dbmicroservice/IConnection.cs
+++ b/microservice/microservice/dbmicroservice/IConnection.cs
@@ -1,1 +1,33 @@
-using System;using System.Net.WebSockets;using System.Threading.Tasks;using Beamable.Common;namespace Beamable.Server{   public interface IConnectionProvider   {      IConnection Create(string host);   }   public interface IConnection   {      IConnection Connect();      Task Close();      Promise SendMessage(string message);      IConnection OnConnect(Action<IConnection> onConnect);      IConnection OnDisconnect(Action<IConnection, bool> onDisconnect);      IConnection OnMessage(Action<IConnection, string, long> onMessage);      WebSocketState State { get; }   }}
+using System;
+using System.Net.WebSockets;
+using System.Threading.Tasks;
+using Beamable.Common;
+
+
+namespace Beamable.Server
+{
+   public interface IConnectionProvider
+   {
+      IConnection Create(string host);
+   }
+
+   public interface IConnection
+
+   {
+
+      IConnection Connect();
+
+      Task Close();
+
+      Task SendMessage(string message);
+
+      IConnection OnConnect(Action<IConnection> onConnect);
+
+      IConnection OnDisconnect(Action<IConnection, bool> onDisconnect);
+
+      IConnection OnMessage(Action<IConnection, string, long> onMessage);
+
+      WebSocketState State { get; }
+   }
+
+}

--- a/microservice/microserviceTests/PromiseTests/ErrorTests.cs
+++ b/microservice/microserviceTests/PromiseTests/ErrorTests.cs
@@ -1,0 +1,86 @@
+using Beamable.Common;
+using Beamable.Server;
+using Core.Server.Common;
+using microserviceTests.microservice.Util;
+using NUnit.Framework;
+using Serilog;
+using Serilog.Events;
+using Serilog.Formatting.Raw;
+using Serilog.Sinks.TestCorrelator;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace microserviceTests.PromiseTests;
+
+[TestFixture]
+public class ErrorTests
+{
+
+	[SetUp]
+	public void Setup()
+	{
+		BeamableLogProvider.Provider = new BeamableSerilogProvider();
+		Debug.Instance = new MicroserviceDebug();
+		// https://github.com/serilog/serilog/wiki/Configuration-Basics
+		Log.Logger = new LoggerConfiguration()
+			.MinimumLevel.Warning()
+			.WriteTo.TestCorrelator().CreateLogger();
+		BeamableSerilogProvider.LogContext.Value = Log.Logger;
+	}
+
+	[Test]
+	public async Task CaughtPromiseDoesNotLog()
+	{
+
+		MicroserviceBootstrapper.ConfigureUnhandledError();
+		var exception = new Exception("test failure");
+#pragma warning disable CS1998
+		async Promise SubMethod()
+#pragma warning restore CS1998
+		{
+			throw exception;
+		}
+
+		Promise Method()
+		{
+			return SubMethod();
+		}
+
+		var caughtException = default(Exception);
+		try
+		{
+			await Method();
+		}
+		catch (Exception ex)
+		{
+			caughtException = ex;
+		}
+
+		var logs = TestCorrelator.GetLogEventsFromCurrentContext().ToList();
+		Assert.IsEmpty(logs.Select(l => l.RenderMessage()));
+		Assert.AreEqual(caughtException, exception);
+	}
+
+
+	[Test]
+	public async Task UncaughtPromiseDoesLog()
+	{
+
+		MicroserviceBootstrapper.ConfigureUnhandledError();
+		var exception = new Exception("test failure");
+#pragma warning disable CS1998
+		async Promise SubMethod()
+#pragma warning restore CS1998
+		{
+			throw exception;
+		}
+
+		var _ = SubMethod();
+
+		await Task.Delay(10); // wait for the uncaught promises...
+		var logs = TestCorrelator.GetLogEventsFromCurrentContext().ToList();
+		Assert.IsNotEmpty(logs.Select(l => l.RenderMessage()));
+	}
+}

--- a/microservice/microserviceTests/microservice/TestSocket.cs
+++ b/microservice/microserviceTests/microservice/TestSocket.cs
@@ -835,7 +835,7 @@ namespace Beamable.Microservice.Tests.Socket
         }
 
         public bool MockIsConnectionOpen = true;
-        public async Promise SendMessage(string message)
+        public async Task SendMessage(string message)
         {
             if (!MockIsConnectionOpen)
             {

--- a/microservice/microserviceTests/microserviceTests.csproj
+++ b/microservice/microserviceTests/microserviceTests.csproj
@@ -34,6 +34,7 @@
         <PackageReference Include="NUnit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     </ItemGroup>
 
 <!--    <ItemGroup>-->


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2807

# Brief Description
2 things-
1. I changed the method return type from `Promise` to `Task` to avoid the nonsense, and I think it'll work. The nonsense was, 
2. when a `Promise` fails, it'll check if it has any error listeners. If it doesn't, it'll emit a "uncaught promise" event. The default handler in the C#MS was to immediately log an exception. The problem is that in an async/await context, if the method `throws` an exception, that immediately triggers the fail logic on the promise _before_ the `catch` code has been run that internally adds the `Error` listener. We have this problem on Unity land too, and the solve is to "wait a frame before yelling about uncaught promises". I did the same thing in the base image.  


We already have retry logic to handle a message sent to a closed socket. I think that the log was just happening due to the uncaught promise handler glitch.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
