### PR TITLE
beam 2960 - better pid empty check

### DIFF
--- a/client/Packages/com.beamable/Editor/BeamEditor.cs
+++ b/client/Packages/com.beamable/Editor/BeamEditor.cs
@@ -582,10 +582,10 @@ namespace Beamable
 
 			// Gets the stored pid, if its there
 			ConfigDatabase.TryGetString("pid", out var pid);
-			
+
 			// Set the config defaults to reflect the new Customer.
 			SaveConfig(alias, pid, BeamableEnvironment.ApiUrl, cid);
-			
+
 			// Attempt to get an access token.
 			return await Login(email, password, pid);
 		}
@@ -613,7 +613,7 @@ namespace Beamable
 			{
 				realm = await realmService.GetRealm();
 
-				if (realm == null && CurrentRealm != null) // reset current realm if last realm don't exist on serverside 
+				if (realm == null && CurrentRealm != null) // reset current realm if last realm don't exist on serverside
 				{
 					var currentRealmFromServer = await realmService.GetRealms().Map(all => { return all.Find(v => v.Pid == CurrentRealm.Pid); });
 
@@ -639,13 +639,19 @@ namespace Beamable
 			{
 				var games = await realmService.GetGames();
 
-				if (pid == null)
+				if (string.IsNullOrEmpty(pid))
 				{
 					var realms = await realmService.GetRealms(games.First());
 					realm = realms.First(rv => !rv.Archived);
 				}
 				else
-					realm = (await realmService.GetRealms(pid)).First(rv => rv.Pid == pid);
+				{
+					realm = (await realmService.GetRealms(pid)).FirstOrDefault(rv => rv.Pid == pid);
+					if (realm == null)
+					{
+						Debug.LogWarning($"Beamable could not find a realm for pid=[{pid}]. ");
+					}
+				}
 			}
 
 			await (realm == null ? Promise.Success : SwitchRealm(realm));


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2960

# Brief Description
I suspect that the pid was `""`, which isn't `null`, and so then we were trying to find a matching pid based on an empty string

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
