### PR TITLE
beam 2776 - forward error and success logs from client gen

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added microservice archive/unarchive feature.
 - Basic Chat SDK functions to Microservice
 - The base docker image used for Microservices and Microstorages will be automatically pulled at startup.
+- Client Generator logs go to the Microservice Window
 
 ### Changed
 - local microservice logs will appear for dotnet watch command

--- a/client/Packages/com.beamable.server/Editor/BeamServicesCodeWatcher.cs
+++ b/client/Packages/com.beamable.server/Editor/BeamServicesCodeWatcher.cs
@@ -404,27 +404,62 @@ namespace Beamable.Server.Editor
 
 			var check = new CheckImageReturnableCommand(generatorDesc);
 
+
 			check.StartAsync().Then(isRunning =>
 			{
 				if (isRunning && !force)
 				{
-					var codeGenCheck = new CheckImageCodeGenErrorCommand(generatorDesc);
-
-					codeGenCheck.StartAsync().Then(hasCodeError =>
-					{
-						if (hasCodeError)
-						{
-							RebuildAndRegenerate(generatorDesc);
-						}
-					});
+					FollowGeneratorLogs(service, generatorDesc);
 				}
 				else
-					RebuildAndRegenerate(generatorDesc);
+					RebuildAndRegenerate(service, generatorDesc);
 
 			});
 		}
 
-		private static void RebuildAndRegenerate(MicroserviceDescriptor generatorDesc)
+		private static void FollowGeneratorLogs(MicroserviceDescriptor service, MicroserviceDescriptor generatorDesc)
+		{
+			bool TryGetErrorCode(string message, out int errCode)
+			{
+				errCode = 0;
+				var errorMatchStr = "error CS";
+				if (message == null) return false;
+				var index = message.IndexOf(errorMatchStr, StringComparison.InvariantCulture);
+				if (index <= -1) return false; // only care about errors...
+
+				var numbers = message.Substring(index + errorMatchStr.Length, 4);
+				if (!int.TryParse(numbers, out errCode))
+				{
+					return false;
+				}
+
+				return true;
+			}
+
+			var follow = new FollowLogCommand(service, generatorDesc.ContainerName);
+			follow.AddGlobalFilter(message =>
+			{
+				if (message?.Contains(Constants.Features.Services.Logs.GENERATED_CLIENT_PREFIX) ?? false) return true;
+				return TryGetErrorCode(message, out _);
+			});
+			follow.MapGlobal(log =>
+			{
+				if (log.Message.Contains(Constants.Features.Services.Logs.GENERATED_CLIENT_PREFIX))
+				{
+					log.Level = LogLevel.INFO;
+					return log;
+				}
+
+				var parts = log.Message.Split(' ');
+				var otherParts = parts.Skip(1).ToArray();
+				log.Message = "Failed to generated client code\n" + Path.GetFileName(parts[0]) + " " + string.Join(" ", otherParts);
+				log.Level = LogLevel.ERROR;
+				return log;
+			});
+			follow.Start();
+		}
+
+		private static void RebuildAndRegenerate(MicroserviceDescriptor service, MicroserviceDescriptor generatorDesc)
 		{
 			// definately stop the image, even if there was doubt it was running. Because if we do a "build", any existing image will ABSOLUTELY be ruined by the overcopy.
 			new StopImageReturnableCommand(generatorDesc).StartAsync().Then(__ =>
@@ -437,6 +472,8 @@ namespace Beamable.Server.Editor
 					{
 						var clientCommand = new RunClientGenerationCommand(generatorDesc);
 						clientCommand.Start();
+						FollowGeneratorLogs(service, generatorDesc);
+
 						// TODO: add some sort of "cleanup" operation
 						// TODO: consider add info hint when the generator image is running
 					});

--- a/client/Packages/com.beamable.server/Editor/DockerCommands/CheckImageCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/CheckImageCommand.cs
@@ -47,45 +47,6 @@ namespace Beamable.Server.Editor.DockerCommands
 		}
 	}
 
-	public class CheckImageCodeGenErrorCommand : DockerCommandReturnable<bool>
-	{
-		public string ContainerName { get; }
-		public bool HasCodeGenError { get; private set; }
-
-		public CheckImageCodeGenErrorCommand(IDescriptor descriptor)
-			: this(descriptor.ContainerName)
-		{
-
-		}
-
-		public CheckImageCodeGenErrorCommand(string containerName)
-		{
-			ContainerName = containerName;
-		}
-
-		public override string GetCommandString()
-		{
-			var command = $"{DockerCmd} logs --tail=50 {ContainerName}";
-			return command;
-		}
-
-		protected override void HandleStandardOut(string data)
-		{
-			base.HandleStandardOut(data);
-
-			// dependency or code gen errors
-			if (data != null && (data.Contains(COMPILER_ASSEMBLY_REFERENCE_ERROR_CODE)
-								 || data.Contains(COMPILER_TYPE_NAMESPACE_ERROR_CODE)))
-			{
-				HasCodeGenError = true;
-			}
-		}
-		protected override void Resolve()
-		{
-			Promise.CompleteSuccess(HasCodeGenError);
-		}
-	}
-
 	public class CheckImageCommand : CheckImageReturnableCommand
 	{
 		public CheckImageCommand(MicroserviceDescriptor descriptor) : base(descriptor)

--- a/client/Packages/com.beamable.server/Editor/DockerCommands/MicroserviceLogHelper.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/MicroserviceLogHelper.cs
@@ -110,7 +110,7 @@ namespace Beamable.Server.Editor.DockerCommands
 
 		}
 
