### PR TITLE
fix publishing microservices

### DIFF
--- a/client/Packages/com.beamable.server/Editor/DockerCommands/GetImageIdCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/GetImageIdCommand.cs
@@ -17,7 +17,7 @@ namespace Beamable.Server.Editor.DockerCommands
 		}
 		public override string GetCommandString()
 		{
-			var formatString = "--format='{{.Id}}" + SEPARATOR + "{{.Architecture}}" + SEPARATOR + "{{.Os}}"; // string interpolation with {{}} is more confusing than string concat.
+			var formatString = "--format={{.Id}}" + SEPARATOR + "{{.Architecture}}" + SEPARATOR + "{{.Os}}"; // string interpolation with {{}} is more confusing than string concat.
 			return $"{DockerCmd} inspect {formatString} {ImageName}";
 		}
 


### PR DESCRIPTION
# Ticket

# Brief Description

Seems like parameters for inspect command are incorrectly build and results in returning architecture value like `linux/amd64'` and because of this I was unable to publish microservices.

![2022-08-08 14_35_06-cmd](https://user-images.githubusercontent.com/2392583/183419945-47761fb0-1f58-47fd-be0f-0b945a1a41ac.png)

![image](https://user-images.githubusercontent.com/2392583/183420046-3069fdb9-8056-4241-b7e7-b1c9da2f0fc3.png)


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
