### PR TITLE
beam 2928- add friend import to psdk

### DIFF
--- a/client/Packages/com.beamable/Runtime/Player/PlayerFriends.cs
+++ b/client/Packages/com.beamable/Runtime/Player/PlayerFriends.cs
@@ -296,14 +296,13 @@ namespace Beamable.Player
 		}
 
 		/// <summary>
-		/// Import friends from a third party.
-		/// At the moment, only Facebook friends are supported.
+		/// Import friends from Facebook.
 		/// </summary>
 		/// <param name="thirdPartyAuthToken">
-		/// An access token issued from the third party that can be sent to Beamable so that the Beamable Cloud can perform the friend import.
+		/// An access token issued from Facebook that can be sent to Beamable so that the Beamable Cloud can perform the friend import.
 		/// </param>
 		/// <returns>A <see cref="Promise"/> representing the network call.</returns>
-		public async Promise ImportThirdPartyFriends(string thirdPartyAuthToken)
+		public async Promise ImportFacebookFriends(string thirdPartyAuthToken)
 		{
 			await _socialApi.ImportFriends(SocialThirdParty.Facebook, thirdPartyAuthToken);
 			await Refresh();


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2928

# Brief Description
There was a part of the friend api that we needed to add to the psdk layer, which is for importing third party friends.
Since we only support facebook, I opted to not include the enum in the method sig.


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
