### PR TITLE
beam 2857 - add option to disable all events

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Client Generator logs go to the Microservice Window
 - Send Microservice CPU architecture to Beamable Cloud
 - Headers are available on the service `Context` for application version, unity version, game version, and Beamable sdk version
+- `DisableAllBeamableEvents` option for the `MicroserviceAttribute`. When enabled, prevents the Microservice from receiving any Beamable events, including content cache invalidations. 
 
 ### Changed
 - local microservice logs will appear for dotnet watch command

--- a/client/Packages/com.beamable.server/SharedRuntime/MicroserviceAttribute.cs
+++ b/client/Packages/com.beamable.server/SharedRuntime/MicroserviceAttribute.cs
@@ -15,6 +15,19 @@ namespace Beamable.Server
 		   "Any new client build of your game won't require the payload string. Unless you've deployed a client build using Beamable before version 0.11.0, you shouldn't set this")]
 		public bool UseLegacySerialization { get; set; } = false;
 
+		/// <summary>
+		/// <b>Danger!</b>, if you enable this field, you will not be able to rely on content loaded from the Microservice code.
+		/// Normally, when a Beamable Microservice starts, it registers an event subscription with Beamable's internal platform,
+		/// so that it can receive a stream of Beamable events. The primary use case is to receive events about Content Publication.
+		/// When a Content Publication event is received, the Microservice flushes the in-memory content cache. After the cache is flushed,
+		/// all future content requests download new content. Without the event, the content downloaded on the Microservice will
+		/// always be the same as it was the first time the content was requested.
+		///
+		/// When this flag is enabled, the Microservice will not register an event subscription. This may be useful to prevent
+		/// the Microservice from receiving other unrelated Beamable platform events such as inventory-change events.
+		/// </summary>
+		public bool DisableAllBeamableEvents { get; set; } = false;
+
 		public MicroserviceAttribute(string microserviceName, [CallerFilePath] string sourcePath = "")
 		{
 			MicroserviceName = microserviceName;

--- a/microservice/microservice/Content/ContentService.cs
+++ b/microservice/microservice/Content/ContentService.cs
@@ -87,6 +87,24 @@ namespace Beamable.Server.Content
       }
    }
 
+   public class UnreliableContentService : ContentService
+   {
+	   public UnreliableContentService(MicroserviceRequester requester, SocketRequesterContext socket, IContentResolver contentResolver, ReflectionCache reflectionCache) : base(requester, socket, contentResolver, reflectionCache)
+	   {
+	   }
+
+	   public override Promise<IContentObject> GetContent(string contentId, Type contentType, string manifestID = "")
+	   {
+		   BeamableLogger.LogWarning("The content=[{contentId}] may be unreliable. When the Microservice's {attributeName} " +
+		                             "is enabled, the Microservice will never receive content updates. " +
+		                             "This means that you may resolve content, but after the first time you do so, " +
+		                             "the content will never ever change until the Microservice instance stops and restarts. " +
+		                             "It is highly recommend that you do not use the Content service at all when the configuration is set.",
+			   contentId, nameof(MicroserviceAttribute.DisableAllBeamableEvents));
+		   return base.GetContent(contentId, contentType, manifestID);
+	   }
+   }
+
    public class ContentService : IMicroserviceContentApi
    {
       private readonly MicroserviceRequester _requester;
@@ -220,7 +238,7 @@ namespace Beamable.Server.Content
          return Resolve(reference);
       }
 
