### PR TITLE
beam-2781 - adds realm scoped handling to old branch

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.6]
+### Fixed
+- Realm scoped permissions are now respected
+
 ## [0.18.5]
 ### Fixed
 - Deferred retry of failed uploads to the poll coroutine, to eliminate an infinite loop that could crash the app.

--- a/client/Packages/com.beamable/Editor/EditorAPI.cs
+++ b/client/Packages/com.beamable/Editor/EditorAPI.cs
@@ -80,6 +80,8 @@ namespace Beamable.Editor
       public RealmView Realm { get; private set; }
       public RealmView ProductionRealm { get; private set; }
 
+      public UserPermissions Permissions => User?.GetPermissionsForRealm(Realm.Pid) ?? new UserPermissions(null);
+
       public EditorUser User;
       public AccessToken Token => _requester.Token;
 
@@ -90,7 +92,7 @@ namespace Beamable.Editor
 
       private Promise<EditorAPI> Initialize()
       {
-         if (!Application.isPlaying) 
+         if (!Application.isPlaying)
          {
             var promiseHandlerConfig = CoreConfiguration.Instance.DefaultUncaughtPromiseHandlerConfiguration;
             switch (promiseHandlerConfig)
@@ -99,10 +101,10 @@ namespace Beamable.Editor
                {
                   if(!PromiseBase.HasUncaughtErrorHandler)
                      PromiseExtensions.RegisterBeamableDefaultUncaughtPromiseHandler();
-                        
+
                   break;
                }
-               case CoreConfiguration.EventHandlerConfig.Replace:                        
+               case CoreConfiguration.EventHandlerConfig.Replace:
                case CoreConfiguration.EventHandlerConfig.Add:
                {
                   PromiseExtensions.RegisterBeamableDefaultUncaughtPromiseHandler(promiseHandlerConfig == CoreConfiguration.EventHandlerConfig.Replace);

--- a/client/Packages/com.beamable/Editor/Modules/Account/EditorAuthService.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Account/EditorAuthService.cs
@@ -1,61 +1,169 @@
+using Beamable.Api;
 using Beamable.Api.Auth;
 using Beamable.Common;
 using Beamable.Common.Api;
 using Beamable.Common.Api.Auth;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine.Rendering;
 
 namespace Beamable.Editor.Modules.Account
 {
-   public interface IEditorAuthApi : IAuthService
-   {
-      Promise<EditorUser> GetUserForEditor();
-   }
+	public interface IEditorAuthApi : IAuthService
+	{
+		Promise<EditorUser> GetUserForEditor();
+	}
 
-   public class EditorAuthService : AuthService, IEditorAuthApi
-   {
-      public EditorAuthService(IBeamableRequester requester) : base(requester, new DefaultAuthSettings
-      {
-         PasswordResetCodeType = CodeType.PIN
-      })
-      {
+	public class EditorAuthService : AuthService, IEditorAuthApi
+	{
+		public EditorAuthService(IBeamableRequester requester) : base(requester, new DefaultAuthSettings
+		{
+			PasswordResetCodeType = CodeType.PIN
+		})
+		{
+			if (requester is PlatformRequester platformRequester)
+				platformRequester.AuthService = this;
+		}
 
-      }
+		// This API call will only work if made by editor code.
+		public Promise<EditorUser> GetUserForEditor()
+		{
+			return Requester.Request<EditorUser>(Method.GET, $"{ACCOUNT_URL}/admin/me", useCache: true);
+		}
+	}
 
-      // This API call will only work if made by editor code.
-      public Promise<EditorUser> GetUserForEditor()
-      {
-         return Requester.Request<EditorUser>(Method.GET, $"{ACCOUNT_URL}/admin/me", useCache:true);
-      }
-   }
+	[System.Serializable]
+	public class EditorUserRealmPermission
+	{
+		/// <summary>
+		/// The role will either be tester, developer, or admin
+		/// </summary>
+		public string role;
 
-   [System.Serializable]
-   public class EditorUser : User
-   {
-      public const string ADMIN_ROLE = "admin";
-      public const string DEVELOPER_ROLE = "developer";
-      public const string TESTER_ROLE = "tester";
+		/// <summary>
+		/// The pid specifies for which realm this permission applies. A user may be a tester on one realm, but an admin on another.
+		/// </summary>
+		public string projectId;
+	}
 
-      public string roleString;
+	[System.Serializable]
+	public class EditorUser : User
+	{
+		public const string ADMIN_ROLE = "admin";
+		public const string DEVELOPER_ROLE = "developer";
+		public const string TESTER_ROLE = "tester";
 
-      public bool IsAtLeastAdmin => string.Equals(roleString, ADMIN_ROLE);
-      public bool IsAtLeastDeveloper => IsAtLeastAdmin || string.Equals(roleString, DEVELOPER_ROLE);
-      public bool IsAtLeastTester => IsAtLeastDeveloper || string.Equals(roleString, TESTER_ROLE);
-      public bool HasNoRole => !IsAtLeastTester;
+		/// <summary>
+		/// The role will be either admin, developer or tester. This is the global role for the user for all realms. However, there
+		/// may be realm specific overrides in the <see cref="roles"/> list.
+		/// </summary>
+		public string roleString;
 
-      public bool CanPushContent => IsAtLeastDeveloper;
+		/// <summary>
+		/// The list of <see cref="EditorUserRealmPermission"/> describes the realm specific overrides for the users permissions.
+		/// By default, in every realm, the user will have the role assigned in the  <see cref="roleString"/> field. However, this
+		/// list may contain realm specific overrides that grant the user higher or lower privileges in the given realm.
+		/// </summary>
+		public List<EditorUserRealmPermission> roles = new List<EditorUserRealmPermission>();
 
-      public EditorUser()
-      {
+		private UserPermissions _globalPermissions;
 
-      }
+		/// <summary>
+		/// The global <see cref="UserPermissions"/> contain the permissions for the user's global role.
+		/// <b>The user's roles for the current realm may be different!</b> Please use the <see cref="GetPermissionsForRealm"/> method.
+		/// </summary>
+		public UserPermissions GlobalPermissions =>
+			_globalPermissions ?? (_globalPermissions = new UserPermissions(roleString));
 
-      public EditorUser(User user)
-      {
-         id = user.id;
-         email = user.email;
-         language = user.language;
-         scopes = user.scopes;
-         thirdPartyAppAssociations = user.thirdPartyAppAssociations;
-      }
+		[Obsolete("Please use the " + nameof(GetPermissionsForRealm) + " method instead.")]
+		public bool IsAtLeastAdmin => GlobalPermissions.IsAtLeastAdmin;
 
-   }
+		[Obsolete("Please use the " + nameof(GetPermissionsForRealm) + " method instead.")]
+		public bool IsAtLeastDeveloper => GlobalPermissions.IsAtLeastDeveloper;
+
+		[Obsolete("Please use the " + nameof(GetPermissionsForRealm) + " method instead.")]
+		public bool IsAtLeastTester => GlobalPermissions.IsAtLeastTester;
+
+		[Obsolete("Please use the " + nameof(GetPermissionsForRealm) + " method instead.")]
+		public bool HasNoRole => !IsAtLeastTester;
+
+		[Obsolete("Please use the " + nameof(GetPermissionsForRealm) + " method instead.")]
+		public bool CanPushContent => IsAtLeastDeveloper;
+
+		public EditorUser()
+		{
+
+		}
+
+		public EditorUser(User user)
+		{
+			id = user.id;
+			email = user.email;
+			language = user.language;
+			scopes = user.scopes;
+			thirdPartyAppAssociations = user.thirdPartyAppAssociations;
+		}
+
+		/// <summary>
+		/// Get the user's <see cref="UserPermissions"/> for the given realm.
+		/// By default, a user's role will be equal to the <see cref="roleString"/> field. However, the contents of the <see cref="roles"/> list
+		/// may contain realm specific overrides for the user's permissions.
+		/// </summary>
+		/// <param name="pid">Some realm pid.</param>
+		/// <returns>The user's permissions for the current realm.</returns>
+		public UserPermissions GetPermissionsForRealm(string pid)
+		{
+			if (string.IsNullOrEmpty(pid)) return GlobalPermissions;
+
+			var realmOverride = roles?.FirstOrDefault(role => string.Equals(role.projectId, pid));
+			if (realmOverride == null) return GlobalPermissions;
+			return new UserPermissions(realmOverride.role);
+		}
+
+	}
+
+	/// <summary>
+	/// Describes the permissions for a user.
+	/// </summary>
+	[System.Serializable]
+	public class UserPermissions
+	{
+		public string Role { get; }
+
+		public UserPermissions(string role)
+		{
+			Role = role;
+		}
+
+		/// <summary>
+		/// Returns true when the <see cref="Role"/> is an admin.
+		/// </summary>
+		public bool IsAtLeastAdmin => string.Equals(Role, EditorUser.ADMIN_ROLE);
+
+		/// <summary>
+		/// Returns true when the <see cref="Role"/> is developer or admin.
+		/// </summary>
+		public bool IsAtLeastDeveloper => IsAtLeastAdmin || string.Equals(Role, EditorUser.DEVELOPER_ROLE);
+
+		/// <summary>
+		/// Returns true when the <see cref="Role"/> is tester, developer, or admin.
+		/// </summary>
+		public bool IsAtLeastTester => IsAtLeastDeveloper || string.Equals(Role, EditorUser.TESTER_ROLE);
+
+		/// <summary>
+		/// Returns true when the <see cref="Role"/> is not tester, developer, or admin.
+		/// </summary>
+		public bool HasNoRole => !IsAtLeastTester;
+
+		/// <summary>
+		/// Returns true when the user has the permission to publish Content.
+		/// </summary>
+		public bool CanPushContent => IsAtLeastDeveloper;
+
+		/// <summary>
+		/// Returns true when the user has the permission to publish Microservice and Microstorages.
+		/// </summary>
+		public bool CanPublishMicroservices => IsAtLeastDeveloper;
+	}
 }

--- a/client/Packages/com.beamable/Editor/UI/Content/ContentManager.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/ContentManager.cs
@@ -27,7 +27,8 @@ namespace Beamable.Editor.Content
          {
             Model.ContentIO = de.ContentIO;
 
-            Model.UserCanPublish = de.User?.CanPushContent ?? false;
+
+            Model.UserCanPublish = de.Permissions.CanPushContent;
             EditorAPI.Instance.Then(b =>
             {
                b.OnUserChange -= HandleOnUserChanged;
@@ -213,7 +214,10 @@ namespace Beamable.Editor.Content
 
       private void HandleOnUserChanged(EditorUser user)
       {
-         Model.UserCanPublish = user?.CanPushContent ?? false;
+	      EditorAPI.Instance.Then(de =>
+	      {
+		      Model.UserCanPublish = de.Permissions.CanPushContent;
+	      });
       }
 
       public Promise<ContentPublishSet> CreatePublishSet(bool newNamespace=false)

--- a/client/Packages/com.beamable/Editor/UI/Login/UI/Components/AccountSummaryVisualElement/AccountSummaryVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Login/UI/Components/AccountSummaryVisualElement/AccountSummaryVisualElement.cs
@@ -75,8 +75,14 @@ namespace Beamable.Editor.Login.UI.Components
          if (Model.CurrentUser == null) return;
 
          _emailField.SetValueWithoutNotify(Model.CurrentUser.email);
-         _roleField.SetValueWithoutNotify(Model.CurrentUser.roleString);
-
+         if (Model.CurrentRealm != null)
+         {
+	         _roleField.SetValueWithoutNotify(Model.CurrentUser.GetPermissionsForRealm(Model.CurrentRealm.Pid).Role);
+         }
+         else
+         {
+	         _roleField.SetValueWithoutNotify(Model.CurrentUser.roleString + " (default)");
+         }
       }
 
       private void SetGameView()


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2781

# Brief Description
There was pretty much no way a cherry pick was going to work, so I just copy/pasted/edited-where-needed the logic from realm scoped permissions on `main`. 

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
