### PR TITLE
beam 2948 - adds stats clear cache

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Editor tooling for `SerializableDictionaryStringToSomething<T>` has context menu
-
+- `ClearCaches` function on `StatsApi` to force invalidate stats cache.
 
 ### [1.3.2]
 

--- a/client/Packages/com.beamable/Common/Runtime/Api/IUserDataCache.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/IUserDataCache.cs
@@ -51,6 +51,12 @@ namespace Beamable.Common.Api
 		/// <param name="gamerTag">The gamertag of the player to remove from the cache</param>
 		public abstract void Remove(long gamerTag);
 
+		/// <summary>
+		/// Remove all players from the cache. The next time any player data is requested, the <see cref="CacheResolver"/> will be used
+		/// to get the latest data for the players.
+		/// </summary>
+		public abstract void Clear();
+
 		protected class UserDataCacheEntry
 		{
 			public T data;

--- a/client/Packages/com.beamable/Common/Runtime/Api/Stats/AbsStatsApi.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/Stats/AbsStatsApi.cs
@@ -24,6 +24,21 @@ namespace Beamable.Common.Api.Stats
 			Provider = provider;
 		}
 
+		public void ClearCaches()
+		{
+			foreach (var kvp in caches)
+			{
+				kvp.Value.Clear();
+			}
+			caches.Clear();
+		}
+
+		public UserDataCache<Dictionary<string, string>> GetCache(string domain, string access, string type)
+		{
+			string prefix = $"{domain}.{access}.{type}.";
+			return GetCache(prefix);
+		}
+
 		public UserDataCache<Dictionary<string, string>> GetCache(string prefix)
 		{
 			if (!caches.TryGetValue(prefix, out var cache))
@@ -55,6 +70,8 @@ namespace Beamable.Common.Api.Stats
 			string prefix = $"{domain}.{access}.{type}.";
 			return GetCache(prefix).Get(id);
 		}
+
+
 
 		/// <summary>
 		/// <para>Supports searching for DBIDs by stat query. This method is useful e.g for friend search</para>
@@ -145,7 +162,7 @@ namespace Beamable.Common.Api.Stats
 	}
 
 	/// <summary>
-	/// A definition of a comparison (<see cref="Rel"/>) to be run against the specified <see cref="Stat"/>.  
+	/// A definition of a comparison (<see cref="Rel"/>) to be run against the specified <see cref="Stat"/>.
 	/// </summary>
 	public class Criteria
 	{

--- a/client/Packages/com.beamable/Common/Runtime/Api/Stats/IStatsApi.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/Stats/IStatsApi.cs
@@ -19,6 +19,20 @@ namespace Beamable.Common.Api.Stats
 		UserDataCache<Dictionary<string, string>> GetCache(string prefix);
 
 		/// <summary>
+		/// Get the <see cref="UserDataCache{T}"/> for the stat keys
+		/// </summary>
+		/// <param name="domain">Should be either "client" or "game"</param>
+		/// <param name="access">Should be "public" or "private"</param>
+		/// <param name="type">should always be "player" </param>
+		/// <returns>The <see cref="UserDataCache{T}"/> containing stats given the prefix.</returns>
+		UserDataCache<Dictionary<string, string>> GetCache(string domain, string access, string type);
+
+		/// <summary>
+		/// Removes any stored data for all local stats.
+		/// </summary>
+		void ClearCaches();
+
+		/// <summary>
 		/// Set the current player's client player stats.
 		/// </summary>
 		/// <param name="access">

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/UnityUserDataCache.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/UnityUserDataCache.cs
@@ -81,6 +81,11 @@ namespace Beamable.Api
 			cache.Remove(gamerTag);
 		}
 
+		public override void Clear()
+		{
+			cache.Clear();
+		}
+
 		protected virtual void Resolve()
 		{
 

--- a/microservice/microservice/Api/ServiceUserDataCache.cs
+++ b/microservice/microservice/Api/ServiceUserDataCache.cs
@@ -34,5 +34,10 @@ namespace Beamable.Server.Api
       {
          // no op. In an ephemeral cache, data is never stored.
       }
+
+      public override void Clear()
+      {
+	      // no op. In an ephemeral cache, data is never stored, so there is no point in clearing it.
+      }
    }
 }

--- a/wiki/features/beam-2948.md
+++ b/wiki/features/beam-2948.md
@@ -1,0 +1,19 @@
+### Why
+Users would have to wait for the regular StatsService TTL cache of 15 minutes before getting their new stat values. Now they can use the new `ClearCaches` function to force clear the cache.
+
+### Configuration
+none
+
+### How
+```csharp
+	[ContextMenu("Clear Stats")]
+	private async void ClearStats()
+	{
+		var beamable = BeamContext.Default;
+		await beamable.OnReady;
+		beamable.Api.Stats.ClearCaches();
+	}
+```
+
+### Notes
+You could combine this with a custom Notification sent from a Microservice


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-2948

# Brief Description
yep, we just needed a nicer way to clear the caches, so here it is.
Previously, if you changed a stat value, it'd take the game up to 15 minutes to realize, due to its TTL. 


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [X] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