-		public static bool HandleLog(IDescriptor descriptor, string label, string data, DateTime fallbackTime = default)
+		public static bool HandleLog(IDescriptor descriptor, string label, string data, DateTime fallbackTime = default, Func<LogMessage, LogMessage> logProcessor=null)
 		{
 			if (Json.Deserialize(data) is ArrayDict jsonDict)
 			{
@@ -202,6 +202,7 @@ namespace Beamable.Server.Editor.DockerCommands
 					Level = logLevelValue,
 					Timestamp = LogMessage.GetTimeDisplay(time)
 				};
+				logMessage = logProcessor?.Invoke(logMessage) ?? logMessage;
 				BeamEditorContext.Default.Dispatcher.Schedule(() => MicroservicesDataModel.Instance.AddLogMessage(descriptor, logMessage));
 
 				if (MicroserviceConfiguration.Instance.ForwardContainerLogsToUnityConsole)
@@ -230,6 +231,7 @@ namespace Beamable.Server.Editor.DockerCommands
 					Level = LogLevel.INFO,
 					Timestamp = LogMessage.GetTimeDisplay(fallbackTime)
 				};
+				logMessage = logProcessor?.Invoke(logMessage) ?? logMessage;
 				if (string.IsNullOrEmpty(logMessage.Message))
 				{
 					return false;
@@ -244,7 +246,7 @@ namespace Beamable.Server.Editor.DockerCommands
 		}
 
 
-		public static bool HandleLog(MicroserviceDescriptor descriptor, LogLevel logLevel, string message, Color color, bool isBoldMessage, string postfixIcon)
+		public static bool HandleLog(IDescriptor descriptor, LogLevel logLevel, string message, Color color, bool isBoldMessage, string postfixIcon)
 		{
 			var logMessage = new LogMessage
 			{

--- a/client/Packages/com.beamable/Common/Runtime/Constants/Implementations/DockerConstants.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Constants/Implementations/DockerConstants.cs
@@ -6,9 +6,6 @@
 		{
 			public static partial class Docker
 			{
-				public const string COMPILER_ASSEMBLY_REFERENCE_ERROR_CODE = "CS0012";
-				public const string COMPILER_TYPE_NAMESPACE_ERROR_CODE = "CS0246";
-
 				public const string DEFAULT_DOCKER_BUILD_ARCHITECTURE = "linux/amd64";
 				public const string SUPPORTED_DEPLOY_ARCHITECTURE = "linux/amd64";
 			}

--- a/client/Packages/com.beamable/Common/Runtime/Constants/Implementations/ServiceConstants.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Constants/Implementations/ServiceConstants.cs
@@ -56,6 +56,7 @@ namespace Beamable.Common
 					public const string SERVICE_PROVIDER_INITIALIZED = "Service provider initialized";
 					public const string EVENT_PROVIDER_INITIALIZED = "Event provider initialized";
 					public const string STORAGE_READY = "Waiting for connections";
+					public const string GENERATED_CLIENT_PREFIX = "Generated Client Code.";
 				}
 
 				public static class Dialogs

--- a/microservice/microservice/CommandLine.cs
+++ b/microservice/microservice/CommandLine.cs
@@ -1,3 +1,4 @@
+using Beamable.Common;
 using System;
 using System.CommandLine;
 using System.IO;
@@ -78,6 +79,7 @@ namespace Beamable.Server
 				Directory.CreateDirectory(outputDirectory);
 			}
 			generator.GenerateCSharpCode(filePath);
+			Console.WriteLine(Constants.Features.Services.Logs.GENERATED_CLIENT_PREFIX);
 		}
 	}
 }


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2776

# Brief Description
Before, we were were only checking for errors in the generator container by checking its logs. 
Now, I'd like to always stream the logs from a generator container to the Microservice window. However, because the logs we are getting aren't structured json, I added some janky string parsing, so that we only show a CSXYZW error, or a "success" error.

This is helpful, because now we'll get visual feedback when the user has something in their microservice like a bad namespace, or using `Debug.LogWarningFormat` whose mock doesn't exist in the service. 


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
