### PR TITLE
beam 2832 - beam console works after reset

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Beamable button in Unity toolbar should be in correct position for production packages
 - Content validation callbacks now support invoking private methods in base classes
+- BeamConsole accepts events after RESET command
 
 ## [1.2.6]
 no changes

--- a/client/Packages/com.beamable/Runtime/Modules/BeamableModule.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/BeamableModule.cs
@@ -6,7 +6,7 @@ namespace Beamable
 {
 	public class BeamableModule : MonoBehaviour
 	{
-		void Start()
+		void OnEnable()
 		{
 			if (EventSystem.current == null && Application.isPlaying)
 			{


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2832

# Brief Description
What was happening, was that if you did a RESET on a basic scene that only had an AdminFlow in it, when the scene reloaded, you couldn't interact with the console.
This was because the EventSystem gameobject had been destroyed. We have code already that tries to create an EventSystem doesn't exist, so I just made it fire on the `OnEnable` instead of the `Start` method. 


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
