### PR TITLE
beam-2888 - avoid Nan for column layouts

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ContentListVisualElement/ContentListVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ContentListVisualElement/ContentListVisualElement.cs
@@ -149,10 +149,11 @@ namespace Beamable.Editor.Content.Components
 			listElement.Q("tagListVisualElement").style.flexGrow = (GetHeaderSizeChanges()[2].Flex);
 			listElement.Q("lastChanged").style.flexGrow = (GetHeaderSizeChanges()[3].Flex);
 
-			listElement.Q("nameTextField").style.minWidth = (_headerSizeChanges[0].MinWidth);
-			listElement.Q("pathLabel").style.minWidth = (_headerSizeChanges[1].MinWidth);
-			listElement.Q("tagListVisualElement").style.minWidth = (_headerSizeChanges[2].MinWidth);
-			listElement.Q("lastChanged").style.minWidth = (_headerSizeChanges[3].MinWidth);
+
+			listElement.Q("nameTextField").style.minWidth = (_headerSizeChanges[0].SafeMinWidth);
+			listElement.Q("pathLabel").style.minWidth = (_headerSizeChanges[1].SafeMinWidth);
+			listElement.Q("tagListVisualElement").style.minWidth = (_headerSizeChanges[2].SafeMinWidth);
+			listElement.Q("lastChanged").style.minWidth = (_headerSizeChanges[3].SafeMinWidth);
 		}
 
 		private void Model_OnFilteredContentChanged()

--- a/client/Packages/com.beamable/Editor/UI/Content/Components/HeaderVisualElement/HeaderVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/HeaderVisualElement/HeaderVisualElement.cs
@@ -15,6 +15,9 @@ namespace Beamable.Editor.Content.Components
 	public struct HeaderSizeChange
 	{
 		public float Flex, MinWidth;
+
+		public float SafeMinWidth => float.IsNaN(MinWidth) ? 0 : MinWidth;
+
 	}
 
 	public class HeaderVisualElement : ContentManagerComponent


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2888

# Brief Description

The layout stuff for this table is _jank_, yo. 
Anyway, it seems like sometimes its possible for the minWidths to appear as `NaN`, which causes the uss layout engine to go bezerk. So, I added a thing to say, "if its NaN, just do anything but allow that... how about 0? Better than exploding". And hey, it worked like a charm :D

This falls firmly in the camp of, "my code works and I don't know why"

<img width="614" alt="image" src="https://user-images.githubusercontent.com/3848374/183181521-a9b1f9d8-191e-4c5d-b752-7f50a3b911b6.png">

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
