### PR TITLE
beam 2871 - event white list for C#MS

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Microservices cache their `dotnet restore` output in the Docker cache for faster development builds
 - Microservices share a realm secret request for faster development builds
 - Local microservices no longer output emoji characters from their `dotnet watch` command
+- Microservices only receive events for content updates
 
 ### Fixed
 - Microservice related actions can run while Unity is a background process.

--- a/client/Packages/com.beamable/Common/Runtime/Constants/Implementations/ServiceConstants.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Constants/Implementations/ServiceConstants.cs
@@ -23,6 +23,8 @@ namespace Beamable.Common
 
 				public const string REMOTE_ONLY = "Remote Only";
 
+				public const string CONTENT_UPDATE_EVENT = "content.manifest";
+
 				public const int HEALTH_PORT = 6565;
 
 				public const string UPLOAD_CONTAINER_MESSAGE = "Uploaded container service=[{0}]";

--- a/microservice/microservice/Content/ContentService.cs
+++ b/microservice/microservice/Content/ContentService.cs
@@ -154,7 +154,7 @@ namespace Beamable.Server.Content
 
       public void Init()
       {
-         _socket.Subscribe<ContentManifestEvent>("content.manifest", HandleContentPublish);
+         _socket.Subscribe<ContentManifestEvent>(Constants.Features.Services.CONTENT_UPDATE_EVENT, HandleContentPublish);
       }
 
       void HandleContentPublish(ContentManifestEvent manifestEvent)

--- a/microservice/microservice/dbmicroservice/BeamableMicroService.cs
+++ b/microservice/microservice/dbmicroservice/BeamableMicroService.cs
@@ -72,9 +72,16 @@ namespace Beamable.Server
       public string result;
    }
 
-   public class MicroserviceProviderRequest
+   public class MicroserviceServiceProviderRequest
    {
-      public string name, type;
+	   public string type = "basic";
+	   public string name;
+   }
+
+   public class MicroserviceEventProviderRequest
+   {
+	   public string type = "event";
+	   public string[] evtWhitelist;
    }
 
    public class MicroserviceProviderResponse
@@ -929,7 +936,7 @@ namespace Beamable.Server
 
       private Promise<Unit> ProvideService(string name)
       {
-         var req = new MicroserviceProviderRequest
+         var req = new MicroserviceServiceProviderRequest
          {
             type = "basic",
             name = name
@@ -949,7 +956,7 @@ namespace Beamable.Server
 
       private Promise<Unit> RemoveService(string name)
       {
-         var req = new MicroserviceProviderRequest
+         var req = new MicroserviceServiceProviderRequest
          {
             type = "basic",
             name = name

--- a/microservice/microservice/dbmicroservice/MicroserviceRequester.cs
+++ b/microservice/microservice/dbmicroservice/MicroserviceRequester.cs
@@ -524,9 +524,10 @@ namespace Beamable.Server
       /// <returns></returns>
       public Promise<EmptyResponse> InitializeSubscription()
       {
-         var req = new MicroserviceProviderRequest
+         var req = new MicroserviceEventProviderRequest
          {
-            type = "event"
+            type = "event",
+            evtWhitelist = new []{Constants.Features.Services.CONTENT_UPDATE_EVENT}
          };
          var promise = Request<MicroserviceProviderResponse>(Method.POST, "gateway/provider", req);
 

--- a/microservice/microserviceTests/microservice/TestSocket.cs
+++ b/microservice/microserviceTests/microservice/TestSocket.cs
@@ -818,7 +818,7 @@ namespace Beamable.Microservice.Tests.Socket
                      .WithRouteContains("gateway/provider")
                      .WithReqId(-3 - requestIdOffset)
                      .WithPost()
-                     .WithBody<MicroserviceProviderRequest>(body => body.type == "basic"),
+                     .WithBody<MicroserviceServiceProviderRequest>(body => body.type == "basic"),
                   MessageResponder.Success(new MicroserviceProviderResponse()),
                   MessageFrequency.OnlyOnce()
                )
@@ -827,7 +827,7 @@ namespace Beamable.Microservice.Tests.Socket
                      .WithRouteContains("gateway/provider")
                      .WithReqId(-4 - requestIdOffset)
                      .WithPost()
-                     .WithBody<MicroserviceProviderRequest>(body => body.type == "event"),
+                     .WithBody<MicroserviceServiceProviderRequest>(body => body.type == "event"),
                   MessageResponder.Success(new MicroserviceProviderResponse()),
                   MessageFrequency.OnlyOnce()
                );
@@ -846,7 +846,7 @@ namespace Beamable.Microservice.Tests.Socket
 		        MessageMatcher
 			        .WithRouteContains("gateway/provider")
 			        .WithDelete()
-			        .WithBody<MicroserviceProviderRequest>(body => body.type == "basic"),
+			        .WithBody<MicroserviceServiceProviderRequest>(body => body.type == "basic"),
 		        MessageResponder.Success(new MicroserviceProviderResponse()),
 		        MessageFrequency.OnlyOnce()
 	        );

--- a/microservice/microserviceTests/microservice/dbmicroservice/BeamableMicroServiceTests/StartTests.cs
+++ b/microservice/microserviceTests/microservice/dbmicroservice/BeamableMicroServiceTests/StartTests.cs
@@ -450,7 +450,7 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
                    MessageMatcher
                       .WithRouteContains("gateway/provider")
                       .WithDelete()
-                      .WithBody<MicroserviceProviderRequest>(body => body.type == "basic"),
+                      .WithBody<MicroserviceServiceProviderRequest>(body => body.type == "basic"),
                    MessageResponder.SuccessWithDelay(providerDelay, new MicroserviceProviderResponse()),
                    MessageFrequency.OnlyOnce()
                 )
@@ -459,7 +459,7 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
                       .WithRouteContains("gateway/provider")
                       .WithReqId(-3)
                       .WithPost()
-                      .WithBody<MicroserviceProviderRequest>(body => body.type == "basic"),
+                      .WithBody<MicroserviceServiceProviderRequest>(body => body.type == "basic"),
                    MessageResponder.SuccessWithDelay(eventDelay, new MicroserviceProviderResponse()),
                    MessageFrequency.OnlyOnce()
                 )
