### PR TITLE
beam 2870 - inventory perf

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved some parts of the `ChatService` to Beamable.Common assembly
 - Changed namespace of `Beamable.Pooling.ClassPool` to `Beamable.Common.Pooling.ClassPool`
 - Account Management Flow will merge gamertags when existing login credential is detected, instead of always creating a new gamertag. This allows you to keep your gamertag on the realm. 
+- Improved performance of `PlayerInventory` sdk
 
 ### Fixed
 - Beamable button in Unity toolbar should be in correct position for production packages

--- a/client/Packages/com.beamable/Common/Runtime/Api/Inventory/IInventoryApi.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/Inventory/IInventoryApi.cs
@@ -298,6 +298,11 @@ namespace Beamable.Common.Api.Inventory
 		/// The timestamp of when the last modification to item occured.
 		/// </summary>
 		public long UpdatedAt;
+
+		/// <summary>
+		/// The code is a unique hashing code that combines the Content Id and the Item Id
+		/// </summary>
+		public int UniqueCode;
 	}
 
 	/// <summary>
@@ -376,11 +381,11 @@ namespace Beamable.Common.Api.Inventory
 		public HashSet<string> GetNotifyScopes(string[] givenScopes = null)
 		{
 			var notifyScopes = new HashSet<string>();
-			notifyScopes.UnionWith(currencies.Select(currency => currency.id));
-			notifyScopes.UnionWith(items.Select(item => item.id));
-			notifyScopes.UnionWith(Scopes);
+				notifyScopes.UnionWith(currencies.Select(currency => currency.id));
+				notifyScopes.UnionWith(items.Select(item => item.id));
+				notifyScopes.UnionWith(Scopes);
 			notifyScopes.Add(""); // always notify the root scope
-								  // TODO: if a scope is in notifySCopes, 'a.b.c', we should also make sure 'a.b', and 'a' are also in the set, so that item parent/child relationships are respected.
+				// TODO: if a scope is in notifySCopes, 'a.b.c', we should also make sure 'a.b', and 'a' are also in the set, so that item parent/child relationships are respected.
 			if (givenScopes != null)
 			{
 				notifyScopes.UnionWith(givenScopes);

--- a/client/Packages/com.beamable/Common/Runtime/Api/Inventory/InventoryApi.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/Inventory/InventoryApi.cs
@@ -244,6 +244,7 @@ namespace Beamable.Common.Api.Inventory
 					.FlatMap(service => service.GetContent<TContent>(new ItemRef(kvp.Key)))
 					.Map(content =>
 					{
+
 						return kvp.Value
 							.Select(item => new InventoryObject<TContent>
 							{
@@ -251,7 +252,8 @@ namespace Beamable.Common.Api.Inventory
 								Properties = item.properties,
 								ItemContent = content,
 								CreatedAt = item.createdAt,
-								UpdatedAt = item.updatedAt
+								UpdatedAt = item.updatedAt,
+								UniqueCode = (((item.id.GetHashCode() << 5) + item.id.GetHashCode()) ^ content.Id.GetHashCode())
 							}).ToList();
 					});
 			}).ToList()).Map(itemGroups =>

--- a/client/Packages/com.beamable/Common/Runtime/Api/Inventory/InventoryUpdateBuilder.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/Inventory/InventoryUpdateBuilder.cs
@@ -313,6 +313,40 @@ namespace Beamable.Common.Api.Inventory
 			return UpdateItem(item.ItemContent.Id, item.Id, item.Properties);
 		}
 
