### PR TITLE
beam 2903 - remove content object warning

### DIFF
--- a/client/Packages/com.beamable/Common/Runtime/Content/ContentTypeReflectionCache.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Content/ContentTypeReflectionCache.cs
@@ -71,7 +71,7 @@ namespace Beamable.Common.Content
 
 		public void OnBaseTypeOfInterestFound(BaseTypeOfInterest baseType, IReadOnlyList<MemberInfo> cachedSubTypes)
 		{
-			// Gather all validation results ensuring the ContentTypeAttribute exists and Validation 
+			// Gather all validation results ensuring the ContentTypeAttribute exists and Validation
 			var contentTypeAttributePairs = new List<MemberAttribute>();
 			{
 				var warningMessage = "This type is not deserializable by Beamable and you will not be able to create content of this type directly via the Content Manager!";
@@ -80,6 +80,9 @@ namespace Beamable.Common.Content
 																							null, info, ReflectionCache.ValidationResultType.Warning, warningMessage));
 
 				validationResults.SplitValidationResults(out var valid, out var warnings, out var errors);
+
+				// manually remove the ContentObject from the warnings set.
+				warnings.RemoveAll(r => r.Pair.Info == typeof(ContentObject));
 
 #if UNITY_EDITOR
 				// Warning level validations that happen for the content type attribute.
@@ -102,7 +105,7 @@ namespace Beamable.Common.Content
 				contentTypeAttributePairs.AddRange(valid.Select(a => a.Pair));
 			}
 
-			// Gather all validation results ensuring the ContentTypeAttribute exists and Validation 
+			// Gather all validation results ensuring the ContentTypeAttribute exists and Validation
 			var formerContentTypeAttributePairs = new List<MemberAttribute>();
 			{
 				var validationResults = cachedSubTypes.GetAndValidateAttributeExistence(CONTENT_TYPE_FORMERLY_SERIALIZED_AS_ATTRIBUTE,
@@ -156,7 +159,7 @@ namespace Beamable.Common.Content
 
 				var validContentTypes = valid.Select(v => v.Pair.Info as Type).ToList();
 
-				// Cache data 😃                   
+				// Cache data 😃
 				foreach (var type in validContentTypes)
 				{
 					AddContentTypeToDictionaries(type, contentTypeToClassDict, classToContentTypeDict);


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2903

# Brief Description
Seems like the hint system is picking up that our base type `ContentObject` doesn't have the `ContentType` attribute on it. I don't want to mess with the detection logic, and its a one liner to just _remove_ that from the output type.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
