### PR TITLE
beam 2848 - wait for beam editor context to init before launching docker commands

### DIFF
--- a/client/Packages/com.beamable.server/Editor/DockerCommands/ProcessCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/ProcessCommand.cs
@@ -275,6 +275,7 @@ namespace Beamable.Server.Editor.DockerCommands
 
 						// before starting anything, make sure the beam context has initialized, so that the dispatcher can be accessed later.
 						await BeamEditorContext.Default.InitializePromise;
+						await MicroserviceEditor.WaitForInit();
 
 						_process.Start();
 						_started = true;

--- a/client/Packages/com.beamable.server/Editor/MicroserviceEditor.cs
+++ b/client/Packages/com.beamable.server/Editor/MicroserviceEditor.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Assertions;
@@ -112,6 +113,21 @@ namespace Beamable.Server.Editor
 				// it does not matter if this request fails- because it is only a preload operation.
 				// in the event this fails, the image will be downloaded later.
 			}
+		}
+
+		/// <summary>
+		/// A utility function that will wait for the microservice editor <see cref="IsInitialized"/> flag to be true.
+		/// This method should only be called in a task-friendly environment.
+		/// </summary>
+		public static async Task WaitForInit()
+		{
+			await Task.Run(async () =>
+			{
+				while (!IsInitialized)
+				{
+					await Task.Delay(1);
+				}
+			});
 		}
 
 		public static async void TryToPreloadMongoImage()


### PR DESCRIPTION

# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2848

# Brief Description
So Peter realized that the Beamable Dispatcher could be _not ready_ by the time the docker command runs _somehow_.
Either way, it should be safe to say that the docker command won't _run_ unless the beam editor context is available.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
