### PR TITLE
beam 2885 - delete meta files on archive

### DIFF
--- a/client/Packages/com.beamable.server/Editor/MicroserviceEditor.cs
+++ b/client/Packages/com.beamable.server/Editor/MicroserviceEditor.cs
@@ -291,12 +291,14 @@ namespace Beamable.Server.Editor
 				if (descriptor is MicroserviceDescriptor desc)
 				{
 					FileUtil.DeleteFileOrDirectory(desc.SourcePath);
+					FileUtil.DeleteFileOrDirectory(Path.ChangeExtension(desc.SourcePath, "meta"));
 					FileUtil.DeleteFileOrDirectory(desc.HidePath);
 					FileUtil.DeleteFileOrDirectory(desc.BuildPath);
 				}
 				else if (descriptor is StorageObjectDescriptor storageDesc)
 				{
 					string directoryPath = Path.GetDirectoryName(storageDesc.AttributePath);
+					FileUtil.DeleteFileOrDirectory(Path.ChangeExtension(storageDesc.AttributePath, "meta"));
 					FileUtil.DeleteFileOrDirectory(directoryPath);
 				}
 			}


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2885

# Brief Description
We were deleting the service folders, but Unity has a meta file for the folder itself, so there is a sneaky thing outside the folder we need to delete.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
