### PR TITLE
beam 2770, log fixes, dispatcher fix

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `RemovePlayerEntry` for leaderboards API which allows to remove given player from the leaderboard
 - Added microservice archive/unarchive feature.
 
+### Changed
+- local microservice logs will appear for dotnet watch command
+
+### Fixed
+- Microservice related actions can run while Unity is a background process.
+
 ## [1.2.6]
 ### Added
 - `RemovePlayerEntry` for leaderboards API which allows to remove given player from the leaderboard

--- a/client/Packages/com.beamable.server/Editor/BuildUtils.cs
+++ b/client/Packages/com.beamable.server/Editor/BuildUtils.cs
@@ -1,4 +1,6 @@
+using Beamable.Editor.UI.Model;
 using Beamable.Server.Editor.CodeGen;
+using Beamable.Server.Editor.DockerCommands;
 using System;
 using System.IO;
 using UnityEngine;
@@ -24,10 +26,11 @@ namespace Beamable.Server.Editor
 				(new ProgramCodeGenerator(descriptor)).GenerateCSharpCode(programFilePath);
 				(new DockerfileGenerator(descriptor, includeDebugTools, watch)).Generate(dockerfilePath);
 				(new ProjectGenerator(descriptor, dependencies)).Generate(csProjFilePath);
-
 			}
 			catch (Exception ex)
 			{
+				BeamEditorContext.Default.ServiceScope.GetService<MicroservicesDataModel>()
+				                 .AddLogException(descriptor, ex);
 				Debug.LogException(ex);
 			}
 		}

--- a/client/Packages/com.beamable.server/Editor/DockerCommands/BuildImageCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/BuildImageCommand.cs
@@ -21,7 +21,7 @@ namespace Beamable.Server.Editor.DockerCommands
 		public bool IncludeDebugTools { get; }
 		public string ImageName { get; set; }
 		public string BuildPath { get; set; }
-		
+
 		public Promise<Unit> ReadyForExecution { get; private set; }
 
 		private Exception _constructorEx;
@@ -51,7 +51,7 @@ namespace Beamable.Server.Editor.DockerCommands
 			// build the Program file, and place it in the temp dir.
 			BuildUtils.PrepareBuildContext(descriptor, includeDebugTools, watch);
 		}
