### PR TITLE
[BEAM-2921] ChangeAuthorizedPlayer subscriptions problem

### DIFF
--- a/client/Packages/com.beamable/Runtime/BeamContext.cs
+++ b/client/Packages/com.beamable/Runtime/BeamContext.cs
@@ -264,6 +264,7 @@ namespace Beamable
 				OnUserLoggingOut?.Invoke(AuthorizedUser);
 			}
 
+			await Stop();
 			await SaveToken(token); // set the token so that it gets picked up on the next initialization
 			var ctx = Instantiate(_behaviour, PlayerCode);
 
@@ -771,6 +772,8 @@ namespace Beamable
 			if (GameObject)
 			{
 				UnityEngine.Object.Destroy(GameObject);
+				_behaviour = null;
+				_gob = null;
 			}
 
 


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2921

# Brief Description
Fixed issue with ChangeAuthorizedUser that cause the BeamContext to enter a bad state with respect to its MonoBehaviour systems (coroutine/pubnub).

The gist of it is here:
 - When we call `Stop` on a `BeamContext` we call Dispose of all the existing systems.
 - If we try to re-initialize the context in the same frame, like we do in `ChangeAuthorizedUser`, the mono-behaviour instances of services (`CoroutineService`, `PubNub...`, etc) are only flagged for destruction.
 - The factory method of our DI-framework fails to detect that the instances will be destroyed (because Unity provides no way to check for that) and return the existing instance that will go 💥 next frame.
 - The fix is to forcebly set the property the DI-framework checks to see is null, to null.

# Checklist
* [x] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
