### PR TITLE
beam 2942 - docker build fixes

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Microservices reload route table after hot module reload code change. 
+- Microservices stop stale containers before rebuilding.
+- Microservices recognize build failure vs success correctly during local development.
+
+### Changed
+- Microservices use the docker `-v` flag to specify bind mounts instead of `--mount`.
 
 ## [1.3.0]
 ### Added

--- a/client/Packages/com.beamable.server/Editor/DockerCommands/BuildImageCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/BuildImageCommand.cs
@@ -122,12 +122,7 @@ and then setting the beamable-builder as the default docker builder.";
 
 		protected override void Resolve()
 		{
-			bool success = StandardErrorBuffer?.Contains($"naming to docker.io/library/{_descriptor.ImageName} done") ?? true;
-			if (MicroserviceConfiguration.Instance.DisableDockerBuildkit)
-			{
-				success = string.IsNullOrEmpty(StandardErrorBuffer);
-			}
-
+			var success = _exitCode == 0;
 			SetAsBuild(_descriptor, success);
 			if (success)
 			{

--- a/client/Packages/com.beamable.server/Editor/DockerCommands/RunImageCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/RunImageCommand.cs
@@ -267,8 +267,8 @@ namespace Beamable.Server.Editor.DockerCommands
 				includeOuterQuotes = true;
 #endif
 				var quoteStr = includeOuterQuotes ? "'" : "";
-				var optionStr = $"{(isReadOnly ? "readonly," : "")}type=bind,source=\"{src}\",dst={dst}";
-				return $"--mount {quoteStr}{optionStr}{quoteStr}";
+				var optionStr = $"\"{src}\":{dst}{(isReadOnly ? ":ro": "")}";
+				return $"-v {quoteStr}{optionStr}{quoteStr}";
 			}
 		}
 

--- a/client/Packages/com.beamable.server/Editor/UI/Model/MicroserviceBuilder.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Model/MicroserviceBuilder.cs
@@ -100,6 +100,7 @@ namespace Beamable.Editor.UI.Model
 
 		public async Task<bool> TryToBuild(bool includeDebuggingTools)
 		{
+			await TryToStop();
 			if (IsBuilding) return true;
 
 			IsBuilding = true;

--- a/client/Packages/com.beamable.server/Editor/UI/Model/ServiceBuilderBase.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Model/ServiceBuilderBase.cs
@@ -87,7 +87,6 @@ namespace Beamable.Editor.UI.Model
 
 		public async Task TryToStop()
 		{
-			if (!IsRunning) return;
 			if (_isStopping) return;
 
 			_isStopping = true;


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2942

# Brief Description
As always, a few things...
1. Our `BuildImageCommand` was using log parsing to check for success failure. However, it seems like docker slightly changed their log output on different versions of docker. (they added the duration log to the final build step), so our log matcher broke. Instead of doing log matches, we can actually just use the exit code from the docker process, which is cleaner, and I'm not sure why we didn't do that originally. 
2. Our bind-mounts used to use a legacy docker flag, `--mount`, which wouldn't create the bind mount source directory if it didn't exist. I think given some IO oddness, docker would sometimes think that the `/temp/beam/service` directory didn't exist at quite the right time... Buuut, turns out, there is a "new" flag called `-v` which does everything `--mount` did, and _more_, like sort out the IO problem. 
3. When we click the play button for a C#MS, we would stop the container, build it, and re-run it. Buuut, if there is any sort of runtime bug that causes the container to _not_ log the "Service Ready For Traffic Line", then our code doesn't think the service is running yet- and it'll log the error, and make the play button appear "off". In some ways, this is fine, because the service isn't really accepting traffic. But, a major bug was that if the user cleared their logs, so-in-lost the failure log, and then tried to hit the play button again, they'd get a "cannot modify file directory" error, because our code that stops the existing container failed to recognize there _was_ a container running. It jumped straight to the build step, which would fail to delete the build directory, because it was being used by a running container. The easy fix is, "Always try to stop a container before building". Even if there isn't a container, the effort it takes to shoot a docker-stop command and shrug if it fails is totally worth it.


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings-and-Comments)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
