### PR TITLE
beam 2773 and 2840 - asset lock publish flow

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Microservice related actions can run while Unity is a background process.
+- Publish flow locks Asset Database so that no re-imports may happen.
 
 ### Removed
 - Unused legacy code around "Auto Run Local Microservices" menu item

--- a/client/Packages/com.beamable.server/Editor/ReflectionCache/UserSystems/MicroserviceReflectionCache.cs
+++ b/client/Packages/com.beamable.server/Editor/ReflectionCache/UserSystems/MicroserviceReflectionCache.cs
@@ -317,7 +317,23 @@ namespace Beamable.Server.Editor
 			public event Action<IDescriptor, ServicePublishState> OnServiceDeployStatusChanged;
 			public event Action<IDescriptor> OnServiceDeployProgress;
 
-			public async System.Threading.Tasks.Task Deploy(ManifestModel model, CancellationToken token, Action<IDescriptor> onServiceDeployed = null, Action<LogMessage> logger = null)
+			public async Task Deploy(ManifestModel model,
+			                         CancellationToken token,
+			                         Action<IDescriptor> onServiceDeployed = null,
+			                         Action<LogMessage> logger = null)
+			{
+				try
+				{
+					AssetDatabase.StartAssetEditing();
+					await DeployInternal(model, token, onServiceDeployed, logger);
+				}
+				finally
+				{
+					AssetDatabase.StopAssetEditing();
+				}
+			}
+
+			private async Task DeployInternal(ManifestModel model, CancellationToken token, Action<IDescriptor> onServiceDeployed = null, Action<LogMessage> logger = null)
 			{
 				if (Descriptors.Count == 0) return; // don't do anything if there are no descriptors.
 

--- a/client/Packages/com.beamable.server/Editor/UI/Model/MicroservicesDataModel.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Model/MicroservicesDataModel.cs
@@ -257,7 +257,7 @@ namespace Beamable.Editor.UI.Model
 		public bool ContainsModel(string serviceName) => AllLocalServices?.Any(s => s.Descriptor.Name.Equals(serviceName)) ?? false;
 
 		public bool IsArchived(string serviceName) =>
-			AllLocalServices.First(s => s.Descriptor.Name.Equals(serviceName)).IsArchived;
+			AllLocalServices.FirstOrDefault(s => s.Descriptor.Name.Equals(serviceName))?.IsArchived ?? false;
 
 		public T GetModel<T>(IDescriptor descriptor) where T : IBeamableService =>
 		   GetModel<T>(descriptor.Name);

--- a/client/Packages/com.beamable/Runtime/Core/Serialization.meta
+++ b/client/Packages/com.beamable/Runtime/Core/Serialization.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: cdbd998460754486a2ad59390355d9e4
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
# Ticket
missing meta file fix from https://disruptorbeam.atlassian.net/browse/BEAM-2840
and https://disruptorbeam.atlassian.net/browse/BEAM-2773

# Brief Description
Pretty much, just add an Asset Database lock around the publish flow to prevent the re-import of script files


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