@@ -468,7 +468,7 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
                       .WithRouteContains("gateway/provider")
                       .WithReqId(-4)
                       .WithPost()
-                      .WithBody<MicroserviceProviderRequest>(body => body.type == "event"),
+                      .WithBody<MicroserviceServiceProviderRequest>(body => body.type == "event"),
                    res =>
                    {
                        eventProvided = true;
@@ -553,7 +553,7 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
                    MessageMatcher
                       .WithRouteContains("gateway/provider")
                       .WithDelete()
-                      .WithBody<MicroserviceProviderRequest>(body => body.type == "basic"),
+                      .WithBody<MicroserviceServiceProviderRequest>(body => body.type == "basic"),
                    MessageResponder.SuccessWithDelay(providerDelay, new MicroserviceProviderResponse()),
                    MessageFrequency.OnlyOnce()
                 )
@@ -562,7 +562,7 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
                       .WithRouteContains("gateway/provider")
                       .WithReqId(-3)
                       .WithPost()
-                      .WithBody<MicroserviceProviderRequest>(body => body.type == "basic"),
+                      .WithBody<MicroserviceServiceProviderRequest>(body => body.type == "basic"),
                    MessageResponder.SuccessWithDelay(eventDelay, new MicroserviceProviderResponse()),
                    MessageFrequency.OnlyOnce()
                 )
@@ -571,7 +571,7 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
                       .WithRouteContains("gateway/provider")
                       .WithReqId(-4)
                       .WithPost()
-                      .WithBody<MicroserviceProviderRequest>(body => body.type == "event"),
+                      .WithBody<MicroserviceServiceProviderRequest>(body => body.type == "event"),
                    res =>
                    {
                        eventProvided = true;
@@ -642,7 +642,7 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
                    MessageMatcher
                       .WithRouteContains("gateway/provider")
                       .WithDelete()
-                      .WithBody<MicroserviceProviderRequest>(body => body.type == "basic"),
+                      .WithBody<MicroserviceServiceProviderRequest>(body => body.type == "basic"),
                    MessageResponder.SuccessWithDelay(providerDelay, new MicroserviceProviderResponse()),
                    MessageFrequency.OnlyOnce()
                 )
@@ -651,7 +651,7 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
                       .WithRouteContains("gateway/provider")
                       .WithReqId(-3)
                       .WithPost()
-                      .WithBody<MicroserviceProviderRequest>(body => body.type == "basic"),
+                      .WithBody<MicroserviceServiceProviderRequest>(body => body.type == "basic"),
                    MessageResponder.SuccessWithDelay(eventDelay, new MicroserviceProviderResponse()),
                    MessageFrequency.OnlyOnce()
                 )
@@ -660,7 +660,7 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
                       .WithRouteContains("gateway/provider")
                       .WithReqId(-4)
                       .WithPost()
-                      .WithBody<MicroserviceProviderRequest>(body => body.type == "event"),
+                      .WithBody<MicroserviceServiceProviderRequest>(body => body.type == "event"),
                    res =>
                    {
                        eventProvided = true;
@@ -724,7 +724,7 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
 					        .WithRouteContains("gateway/provider")
 					        .WithReqId(-3)
 					        .WithPost()
-					        .WithBody<MicroserviceProviderRequest>(body => body.type == "basic"),
+					        .WithBody<MicroserviceServiceProviderRequest>(body => body.type == "basic"),
 				        MessageResponder.Success(new MicroserviceProviderResponse()),
 				        MessageFrequency.OnlyOnce()
 			        )
@@ -1060,7 +1060,7 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
                    MessageMatcher
                       .WithRouteContains("gateway/provider")
                       .WithDelete()
-                      .WithBody<MicroserviceProviderRequest>(body => body.type == "basic"),
+                      .WithBody<MicroserviceServiceProviderRequest>(body => body.type == "basic"),
                    MessageResponder.Success(new MicroserviceProviderResponse()),
                    MessageFrequency.OnlyOnce()
                 )
@@ -1069,7 +1069,7 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
                       .WithRouteContains("gateway/provider")
                       .WithReqId(-3)
                       .WithPost()
-                      .WithBody<MicroserviceProviderRequest>(body => body.type == "basic"),
+                      .WithBody<MicroserviceServiceProviderRequest>(body => body.type == "basic"),
                    MessageResponder.SuccessWithDelay(basicProviderDelay, new MicroserviceProviderResponse()),
                    MessageFrequency.OnlyOnce()
                 )
@@ -1078,7 +1078,7 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
                       .WithRouteContains("gateway/provider")
                       .WithReqId(-4)
                       .WithPost()
-                      .WithBody<MicroserviceProviderRequest>(body => body.type == "event"),
+                      .WithBody<MicroserviceServiceProviderRequest>(body => body.type == "event"),
                    res =>
                    {
                        eventProvided = true;


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2871

# Brief Description
We recently updated thorium to accept a white list of events to actually send to the client. Now, we just need the service to send a whitelist, which in this case, should ONLY be the content update event.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
