### PR TITLE
beam 2878 - add back required field to eventProvider

### DIFF
--- a/microservice/microservice/dbmicroservice/BeamableMicroService.cs
+++ b/microservice/microservice/dbmicroservice/BeamableMicroService.cs
@@ -82,6 +82,7 @@ namespace Beamable.Server
    {
 	   public string type = "event";
 	   public string[] evtWhitelist;
+	   public string name; // We can remove this field after the platform no longer needs it. Maybe mid August 2022?
    }
 
    public class MicroserviceProviderResponse


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2878

# Brief Description
I goofed, and forgot that until we release the next plat production (in 2 weeks), we still need to send this `name` field on the event provider request. It never did anything, but it used to be _required_. The new version of plat won't require it anymore, but until then, we still need it to appear in the JSON, otherwise the request fails.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
