### PR TITLE
beam 2938 - null check config elements

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Publish doesn't fail if there is an unused StorageObject entry in the MicroserviceConfiguration 
 
 ## [1.3.0]
 ### Added

--- a/client/Packages/com.beamable.server/Editor/UI/Components/PublishPopup/PublishPopup.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/PublishPopup/PublishPopup.cs
@@ -296,7 +296,12 @@ namespace Beamable.Editor.Microservice.UI.Components
 
 		private void HandleServiceDeployStatusChanged(IDescriptor descriptor, ServicePublishState state)
 		{
-			_publishManifestElements[descriptor.Name]?.UpdateStatus(state);
+			if (!_publishManifestElements.TryGetValue(descriptor.Name, out var element))
+			{
+				return;
+			}
+
+			element?.UpdateStatus(state);
 			SortServices();
 			switch (state)
 			{


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2931
(sub ticket)

# Brief Description
There was an issue where if a storage object entry exists in the config, but it doesn't exist on the realm, or in the code, then we'd null-access a dictionary.
In this particular method, its only doing a visual update, so we can just "do nothing" if the entry is null.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
