### PR TITLE
[BEAM-2917] C#MS SDK Stats API should expose deleteStats 

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BeamableRequestError` to `RequestException` base type that can be used to catch exception from Microservice requests to Beamable.
 - A leaderboard can now be frozen using `Services.Leaderboards.FreezeLeaderboard` method to prevent additional scores to be submitted.
 - Microservice can include a `CsProjFragment.xml` file as a `.csproj` `<ItemGroup>` property block of nuget references that the microservice will use to resolve.
-- Added `GetAccountId` method to `IMicroserviceAuthApi` that returns the requesting user's AccountId as opposed to their GamerTag. 
+- Added `GetAccountId` method to `IMicroserviceAuthApi` that returns the requesting user's AccountId as opposed to their GamerTag.
+- Added `DeleteProtectedPlayerStats` and `DeleteStats` methods to `IMicroserviceStatsApi`.
 
 ### Fixed
 - Publish doesn't fail if there is an unused StorageObject entry in the MicroserviceConfiguration

--- a/client/Packages/com.beamable.server/SharedRuntime/Api/Stats/IMicroserviceStatsApi.cs
+++ b/client/Packages/com.beamable.server/SharedRuntime/Api/Stats/IMicroserviceStatsApi.cs
@@ -74,5 +74,23 @@ namespace Beamable.Server.Api.Stats
 		/// <param name="criteria">List of all <see cref="Criteria"/> that must match.</param>
 		/// <returns>The list of DBIDs for all users that match ALL of the criteria provided.</returns>
 		Promise<StatsSearchResponse> SearchStats(string domain, string access, string type, List<Criteria> criteria);
+		
+		/// <summary>
+		/// Deletes a player's game private stats (<see cref="DeleteStats"/>).
+		/// </summary>
+		/// <param name="userId">A player's realm-specific GamerTag (for example, <see cref="RequestContext.UserId"/>).</param>
+		/// <param name="stats">The list of stats to delete.</param>
+		/// <returns></returns>
+		Promise DeleteProtectedPlayerStats(long userId, string[] stats);
+		
+		/// <summary>
+		/// Deletes the given stats.
+		/// </summary>
+		/// <param name="domain">"game" or "player".</param>
+		/// <param name="access">"public" or "private"</param>
+		/// <param name="type">Should always be "player" (exists for legacy reasons).</param>
+		/// <param name="userId">A player's realm-specific GamerTag (for example, <see cref="RequestContext.UserId"/>).</param>
+		/// <param name="stats">The list of stats to delete.</param>
+		Promise DeleteStats(string domain, string access, string type, long userId, string[] stats);
 	}
 }

--- a/microservice/microservice/Api/Stats/MicroserviceStatsApi.cs
+++ b/microservice/microservice/Api/Stats/MicroserviceStatsApi.cs
@@ -88,6 +88,19 @@ namespace Beamable.Server.Api.Stats
             });
         }
 
+        public Promise DeleteProtectedPlayerStats(long userId, string[] stats) => 
+	        DeleteStats("game", "private", "player", userId, stats);
+
+        public Promise DeleteStats(string domain, string access, string type, long userId, string[] stats)
+        {
+	        var key = $"{domain}.{access}.{type}.{userId}";
+	        var statString = stats == null ? string.Empty : string.Join(",", stats);
+	        return Requester.Request<Unit>(Method.DELETE, $"{OBJECT_SERVICE}/{key}", new StatsRequest
+	        {
+		        stats = statString
+	        }).ToPromise();
+        }
+
         protected override Promise<Dictionary<long, Dictionary<string, string>>> Resolve(string prefix, List<long> gamerTags)
         {
             string queryString = "";

--- a/wiki/features/BEAM-2917.md
+++ b/wiki/features/BEAM-2917.md
@@ -1,0 +1,35 @@
+### Why
+In order to delete private player stats (accessible only by server-side code) from Microservices.
+
+### Configuration
+N/A
+
+### How
+Simply call `DeleteStats` or `DeleteProtectedPlayerStats` inside a Microservice Callable method.
+
+```csharp
+[ClientCallable]
+public async Task DeleteStat(string statName)
+{
+    await Services.Stats.DeleteStats("game", "private", "player", Context.UserId, new []{statName});
+}
+```
+In this version, you can specify the exact domain/access parameters you want.
+
+```csharp
+[ClientCallable]
+public async Task DeletePrivateStat(string statName)
+{
+    await Services.Stats.DeleteProtectedPlayerStats(Context.UserId, new []{statName});
+}
+```
+In this case, you don't need to specify the "game" and "private" parameters. They are passed in for you.
+
+### Prefab
+N/A
+
+### Editor
+N/A
+
+### Notes
+N/A


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2917

# Brief Description
Exposed Delete Stats API

# Checklist
* [x] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [x] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