-      public Promise<IContentObject> GetContent(string contentId, Type contentType, string manifestID = "")
+      public virtual Promise<IContentObject> GetContent(string contentId, Type contentType, string manifestID = "")
       {
          return WaitForManifest().FlatMap(_ =>
          {

--- a/microservice/microservice/dbmicroservice/BeamableMicroService.cs
+++ b/microservice/microservice/dbmicroservice/BeamableMicroService.cs
@@ -28,6 +28,7 @@ using Beamable.Server.Api.Tournament;
 using Beamable.Server.Api.CloudData;
 using Beamable.Server.Api.RealmConfig;
 using Beamable.Server.Api.Commerce;
+using Beamable.Server.Content;
 using Core.Server.Common;
 using microservice;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -219,7 +220,7 @@ namespace Beamable.Server
          _mongoSerializationService = new MongoSerializationService();
          _storageObjectConnectionProviderService = new StorageObjectConnectionProvider(_args, _requester);
 
-         _contentService = new ContentService(_requester, _socketRequesterContext, _contentResolver, _reflectionCache);
+         _contentService = CreateNewContentService(_requester, _socketRequesterContext, _contentResolver, _reflectionCache);
          ContentApi.Instance.CompleteSuccess(_contentService);
 
          _serviceShutdownTokenSource = new CancellationTokenSource();
@@ -241,6 +242,13 @@ namespace Beamable.Server
          var socket = await _webSocketPromise;
 
          await SetupWebsocket(socket);
+      }
+
+      private ContentService CreateNewContentService(MicroserviceRequester requester, SocketRequesterContext socket, IContentResolver contentResolver, ReflectionCache reflectionCache)
+      {
+	      return _serviceAttribute.DisableAllBeamableEvents
+		      ? new UnreliableContentService(requester, socket, contentResolver, reflectionCache)
+		      : new ContentService(requester, socket, contentResolver, reflectionCache);
       }
 
       public void RunForever()
@@ -930,10 +938,12 @@ namespace Beamable.Server
          {
             Log.Debug(Logs.SERVICE_PROVIDER_INITIALIZED);
          }).ToUnit();
-         var eventProvider = _requester.InitializeSubscription().Then(res =>
-         {
-            Log.Debug(Logs.EVENT_PROVIDER_INITIALIZED);
-         }).ToUnit();
+         var eventProvider = _serviceAttribute.DisableAllBeamableEvents
+	         ? PromiseBase.SuccessfulUnit
+	         : _requester.InitializeSubscription().Then(res =>
+	         {
+		         Log.Debug(Logs.EVENT_PROVIDER_INITIALIZED);
+	         }).ToUnit();
          return Promise.Sequence(serviceProvider, eventProvider).ToUnit();
       }
 

--- a/microservice/microserviceTests/microservice/SimpleMicroservice.cs
+++ b/microservice/microserviceTests/microservice/SimpleMicroservice.cs
@@ -32,6 +32,21 @@ namespace microserviceTests.microservice
 
    }
 
+   [Microservice("simple_no_updates", DisableAllBeamableEvents = true)]
+   public class SimpleMicroserviceWithNoEvents : Microservice
+   {
+	   public static MicroserviceFactory<SimpleMicroserviceWithNoEvents> Factory => () => new SimpleMicroserviceWithNoEvents();
+
+
+	   [ClientCallable]
+	   public async Task<string> GetContent(string id)
+	   {
+		   var content = await Services.Content.GetContent(id);
+		   return "Echo: " + content.Id;
+	   }
+
+   }
+
    [Microservice("simple", UseLegacySerialization = true)]
    public class SimpleMicroservice : Microservice
    {

--- a/microservice/microserviceTests/microservice/TestSocket.cs
+++ b/microservice/microserviceTests/microservice/TestSocket.cs
@@ -833,18 +833,23 @@ namespace Beamable.Microservice.Tests.Socket
                );
             if (addShutdownResponder)
             {
-                socket = socket.AddMessageHandler(
-                   MessageMatcher
-                      .WithRouteContains("gateway/provider")
-                      .WithDelete()
-                      .WithBody<MicroserviceProviderRequest>(body => body.type == "basic"),
-                   MessageResponder.Success(new MicroserviceProviderResponse()),
-                   MessageFrequency.OnlyOnce()
-                );
+	            socket = AddProviderShutdownMessageHandler();
             }
 
             return socket;
 
