### PR TITLE
beam 2845 - fix log streaming

### DIFF
--- a/client/Packages/com.beamable.server/Editor/CodeGen/DockerfileGenerator.cs
+++ b/client/Packages/com.beamable.server/Editor/CodeGen/DockerfileGenerator.cs
@@ -203,8 +203,7 @@ ENV BEAMABLE_SDK_VERSION_EXECUTION={BeamableEnvironment.SdkVersion}
 			var content = GetString();
 
 #if BEAMABLE_DEVELOPER
-			Beamable.Common.BeamableLogger.Log("DOCKER FILE");
-			Beamable.Common.BeamableLogger.Log(content);
+			Beamable.Common.BeamableLogger.Log($"DOCKER FILE {Descriptor.Name}\n{content}");
 #endif
 
 			File.WriteAllText(filePath, content);

--- a/client/Packages/com.beamable.server/Editor/DockerCommands/ProcessCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/ProcessCommand.cs
@@ -63,9 +63,43 @@ namespace Beamable.Server.Editor.DockerCommands
 
 		public string UnityLogLabel = "Docker";
 
+		protected string StandardOutBuffer { get; private set; }
+
+		protected string StandardErrorBuffer { get; private set; }
+
+		public Action<string> OnStandardOut;
+		public Action<string> OnStandardErr;
+
+
 		public abstract string GetCommandString();
 
 		protected virtual void HandleOnExit() { }
+
+		private void ProcessStandardOut(string data)
+		{
+			if (!string.IsNullOrEmpty(data))
+			{
+				StandardOutBuffer += data;
+			}
+			HandleStandardOut(data);
+			if (data != null)
+			{
+				OnStandardOut?.Invoke(data);
+			}
+		}
+
+		private void ProcessStandardErr(string data)
+		{
+			if (!string.IsNullOrEmpty(data))
+			{
+				StandardErrorBuffer += data;
+			}
+			HandleStandardErr(data);
+			if (data != null)
+			{
+				OnStandardErr?.Invoke(data);
+			}
+		}
 
 		protected virtual void HandleStandardOut(string data)
 		{
@@ -216,7 +250,7 @@ namespace Beamable.Server.Editor.DockerCommands
 							{
 								try
 								{
-									HandleStandardOut(args.Data);
+									ProcessStandardOut(args.Data);
 								}
 								catch (Exception ex)
 								{
@@ -230,7 +264,7 @@ namespace Beamable.Server.Editor.DockerCommands
 							{
 								try
 								{
-									HandleStandardErr(args.Data);
+									ProcessStandardErr(args.Data);
 								}
 								catch (Exception ex)
 								{

--- a/client/Packages/com.beamable.server/Editor/DockerCommands/ProcessCommandReturnable.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/ProcessCommandReturnable.cs
@@ -7,14 +7,9 @@ namespace Beamable.Server.Editor.DockerCommands
 {
 	public abstract class DockerCommandReturnable<T> : DockerCommand
 	{
-		public Action<string> OnStandardOut;
-		public Action<string> OnStandardErr;
-
 
 		protected Promise<T> Promise { get; private set; }
 
-		protected string StandardOutBuffer { get; private set; }
-		protected string StandardErrorBuffer { get; private set; }
 
 		protected bool _finished;
 
@@ -37,26 +32,6 @@ namespace Beamable.Server.Editor.DockerCommands
 		}
 
 		protected abstract void Resolve();
-
-		protected override void HandleStandardOut(string data)
-		{
-			base.HandleStandardOut(data);
-			if (data != null)
-			{
-				StandardOutBuffer += data;
-				OnStandardOut?.Invoke(data);
-			}
-		}
-
-		protected override void HandleStandardErr(string data)
-		{
-			base.HandleStandardErr(data);
-			if (data != null)
-			{
-				StandardErrorBuffer += data;
-				OnStandardErr?.Invoke(data);
-			}
-		}
 
 		protected override void HandleOnExit()
 		{

--- a/client/Packages/com.beamable.server/Editor/DockerCommands/RunImageCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/RunImageCommand.cs
@@ -278,15 +278,12 @@ namespace Beamable.Server.Editor.DockerCommands
 
 		public List<BindMount> BindMounts { get; protected set; }
 
-		public Action<string> OnStandardOut;
-		public Action<string> OnStandardErr;
-
 		public RunImageCommand(string imageName, string containerName,
-		   IDescriptor descriptor,
-		   Dictionary<string, string> env = null,
-		   Dictionary<uint, uint> ports = null,
-		   Dictionary<string, string> namedVolumes = null,
-		   List<BindMount> bindMounts = null)
+		                       IDescriptor descriptor,
+		                       Dictionary<string, string> env = null,
+		                       Dictionary<uint, uint> ports = null,
+		                       Dictionary<string, string> namedVolumes = null,
+		                       List<BindMount> bindMounts = null)
 		{
 			_descriptor = descriptor;
 			ImageName = imageName;


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2845

# Brief Description
Before, we had a bug where if you didn't have the setting in Microservice.Configuration enabled where it forwards logs to Unity, the docker-buildkit based images would fail to build. 
I re-worked it so that the `StandardErrBuffer` and `StandardOutBuffer` variables are always accrued instead of relying on odd base class behaviour. 

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
