### PR TITLE
beam 2920 - route table regeneration

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Fixed
+- Microservices reload route table after hot module reload code change. 
+
 ## [1.3.0]
 ### Added
 - User can specify Microservices build and deploy CPU architecture. 

--- a/microservice/microservice/dbmicroservice/MicroserviceArgs.cs
+++ b/microservice/microservice/dbmicroservice/MicroserviceArgs.cs
@@ -54,7 +54,7 @@ namespace Beamable.Server
       public string Secret => Environment.GetEnvironmentVariable("SECRET");
       public string NamePrefix => Environment.GetEnvironmentVariable("NAME_PREFIX") ?? "";
       public string SdkVersionExecution => Environment.GetEnvironmentVariable("BEAMABLE_SDK_VERSION_EXECUTION") ?? "";
-      public bool WatchToken => (Environment.GetEnvironmentVariable("WATCH_TOKEN") ?? "") == "true";
+      public bool WatchToken => (Environment.GetEnvironmentVariable("WATCH_TOKEN")?.ToLowerInvariant() ?? "") == "true";
       public bool DisableCustomInitializationHooks => (Environment.GetEnvironmentVariable("DISABLE_CUSTOM_INITIALIZATION_HOOKS")?.ToLowerInvariant() ?? "") == "true";
       public string SdkVersionBaseBuild => File.ReadAllText(".beamablesdkversion").Trim();
    }


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2920

# Brief Description
Somewhere along the line, the `WatchToken` env var used to be sent as "true", but then started getting sent as "True", so our regeneration logic wasn't triggering :/ 

Silly fix, just need to do a case-insensitive check.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
