### PR TITLE
beam 2886 - toolbox alignment

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Toolbox/Components/ToolboxContentListVisualElement/ToolboxContentListVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Toolbox/Components/ToolboxContentListVisualElement/ToolboxContentListVisualElement.cs
@@ -134,7 +134,7 @@ namespace Beamable.Editor.Toolbox.Components
 			for (var i = 0; i < ExtraElementCount; i++)
 			{
 				var widgetElement = new ToolboxFeatureVisualElement();
-				widgetElement.AddToClassList("invisible");
+				widgetElement.AddToClassList("toolbox-invisible-element");
 				widgetElement.Refresh();
 				_extraElements.Add(widgetElement);
 				_gridContainer.Add(widgetElement);

--- a/client/Packages/com.beamable/Editor/UI/Toolbox/Components/ToolboxFeatureVisualElement/ToolboxFeatureVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Toolbox/Components/ToolboxFeatureVisualElement/ToolboxFeatureVisualElement.uss
@@ -21,7 +21,7 @@ ToolboxFeatureVisualElement {
     max-height: 160px;
 }
 
-ToolboxFeatureVisualElement.invisible{
+ToolboxFeatureVisualElement.toolbox-invisible-element{
     opacity: 0;
 }
 


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2886

# Brief Description
a uss bug :*( 
We had a class called `invisible` that we were adding to the extra elements that we use to pad the toolbox and keep left-alignment... All its supposed to do is turn the elements' opacity to 0. 
Buuuut, at some point, we added an 'invisible' class to a common parent type that was taking the elements out fo the layout engine by using `position: absolute`, and it was (incorrectly) applying to our poor toolbox.

So I just changed the class name we use.
<img width="1044" alt="image" src="https://user-images.githubusercontent.com/3848374/183166687-f389f9c6-6f19-4c08-8cbf-476771508b4d.png">


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