-		
+
 		protected override void ModifyStartInfo(ProcessStartInfo processStartInfo)
 		{
 			base.ModifyStartInfo(processStartInfo);
@@ -79,7 +79,7 @@ namespace Beamable.Server.Editor.DockerCommands
 			pullStr = ""; // we cannot force the pull against the local image.
 #endif
 			var platformStr = "";
-			
+
 #if !BEAMABLE_DISABLE_AMD_MICROSERVICE_BUILDS
 			platformStr = $"--platform {GetProcessArchitecture()}";
 #endif
@@ -89,7 +89,7 @@ namespace Beamable.Server.Editor.DockerCommands
 
 		protected override void HandleStandardOut(string data)
 		{
-			if (!MicroserviceLogHelper.HandleLog(_descriptor, UnityLogLabel, data))
+			if (string.IsNullOrEmpty(data) || !MicroserviceLogHelper.HandleLog(_descriptor, UnityLogLabel, data))
 			{
 				base.HandleStandardOut(data);
 			}
@@ -98,7 +98,7 @@ namespace Beamable.Server.Editor.DockerCommands
 
 		protected override void HandleStandardErr(string data)
 		{
-			if (!MicroserviceLogHelper.HandleLog(_descriptor, UnityLogLabel, data))
+			if (string.IsNullOrEmpty(data) || !MicroserviceLogHelper.HandleLog(_descriptor, UnityLogLabel, data))
 			{
 				base.HandleStandardErr(data);
 			}

--- a/client/Packages/com.beamable.server/Editor/DockerCommands/FollowLogCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/FollowLogCommand.cs
@@ -1,3 +1,7 @@
+using Beamable.Editor;
+using System;
+using UnityEngine;
+
 namespace Beamable.Server.Editor.DockerCommands
 {
 	public class FollowLogCommand : DockerCommand
@@ -5,16 +9,17 @@ namespace Beamable.Server.Editor.DockerCommands
 		private readonly IDescriptor _descriptor;
 		public string ContainerName { get; }
 
-
 		public FollowLogCommand(IDescriptor descriptor)
 		{
 			_descriptor = descriptor;
 			ContainerName = descriptor.ContainerName;
+			UnityLogLabel = null;
 		}
 
 		protected override void HandleStandardOut(string data)
 		{
-			if (!MicroserviceLogHelper.HandleLog(_descriptor, UnityLogLabel, data))
+			CheckFallbackTime(ref data, out var fallbackTime);
+			if (!MicroserviceLogHelper.HandleLog(_descriptor, UnityLogLabel, data, fallbackTime))
 			{
 				base.HandleStandardOut(data);
 			}
@@ -22,15 +27,56 @@ namespace Beamable.Server.Editor.DockerCommands
 
 		protected override void HandleStandardErr(string data)
 		{
-			if (!MicroserviceLogHelper.HandleLog(_descriptor, UnityLogLabel, data))
+			// the logs will always start with a timestamp, we just don't know how long it will be.
+
+			CheckFallbackTime(ref data, out var fallbackTime);
+			if (!MicroserviceLogHelper.HandleLog(_descriptor, UnityLogLabel, data, fallbackTime))
 			{
 				base.HandleStandardErr(data);
 			}
 		}
 
+		private void CheckFallbackTime(ref string data, out DateTime fallbackTime)
+		{
+			fallbackTime = default;
+			if (data != null)
+			{
+				var firstSpace = data.IndexOf(' ');
+				if (firstSpace > 0)
+				{
+					var timestampStr = data.Substring(0, firstSpace);
+					if (DateTime.TryParse(timestampStr, out fallbackTime))
+					{
+						data = data.Substring(firstSpace + 1); // consume the space.
+					}
+				}
+			}
+		}
+
 		public override string GetCommandString()
 		{
-			return $"{DockerCmd} logs {ContainerName} -f --since 0m";
+			/*
+			 * The logs command is meant to retrieve logs from a container that was started during a different compilation pass.
+			 * For example, start a microservice, then edit some client code, then go back to unity, then cause some service logs...
+			 * You'd expect to see those logs.
+			 *
+			 * That works!
+			 *
+			 * But here is an issue, because of hot-reload, if you edit the microservice code itself...
+			 * then Unity will do a recompile, and this follow command _won't_ run until Unity has finished compiling.
+			 * Unity is slow, and the dotnet watch command is much faster, so the logs that represent the microservice
+			 * recompiling will have finished by the time Unity runs this command.
+			 *
+			 * Which means, if we use a "--since 0m" flag (like we did in 1.2.6 and before), we'll MISS the important
+			 * logs saying the service is alive. It is alive, it'll just look sort of STUCK, because there are missing logs :/
+			 * Non deterministic missing logs are the worst kind.
+			 *
+			 *
+			 * So to fix that, we can use a "--since Nm" where N is some "reasonable" amount of time that a compile should take.
+			 * This will give us duplicate logs, so the logging window needs to be smart enough not to re-render duplicated logs.
+			 * We can achieve that by using the timestamp on the log itself. Don't render _old_ logs.
+			 */
+			return $"{DockerCmd} logs {ContainerName} -f -t --since 2m"; // a compile longer than 2m... sad.
 		}
 	}
 }

--- a/client/Packages/com.beamable.server/Editor/DockerCommands/ProcessCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/ProcessCommand.cs
@@ -187,14 +187,21 @@ namespace Beamable.Server.Editor.DockerCommands
 					_standardOutComplete = new TaskCompletionSource<int>();
 					EventHandler eh = (s, e) =>
 					{
-						// there still may pending log lines, so we need to make sure they get processed before claiming the process is complete
-						_hasExited = true;
-						_exitCode = _process.ExitCode;
+						Task.Run(async () =>
+						{
+							await Task.Delay(1); // give 1 ms for log messages to eep out
+							BeamEditorContext.Default.Dispatcher.Schedule(() =>
+							{
+								// there still may pending log lines, so we need to make sure they get processed before claiming the process is complete
+								_hasExited = true;
+								_exitCode = _process.ExitCode;
 
-						OnExit?.Invoke(_process.ExitCode);
-						HandleOnExit();
+								OnExit?.Invoke(_process.ExitCode);
+								HandleOnExit();
 
-						_status.TrySetResult(0);
+								_status.TrySetResult(0);
+							});
+						});
 					};
 
 					_process.Exited += eh;

--- a/client/Packages/com.beamable.server/Editor/DockerCommands/RunImageCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/RunImageCommand.cs
@@ -279,7 +279,7 @@ namespace Beamable.Server.Editor.DockerCommands
 			_descriptor = descriptor;
 			ImageName = imageName;
 			ContainerName = containerName;
-
+			UnityLogLabel = null;
 			Environment = env ?? new Dictionary<string, string>();
 			Ports = ports ?? new Dictionary<uint, uint>();
 			NamedVolumes = namedVolumes ?? new Dictionary<string, string>();
@@ -288,7 +288,7 @@ namespace Beamable.Server.Editor.DockerCommands
 
 		protected override void HandleStandardOut(string data)
 		{
-			if (_descriptor == null || !MicroserviceLogHelper.HandleLog(_descriptor, UnityLogLabel, data))
+			if (_descriptor == null || data == null || !MicroserviceLogHelper.HandleLog(_descriptor, UnityLogLabel, data))
 			{
 				base.HandleStandardOut(data);
 			}
@@ -296,7 +296,7 @@ namespace Beamable.Server.Editor.DockerCommands
 		}
 		protected override void HandleStandardErr(string data)
 		{
-			if (_descriptor == null || !MicroserviceLogHelper.HandleLog(_descriptor, UnityLogLabel, data))
+			if (_descriptor == null || data == null || !MicroserviceLogHelper.HandleLog(_descriptor, UnityLogLabel, data))
 			{
 				base.HandleStandardErr(data);
 			}

--- a/client/Packages/com.beamable.server/Editor/UI/MicroserviceWindow.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/MicroserviceWindow.cs
@@ -73,7 +73,7 @@ namespace Beamable.Editor.Microservice.UI
 			minSize = new Vector2(550, 200);
 
 			checkDockerPromise = new CheckDockerCommand().StartAsync();
-			await checkDockerPromise;
+				await checkDockerPromise;
 
 			void OnUserChange(EditorUser _) => BuildWithContext();
 			void OnRealmChange(RealmView _) => _microserviceContentVisualElement?.StopAllServices(true, RealmSwitchDialog.TITLE, RealmSwitchDialog.MESSAGE, RealmSwitchDialog.OK);

--- a/client/Packages/com.beamable.server/Editor/UI/Model/MicroservicesDataModel.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Model/MicroservicesDataModel.cs
@@ -168,6 +168,16 @@ namespace Beamable.Editor.UI.Model
 
 		public void AddLogMessage(IDescriptor descriptor, LogMessage message) => AddLogMessage(descriptor.Name, message);
 
+		public void AddLogException(IDescriptor descriptor, Exception ex)
+		{
+			AddLogMessage(descriptor, new LogMessage
+			{
+				Level = LogLevel.ERROR,
+				Message = $"{ex.GetType().Name} - {ex.Message}\n{ex.StackTrace}",
+				Timestamp = LogMessage.GetTimeDisplay(DateTime.Now),
+			});
+		}
+
 		public ServiceStatus GetStatus(MicroserviceDescriptor descriptor)
 		{
 			return Status?.services?.FirstOrDefault(r => r.serviceName.Equals(descriptor.Name));

--- a/client/Packages/com.beamable/Editor/BeamEditor.cs
+++ b/client/Packages/com.beamable/Editor/BeamEditor.cs
@@ -511,6 +511,9 @@ namespace Beamable
 			requester.Host = BeamableEnvironment.ApiUrl;
 			ServiceScope.GetService<BeamableVsp>().TryToEmitAttribution("login"); // this will no-op if the package isn't a VSP package.
 
+			// pre-initialize the dispatcher to dodge having to make the dependency scope handling multi-threaded inserts
+			ServiceScope.GetService<BeamableDispatcher>();
+
 			async Promise Initialize()
 			{
 				// Attempts to login with recovery.

--- a/client/Packages/com.beamable/Editor/Utility/BeamableDispatcher.cs
+++ b/client/Packages/com.beamable/Editor/Utility/BeamableDispatcher.cs
@@ -10,7 +10,7 @@ namespace Beamable.Editor
 {
 	/// <summary>
 	/// The dispatcher allows you to enqueue work to happen on the main unity thread without waiting for editor render frames.
-	/// Use the <see cref="Schedule(System.Action)"/> method to schedule work. 
+	/// Use the <see cref="Schedule(System.Action)"/> method to schedule work.
 	/// </summary>
 	public class BeamableDispatcher : IBeamableDisposable
 	{
@@ -79,7 +79,7 @@ namespace Beamable.Editor
 
 			var queue = new Queue<Action>();
 			_workQueues.Add(queueName, queue);
-			var coroutine = EditorCoroutineUtility.StartCoroutineOwnerless(Scheduler(queueName, queue));
+			var coroutine = EditorCoroutineUtility.StartCoroutine(Scheduler(queueName, queue), this);
 			_runningSchedulers[queueName] = coroutine;
 			return true;
 		}


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2770

# Brief Description

There are a few things included in this PR. 

1. The actual fix for the ticket is pretty small; there is a try/catch around the build command's file operations, and if an exception happens, now we add an exception to the microservice's log store. That is nice.
2. The blank microservice manager window issue is fixed too, and there are a few separate issues that caused this. Number 1, because Docker gives callbacks back in different threads, when we reference the `BeamableDispatcher` from those threads, it was possible to confuse the `DependencyProvider` and generate _multiple_ instances of the `BeamableDispatcher`, which was no good. So instead of bending over backwards to get thread-safe support for the dependency provider, I followed Pedro's idea and just pre-init the `BeamableDispatcher`. Hooray! The second issue is that _sometimes_ the docker EXIT hook callback triggers before the STDOUT callback. This meant that the resolve function was running before the buffer had a chance to fill up with data. So I fixed this by adding a minor delay to the exit callback. 
3. There was an issue with the `FollowLogsCommand` that I wrote about in comments. The gist is that we miss logs that happen during a recompilation in Unity, which leads to a junky feeling. I solved this by getting logs from 2 minutes in the past, instead of 0, and then in the log store, filtering out logs that are sent before the highest seen time. 
4. I removed the random "Docker: " messages that were appearing- this was happening due to silly not-null checking. 


All in all, the log window feels a lot nicer with these changes.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