+        }
+
+        public TestSocket AddProviderShutdownMessageHandler()
+        {
+	        return AddMessageHandler(
+		        MessageMatcher
+			        .WithRouteContains("gateway/provider")
+			        .WithDelete()
+			        .WithBody<MicroserviceProviderRequest>(body => body.type == "basic"),
+		        MessageResponder.Success(new MicroserviceProviderResponse()),
+		        MessageFrequency.OnlyOnce()
+	        );
         }
 
         public TestSocket AddMessageHandler(TestSocketMessageMatcher matcher, TestSocketResponseGenerator responder, MessageFrequencyRequirements frequencyRequirements = null, string desc=null, bool? requiresAuth=true)

--- a/microservice/microserviceTests/microservice/dbmicroservice/BeamableMicroServiceTests/StartTests.cs
+++ b/microservice/microserviceTests/microservice/dbmicroservice/BeamableMicroServiceTests/StartTests.cs
@@ -704,6 +704,58 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
             Assert.IsTrue(testSocket.AllMocksCalled());
         }
 
+        [Test]
+        [NonParallelizable]
+        public async Task HandleLazyContentLoad_WithUnreliableFlag()
+        {
+
+	        TestSocket testSocket = null;
+	        var contentResolver = new TestContentResolver(async uri =>
+	        {
+		        return "{\"id\": \"content.abc\", \"version\": \"1\", \"properties\": {}}";
+	        });
+	        var ms = new BeamableMicroService(new TestSocketProvider(socket =>
+	        {
+		        testSocket = socket;
+		        socket
+			        .AddAuthMessageHandlers()
+			        .AddMessageHandler(
+				        MessageMatcher
+					        .WithRouteContains("gateway/provider")
+					        .WithReqId(-3)
+					        .WithPost()
+					        .WithBody<MicroserviceProviderRequest>(body => body.type == "basic"),
+				        MessageResponder.Success(new MicroserviceProviderResponse()),
+				        MessageFrequency.OnlyOnce()
+			        )
+			        .AddProviderShutdownMessageHandler()
+			        .AddInitialContentMessageHandler(-4, new ContentReference
+			        {
+				        id = "content.abc",
+				        visibility = "public",
+				        uri = "testuri"
+			        })
+			        .AddMessageHandler(
+				        MessageMatcher.WithReqId(1).WithStatus(200).WithPayload<string>(n => n == "Echo: content.abc"),
+				        MessageResponder.NoResponse(),
+				        MessageFrequency.OnlyOnce()
+			        );
+	        }), contentResolver);
+
+	        await ms.Start<SimpleMicroserviceWithNoEvents>(new TestArgs());
+	        Assert.IsTrue(ms.HasInitialized);
+
+	        testSocket.SendToClient(ClientRequest.ClientCallable("micro_simple_no_updates", nameof(SimpleMicroserviceWithNoEvents.GetContent), 1, 1, "content.abc"));
+
+	        var warningLog = GetLogs().FirstOrDefault(l => l.Level == LogEventLevel.Warning);
+			Assert.IsNotNull(warningLog);
+			Assert.IsTrue(warningLog.RenderMessage().Contains("The content=[\"content.abc\"] may be unreliable"));
+
+
+	        // simulate shutdown event...
+	        await ms.OnShutdown(this, null);
+	        Assert.IsTrue(testSocket.AllMocksCalled());
+        }
 
         [Test]
         [NonParallelizable]


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2857

# Brief Description
Some customers (idlekit) process around 700 inventory change requests per second. Each Microservice instance gets a copy of every one of those events, which does not scale well. In fact, Idlekit's microservices fail to start, because they get flooded by these messages. More specifically, the _websocket_ connection is flooded, and other pending requests simply don't get through the flood of inventory updates.
Thorium doesn't support the ability to filter the types of events to send the Microservice, so this PR simply adds a flag to prevent ANY event subscription. That solves the Idlekit issue, but prevents them from reliably accessing content. They _can_ get content, but it'll very likely be stale and out of date. 

I've adding the config option, and a test to verify that a log-warning is sent out if you try to access content when using the feature.


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
