### PR TITLE
beam 2774 - access the beam editor context from the mmv2 window init process

### DIFF
--- a/client/Packages/com.beamable.server/Editor/MicroserviceEditor.cs
+++ b/client/Packages/com.beamable.server/Editor/MicroserviceEditor.cs
@@ -65,6 +65,7 @@ namespace Beamable.Server.Editor
 				try
 				{
 					BeamEditor.GetReflectionSystem<MicroserviceReflectionCache.Registry>();
+					var _ = BeamEditorContext.Default; // access the beam context
 				}
 				catch (InvalidOperationException)
 				{

--- a/client/Packages/com.beamable.server/Editor/UI/MicroserviceWindow.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/MicroserviceWindow.cs
@@ -37,7 +37,7 @@ namespace Beamable.Editor.Microservice.UI
 				RequireLoggedUser = true,
 			};
 
-			CustomDelayClause = () => !MicroserviceEditor.IsInitialized;
+			CustomDelayClause = () => !MicroserviceEditor.IsInitialized && BeamEditorContext.Default.InitializePromise.IsCompleted;
 		}
 
 		[MenuItem(


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2774

# Brief Description
Super hard to reproduce this, but i think that its possible to skip the `BeamEditorContext` init process when jumping _straight_ to the MMV2 window, so lets put the access hooks in place to make sure `BeamEditorContext` has been woken up.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
