### PR TITLE
[BEAM-2972] Sorting readonly style sheets

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/Buss/BussStyleSheetEditor.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/Buss/BussStyleSheetEditor.cs
@@ -1,5 +1,6 @@
 ﻿using Beamable.Editor.UI.Components;
 using Beamable.UI.Buss;
+using System;
 using UnityEditor;
 #if UNITY_2018
 using UnityEngine.Experimental.UIElements;
@@ -17,6 +18,7 @@ namespace Beamable.Editor.UI.Buss
 #if UNITY_2019_1_OR_NEWER
 		private BussStyleListVisualElement _list;
 		private BussStyleSheet _styleSheet;
+		private LabeledIntegerField _sortingOrder;
 
 		public override VisualElement CreateInspectorGUI()
 		{
@@ -37,7 +39,11 @@ namespace Beamable.Editor.UI.Buss
 			readonlyCheckbox.Refresh();
 			readonlyCheckbox.SetWithoutNotify(_styleSheet.IsReadOnly);
 			root.Add(readonlyCheckbox);
-#endif
+
+			_sortingOrder = new LabeledIntegerField();
+			_sortingOrder.Setup("Sorting Order", _styleSheet.SortingOrder, OnSortingOrderChanged, 0, Int32.MaxValue);
+			root.Add(_sortingOrder);
+#endif 
 
 			if (!_styleSheet.IsReadOnly)
 			{
@@ -48,10 +54,17 @@ namespace Beamable.Editor.UI.Buss
 			return root;
 		}
 
+
+
 #if BEAMABLE_DEVELOPER
 		private void OnReadonlyValueChanged(bool value)
 		{
 			_styleSheet.SetReadonly(value);
+		}
+		
+		private void OnSortingOrderChanged()
+		{
+			_styleSheet.SetSortingOrder(_sortingOrder.Value);
 		}
 #endif
 

--- a/client/Packages/com.beamable/Editor/UI/Common/Components/LabeledIntegerField/LabeledIntegerField.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/Components/LabeledIntegerField/LabeledIntegerField.cs
@@ -90,11 +90,11 @@ namespace Beamable.Editor.UI.Components
 
 		public void Setup(string label, int value, Action onValueChanged, int minValue, int maxValue)
 		{
+			_minValue = minValue;
+			_maxValue = maxValue;
 			Label = label;
 			Value = value;
 			_onValueChanged = onValueChanged;
-			_minValue = minValue;
-			_maxValue = maxValue;
 
 			Refresh();
 		}

--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/BussConfiguration.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/BussConfiguration.cs
@@ -121,14 +121,17 @@ namespace Beamable.UI.Buss // TODO: rename it to Beamable.UI.BUSS - new system's
 			}
 		}
 
-		private void RefreshDefaultStyles()
+		public void RefreshDefaultStyles()
 		{
 			_defaultBeamableStyleSheets.Clear();
 			BussStyleSheet[] bussStyleSheets = Resources
 											   .LoadAll<BussStyleSheet>(
 												   Constants.Features.Buss.Paths.FACTORY_STYLES_RESOURCES_PATH)
 											   .Where(styleSheet => styleSheet.IsReadOnly).ToArray();
-			_defaultBeamableStyleSheets.AddRange(bussStyleSheets);
+
+			var orderedStyleSheets = bussStyleSheets.OrderBy(s => s.SortingOrder);
+
+			_defaultBeamableStyleSheets.AddRange(orderedStyleSheets);
 		}
 
 		private void OnStyleSheetChanged(BussElement element, BussStyleSheet styleSheet)

--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/Styles/BussStyleSheet.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/Styles/BussStyleSheet.cs
@@ -10,7 +10,7 @@ using Object = UnityEngine.Object;
 namespace Beamable.UI.Buss
 {
 	[CreateAssetMenu(fileName = "BUSSStyleConfig", menuName = "Beamable/BUSS Style",
-					 order = Orders.MENU_ITEM_PATH_ASSETS_BEAMABLE_ORDER_2)]
+	                 order = Orders.MENU_ITEM_PATH_ASSETS_BEAMABLE_ORDER_2)]
 	public class BussStyleSheet : ScriptableObject, ISerializationCallbackReceiver
 	{
 		public event Action Change;
@@ -18,15 +18,13 @@ namespace Beamable.UI.Buss
 #pragma warning disable CS0649
 		[SerializeField] private List<BussStyleRule> _styles = new List<BussStyleRule>();
 		[SerializeField, HideInInspector] private List<Object> _assetReferences = new List<Object>();
+		[SerializeField] private bool _isReadOnly;
+		[SerializeField] private int _sortingOrder;
 #pragma warning restore CS0649
 
 		public List<BussStyleRule> Styles => _styles;
-
-#pragma warning disable CS0649
-		[SerializeField] private bool _isReadOnly;
-#pragma warning restore CS0649
-
 		public bool IsReadOnly => _isReadOnly;
+		public int SortingOrder => _sortingOrder;
 
 		public bool IsWritable
 		{
@@ -111,6 +109,13 @@ namespace Beamable.UI.Buss
 		{
 			_isReadOnly = value;
 		}
+
+		public void SetSortingOrder(int order)
+		{
+			_sortingOrder = order;
+			
+			BussConfiguration.OptionalInstance.Value.RefreshDefaultStyles();
+		}
 #endif
 	}
 
@@ -134,7 +139,7 @@ namespace Beamable.UI.Buss
 
 		public static BussStyleRule Create(string selector, List<BussPropertyProvider> properties)
 		{
-			return new BussStyleRule { _selector = selector, _properties = properties };
+			return new BussStyleRule {_selector = selector, _properties = properties};
 		}
 
 		public bool RemoveProperty(IBussProperty bussProperty)
@@ -172,7 +177,7 @@ namespace Beamable.UI.Buss
 		{
 			var propertyProvider = new SerializableValueObject();
 			propertyProvider.Set(property);
-			return new BussPropertyProvider { key = key, property = propertyProvider };
+			return new BussPropertyProvider {key = key, property = propertyProvider};
 		}
 
 		public IBussProperty GetProperty()


### PR DESCRIPTION
# Ticket
BEAM-2792

# Brief Description
I've added sorting order field for stylesheets. From now on - during refresh - factory/readonly stylesheets will be sorted ascending by this value. Visibility for that field is enable only for BEAMABLE_DEVELOPER. I'm not adding docs file as this is only for internal purposes.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
