### PR TITLE
beam 2880 - clone list before enumeration

### DIFF
--- a/client/Packages/com.beamable/Common/Runtime/Dependencies/DependencyProvider.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Dependencies/DependencyProvider.cs
@@ -243,9 +243,9 @@ namespace Beamable.Common.Dependencies
 
 			void DisposeServices(IEnumerable<object> services)
 			{
-				foreach (var service in services)
+				var clonedList = new List<object>(services);
+				foreach (var service in clonedList)
 				{
-
 					if (service == null) continue;
 					if (service is IBeamableDisposable disposable)
 					{


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2880

# Brief Description
As the service is tearing down, seems like there can be some collection modification. 
So as a bug-patch, I clone the list before enumeration. This feels like maybe there is still a bug lurking in the corner, but the error should go away at least

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
