### PR TITLE
[BEAM-2899] Sample Utility window hidden for non BEAMABLE_DEVELOPER users

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/SampleUtility/SampleUtilityWindow.cs
+++ b/client/Packages/com.beamable/Editor/UI/SampleUtility/SampleUtilityWindow.cs
@@ -22,12 +22,16 @@ namespace Beamable.Editor.UI.SampleUtility
 			};
 		}
 
+#if BEAMABLE_DEVELOPER
 		[MenuItem(
 			Constants.MenuItems.Windows.Paths.MENU_ITEM_PATH_WINDOW_BEAMABLE_UTILITIES_SAMPLE,
 			priority = Constants.MenuItems.Windows.Orders.MENU_ITEM_PATH_WINDOW_PRIORITY_1
 		)]
+#endif
 		public static async void Init() => await GetFullyInitializedWindow();
-		public static async void Init(BeamEditorWindowInitConfig initParameters) => await GetFullyInitializedWindow(initParameters);
+
+		public static async void Init(BeamEditorWindowInitConfig initParameters) =>
+			await GetFullyInitializedWindow(initParameters);
 
 		private string currentTypeToAddOrRemove = "";
 		private HashSet<string> currentlySelectedTypes = new HashSet<string>();
@@ -44,7 +48,8 @@ namespace Beamable.Editor.UI.SampleUtility
 			var listOfPossibleTypes = registry.SampleTypesContainingDependencyFunctions.ToList();
 			listOfPossibleTypes.Add("");
 
-			var popup = new PopupField<string>("RegisterBeamableDependency in Samples", listOfPossibleTypes, currentTypeToAddOrRemove);
+			var popup = new PopupField<string>("RegisterBeamableDependency in Samples", listOfPossibleTypes,
+			                                   currentTypeToAddOrRemove);
 			popup.RegisterValueChangedCallback(evt => currentTypeToAddOrRemove = evt.newValue);
 
 			var addBtn = new Button(() =>
@@ -52,24 +57,25 @@ namespace Beamable.Editor.UI.SampleUtility
 				if (string.IsNullOrEmpty(currentTypeToAddOrRemove)) return;
 
 				currentlySelectedTypes.Add(currentTypeToAddOrRemove);
-				EditorPrefs.SetString(Constants.EditorPrefKeys.ALLOWED_SAMPLES_REGISTER_FUNCTIONS, string.Join(";", currentlySelectedTypes));
+				EditorPrefs.SetString(Constants.EditorPrefKeys.ALLOWED_SAMPLES_REGISTER_FUNCTIONS,
+				                      string.Join(";", currentlySelectedTypes));
 
 				BuildWithContext(ActiveContext);
-			})
-			{ text = "+" };
+			}) {text = "+"};
 
 			var removeBtn = new Button(() =>
 			{
 				if (string.IsNullOrEmpty(currentTypeToAddOrRemove)) return;
 
 				currentlySelectedTypes.Remove(currentTypeToAddOrRemove);
-				EditorPrefs.SetString(Constants.EditorPrefKeys.ALLOWED_SAMPLES_REGISTER_FUNCTIONS, string.Join(";", currentlySelectedTypes));
+				EditorPrefs.SetString(Constants.EditorPrefKeys.ALLOWED_SAMPLES_REGISTER_FUNCTIONS,
+				                      string.Join(";", currentlySelectedTypes));
 
 				BuildWithContext(ActiveContext);
-			})
-			{ text = "-" };
+			}) {text = "-"};
 
-			var text = new Label($"Selected Types (in Samples) whose RegisterBeamableDependencies Functions will run: {string.Join("\n", currentlySelectedTypes)}");
+			var text = new Label(
+				$"Selected Types (in Samples) whose RegisterBeamableDependencies Functions will run: {string.Join("\n", currentlySelectedTypes)}");
 
 			this.rootVisualElement.Add(popup);
 			this.rootVisualElement.Add(addBtn);


### PR DESCRIPTION
# Ticket

# Brief Description
Now users without BEAMABLE_DEVELOPER symbol can't acces Sample Utility window from Window/Beamable/Utilities/Sample Utility option

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
