### PR TITLE
beam 2945 - disallow arm publish

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -5,15 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fixed
-- Publish doesn't fail if there is an unused StorageObject entry in the MicroserviceConfiguration 
-
-## [Unreleased]
-
 ### Added
 - A leaderboard can now be frozen using `Services.Leaderboards.FreezeLeaderboard` method to prevent additional scores to be submitted.
 
 ### Fixed
+- Publish doesn't fail if there is an unused StorageObject entry in the MicroserviceConfiguration
 - Microservices reload route table after hot module reload code change. 
 - Microservices can accept `InventoryUpdateBuilder` and other types that include subclasses of `SerializableStringTo<T>`
 - Microservices stop stale containers before rebuilding.
@@ -23,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Microservices use the docker `-v` flag to specify bind mounts instead of `--mount`.
+- Microservices may not be published as ARM images. Microservices will be forced to "linux/amd64" architecture.
 
 ## [1.3.0]
 ### Added

--- a/client/Packages/com.beamable.server/Editor/MicroserviceConfiguration.cs
+++ b/client/Packages/com.beamable.server/Editor/MicroserviceConfiguration.cs
@@ -67,7 +67,7 @@ namespace Beamable.Server.Editor
 
 		[Tooltip("When true, Beamable automatically generates a common assembly called Beamable.UserCode.Shared that is auto-referenced by Unity code, and automatically imported by Microservice assembly definitions. ")]
 		public bool AutoBuildCommonAssembly = true;
-		
+
 		[Tooltip("When true, Beamable guarantees any Assembly Definition referencing a StorageObject's AsmDef also references the required Mongo DLLs.")]
 		public bool EnsureMongoAssemblyDependencies = true;
 
@@ -119,7 +119,8 @@ namespace Beamable.Server.Editor
 		[Tooltip("When you build Microservices, they can be built to an AMD or ARM cpu architecture. By default, locally, Beamable will use whatever the default for your machine is. Allowed values are \"linux/arm64\" or \"linux/amd64\"")]
 		public OptionalString LocalMicroserviceCPUArchitecturePreference = new OptionalString();
 
-		[Tooltip("When you deploy Microservices, they can be built to an AMD or ARM cpu architecture. By default, Beamable will build and deploy images similar to the host architecture. However, if you want to hardcode a specific architecture over all your development machines, you can. Allowed values are \"linux/arm64\" or \"linux/amd64\"")]
+		[Obsolete("Beamable does not support deploying ARM images. Images will be forced to build as AMD.")]
+		[Tooltip("This feature is deprecated. Images will be forced to build as linux/amd64. ")]
 		public OptionalString RemoteMicroserviceCPUArchitecturePreference = new OptionalString();
 
 		[FilePathSelector(true, DialogTitle = "Path to Docker Desktop", FileExtension = "exe", OnlyFiles = true)]
@@ -184,7 +185,7 @@ namespace Beamable.Server.Editor
 				case CPUArchitectureContext.LOCAL:
 					return LocalMicroserviceCPUArchitecturePreference?.GetOrElse(() => null);
 				case CPUArchitectureContext.DEPLOY:
-					return RemoteMicroserviceCPUArchitecturePreference?.GetOrElse(() => null);
+					return Constants.Features.Docker.CPU_LINUX_AMD_64;
 				case CPUArchitectureContext.DEFAULT:
 				default:
 					return null;

--- a/client/Packages/com.beamable/Common/Runtime/Constants/Implementations/DockerConstants.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Constants/Implementations/DockerConstants.cs
@@ -1,4 +1,6 @@
-﻿namespace Beamable.Common
+﻿using System;
+
+namespace Beamable.Common
 {
 	public static partial class Constants
 	{
@@ -6,10 +8,11 @@
 		{
 			public static partial class Docker
 			{
+				[Obsolete]
 				public const string CPU_LINUX_ARM_64 = "linux/arm64";
 				public const string CPU_LINUX_AMD_64 = "linux/amd64";
 
-				public static readonly string[] CPU_SUPPORTED = new string[] { CPU_LINUX_ARM_64, CPU_LINUX_AMD_64 };
+				public static readonly string[] CPU_SUPPORTED = new string[] { CPU_LINUX_AMD_64 };
 			}
 		}
 	}

--- a/wiki/features/beam-2945.md
+++ b/wiki/features/beam-2945.md
@@ -1,0 +1,17 @@
+### Why
+Beamable cannot host ARM based images on Fargate SPOT, because Amazon Web Services does not support it.
+
+### Configuration
+none
+
+### How
+none
+
+### Prefab
+none
+
+### Editor
+none
+
+### Notes
+This is a regression is feature. Technically, ARM upload on fargate spot never worked. We are not removing the configuration properties, in case developers are referencing it for whatever reason, but it is marked as Obsolete and it is not used anymore.


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2945

# Brief Description
Sadly, even though we added support for arm images to deploy to Fargate, Fargate just straight up doesn't support it. Not sure how we missed this, but we cannot allow folks to publish arm images, otherwise their stuff won't work in production.

So we are back to trying to force the deploy to a certain type. At least now if it doesn't work, there will be a better error message about it. And local dev is still separated from remote.


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [X] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
