### PR TITLE
beam 2876 - dont publish disabled, various fixes

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Microservices share a realm secret request for faster development builds
 - Local microservices no longer output emoji characters from their `dotnet watch` command
 - Microservices only receive events for content updates
+- Disabled Microservices no longer get built and published.
 
 ### Fixed
 - Microservice related actions can run while Unity is a background process.
@@ -35,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Local Microservices no longer say "could not find servicename:latest"
 - Publish flow locks Asset Database so that no re-imports may happen.
 - Fixed potential microservice issue that caused C#MSs to hang during initialization.
+- Publish screen loading bar should always be full when publish is complete.
 
 ### Removed
 - Unused legacy code around "Auto Run Local Microservices" menu item

--- a/client/Packages/com.beamable.server/Editor/ReflectionCache/UserSystems/MicroserviceReflectionCache.cs
+++ b/client/Packages/com.beamable.server/Editor/ReflectionCache/UserSystems/MicroserviceReflectionCache.cs
@@ -373,8 +373,23 @@ namespace Beamable.Server.Editor
 					{
 						Level = LogLevel.INFO,
 						Timestamp = LogMessage.GetTimeDisplay(DateTime.Now),
-						Message = $"Building service=[{descriptor.Name}]"
+						Message = $"Checking service=[{descriptor.Name}]"
 					});
+
+					// If the service is disabled, then we won't bother uploading it.
+					var entryModel = model.Services[descriptor.Name];
+					if (!entryModel.Enabled)
+					{
+						logger(new LogMessage
+						{
+							Level = LogLevel.INFO,
+							Timestamp = LogMessage.GetTimeDisplay(DateTime.Now),
+							Message = $"Skipping service=[{descriptor.Name}] because it is disabled."
+						});
+						UpdateServiceDeployStatus(descriptor, ServicePublishState.Published);
+						onServiceDeployed?.Invoke(descriptor);
+						continue;
+					}
 
 					var forceStop = new StopImageReturnableCommand(descriptor);
 					await forceStop.StartAsync(); // force the image to stop.
@@ -476,6 +491,7 @@ namespace Beamable.Server.Editor
 
 						return;
 					}
+					UpdateServiceDeployStatus(descriptor, ServicePublishState.InProgress);
 
 
 					if (token.IsCancellationRequested)
@@ -540,7 +556,6 @@ namespace Beamable.Server.Editor
 						}
 					}
 
-					var entryModel = model.Services[descriptor.Name];
 					var serviceDependencies = new List<ServiceDependency>();
 					foreach (var storage in descriptor.GetStorageReferences())
 					{
@@ -573,6 +588,30 @@ namespace Beamable.Server.Editor
 														   UpdateServiceDeployStatus(descriptor, ServicePublishState.Failed);
 													   }
 												   }, imageId);
+				}
+
+
+
+				// at this point, all storage objects should at least be marked as complete.
+				foreach (var storage in StorageDescriptors)
+				{
+					logger(new LogMessage
+					{
+						Level = LogLevel.INFO,
+						Timestamp = LogMessage.GetTimeDisplay(DateTime.Now),
+						Message = $"Comitting storage=[{storage.Name}]"
+					});
+					onServiceDeployed?.Invoke(storage);
+					OnServiceDeployStatusChanged?.Invoke(storage, ServicePublishState.Published);
+				}
+
+				// we should mark all remote services as complete as well.
+				var remoteOnlyServices = model.Services.Where(s => !nameToImageDetails.ContainsKey(s.Key)).ToList();
+				foreach (var remoteOnly in remoteOnlyServices)
+				{
+					var desc = new MicroserviceDescriptor {Name = remoteOnly.Key};
+					onServiceDeployed?.Invoke(desc);
+					OnServiceDeployStatusChanged?.Invoke(desc, ServicePublishState.Published);
 				}
 
 				logger(new LogMessage


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2876

# Brief Description
A few things...
Pedro & Allister and I had a convo about NOT building&saving&publishing disabled services, with the major reason being, "hey, they aren't going to run, and its super unlikely anyone will re-enable it from portal anyway, and it'd save so much time if they didn't". 

So this PR makes the publish flow just "skip" disabled services, and move on. 
Also, we had some random bugs where the progress bar and status icons weren't updating correctly for storage objects and remote services, so I fixed that too.


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