+		/// <summary>
+		/// Get a set of inventory scopes that the updater will affect.
+		/// </summary>
+		/// <returns>A set of scopes that will be changed based on the changes described in the builder</returns>
+		public HashSet<string> BuildScopes()
+		{
+			var scopes = new HashSet<string>();
+			foreach (var item in newItems)
+			{
+				scopes.Add(item.contentId);
+			}
+
+			foreach (var item in updateItems)
+			{
+				scopes.Add(item.contentId);
+			}
+
+			foreach (var item in deleteItems)
+			{
+				scopes.Add(item.contentId);
+			}
+
+			foreach (var curr in currencies)
+			{
+				scopes.Add(curr.Key);
+			}
+
+			foreach (var curr in currencyProperties)
+			{
+				scopes.Add(curr.Key);
+			}
+			return scopes;
+		}
+
 		void ISerializationCallbackReceiver.OnBeforeSerialize()
 		{
 			_serializedApplyVipBonus = applyVipBonus == null

--- a/client/Packages/com.beamable/Runtime/Player/PlayerInventory.cs
+++ b/client/Packages/com.beamable/Runtime/Player/PlayerInventory.cs
@@ -312,6 +312,7 @@ namespace Beamable.Player
 			var json = evt.Args[0];
 			var data = InventoryUpdateBuilderSerializer.FromNetworkJson(json);
 			var builder = data.Item1;
+			var relevantScopes = builder.BuildScopes();
 			var transaction = data.Item2;
 			try
 			{
@@ -336,7 +337,11 @@ namespace Beamable.Player
 
 				foreach (var itemGroup in _items.Values)
 				{
-					await itemGroup.Refresh();
+					// only bother updating the group if its in the builder.
+					if (relevantScopes.Any(itemGroup.IsScopePartOfGroup))
+					{
+						await itemGroup.Refresh();
+					}
 				}
 				await Currencies.Refresh();
 			}

--- a/client/Packages/com.beamable/Runtime/Player/PlayerItemGroup.cs
+++ b/client/Packages/com.beamable/Runtime/Player/PlayerItemGroup.cs
@@ -9,6 +9,7 @@ using Beamable.Common.Player;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Beamable.Player
 {
@@ -80,6 +81,11 @@ namespace Beamable.Player
 		public long UpdatedAt;
 
 		/// <summary>
+		/// A hash of the <see cref="ContentId"/> and the <see cref="ItemId"/> that can be used for fast identity checking.
+		/// </summary>
+		public int UniqueCode;
+
+		/// <summary>
 		/// A set of instance level property data for the item.
 		/// </summary>
 		public SerializableDictionaryStringToString Properties = new SerializableDictionaryStringToString();
@@ -95,11 +101,22 @@ namespace Beamable.Player
 		/// </summary>
 		public event Action OnDeleted;
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		static int CombineHashCodes(int h1, int h2)
+		{
+			return (((h1 << 5) + h1) ^ h2);
+		}
+
 		internal void TriggerUpdate(InventoryObject<ItemContent> item)
 		{
 			CreatedAt = item.CreatedAt;
 			UpdatedAt = item.UpdatedAt;
-			Properties = new SerializableDictionaryStringToString(item.Properties);
+			UniqueCode = item.UniqueCode;
+			Properties.Clear();
+			foreach (var kvp in item.Properties)
+			{
+				Properties[kvp.Key] = kvp.Value;
+			}
 			Content = item.ItemContent;
 			TriggerUpdate();
 		}
@@ -108,10 +125,16 @@ namespace Beamable.Player
 
 		public override int GetBroadcastChecksum()
 		{
-			// TODO: XXX: There must be a better way to implement this nonsense.
-			var propertiesBroadcastCode = Properties.Select(x => $"{x.Key}:{x.Value}").ToList();
-			propertiesBroadcastCode.Sort();
-			return $"{ContentId}-{ItemId}-{CreatedAt}-{UpdatedAt}-{string.Join(",", propertiesBroadcastCode)}".GetHashCode();
+			var hash = 0;
+			foreach (var kvp in Properties)
+			{
+				hash = CombineHashCodes(hash, kvp.Key.GetHashCode());
+				hash = CombineHashCodes(hash, kvp.Value.GetHashCode());
+			}
+
+			hash = CombineHashCodes(hash, UpdatedAt.GetHashCode());
+			// we don't need to care about the content id, item id, or created at, because logically, they should never change.
+			return hash;
 		}
 
 		internal void TriggerDeletion()
@@ -147,17 +170,52 @@ namespace Beamable.Player
 			var _ = Refresh();
 		}
 
+		/// <summary>
+		/// The inventory group contains some set of items based on the <see cref="ItemRef"/> that was given to the constructor.
+		/// Use this method to check if some scope is part of the group. A scope that is more specific than the group scope, belongs
+		/// to the group.
+		/// For example, if the group scope is "items.X", then the following scopes BELONG
+		/// - "items.X"
+		/// - "items.X.Y",
+		/// - "items.X.Y.Z"
+		/// And the following scopes DO NOT BELONG
+		/// - "items.Y"
+		/// - "items"
+		/// - "items.XY"
+		/// </summary>
+		/// <param name="scope"></param>
+		/// <returns></returns>
+		public bool IsScopePartOfGroup(string scope)
+		{
+			if (string.IsNullOrEmpty(scope)) return false;
+
+			var isPrefix = scope.StartsWith(_rootRef.Id);
+			if (!isPrefix) return false; // the given scope needs to be at least be a prefix-match
+
+			var hasMore = scope.Length > _rootRef.Id.Length;
+			if (!hasMore) return true; // and if its exactly equal, thats fine
+
+			var nextIsDot = scope[_rootRef.Id.Length + 1] == '.';
+			return nextIsDot; // but if it has more characters, than the next character MUST be a new sub type
+		}
+
+
 		protected override async Promise PerformRefresh()
 		{
 			await _platformService.OnReady;
 			var data = await _inventoryService.GetItems(_rootRef);
 
-			var next = new List<PlayerItem>();
+			var next = new List<PlayerItem>(data.Count);
 			var seen = new HashSet<PlayerItem>();
+
+			var map = new Dictionary<int, PlayerItem>(data.Count);
+			foreach (var item in this)
+			{
+				map[item.UniqueCode] = item;
+			}
 			foreach (var kvp in data)
 			{
-				var existing = this.FirstOrDefault(c => c.ContentId == kvp.ItemContent.Id && c.ItemId == kvp.Id);
-				if (existing != null)
+				if (map.TryGetValue(kvp.UniqueCode, out var existing))
 				{
 					next.Add(existing);
 					existing.TriggerUpdate(kvp);
@@ -167,6 +225,7 @@ namespace Beamable.Player
 				{
 					next.Add(new PlayerItem
 					{
+						UniqueCode = kvp.UniqueCode,
 						Content = kvp.ItemContent,
 						ContentId = kvp.ItemContent.Id,
 						CreatedAt = kvp.CreatedAt,
@@ -182,7 +241,7 @@ namespace Beamable.Player
 			{
 				item.TriggerDeletion();
 			}
-			SetData(next);
+			 SetData(next);
 		}
 
 	}


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2870

# Brief Description
Russell at PN posted in Slack that when he had 3k or 4k inventory objects, it was taking a long time to refresh the list. Whats worse (and this PR doesn't solve) is that if he simply updated a currency, the high inventory update cost would get triggered. 
So (1), our inventory update code is slow, and (2) it runs when a developer doesn't expect it to.

This PR only solves 1. Well, mostly....
The _huge_ change in this PR is in the main loop section, where we used to be doing a `FirstOrDefault`. That was creating a O(n^2) runtime profile, because for every item, we would run the `FirstOrDefault` on the existing items to find it. At worst case, thats a squared runtime. I changed this to pre-calc a dictionary ahead of time using a hash, and then reference that dictionary in the loop. That brings the runtime down to something like a O(2n) (aka, O(n)). So that helped a _lot_. I had a test with 9k objects, and it used to take upwards of 12 seconds to update! After this change, it took about 90 or 100ms. 

The other big change was to change some hashing stuff. When each item gets considered, we want to keep the old instance in memory if possible. If the old item has updated in anyway, then we should send an event on that item. In order to make this check, we used to pretty much `ToString` all the fields, hash-code it, and compare the hashcode of the previous item. Instead of doing that, we only consider the properties, and the udpatedAt time, because content-id and item-id and created-at should never change. Additionally, I used the C#-tuple hash combine function on the properties and updated-at instead of the janky toString method.
I also used that C#-tuple hash code thing to pre-calc a hash for the items, so that we don't have to calculate it over and over again. 

Ultimately, the runtime is down to like, 12 or 15ms now. Much better than 10 seconds. Still slow if it was running in a tight loop, but as a one-off "hey, here are 3k items", not so bad. 

I have not created a solution for this code running when a currency is updated, because
1. the developer doesn't get events, so except for the perf hit, its not a problem
2. the perf hit isn't so bad anymore... Should still figure it out, but maybe its another ticket.


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
