### PR TITLE
beam 3005 - raise timeout to 15 seconds for appreq

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - The default uncaught Promise handler no longer throws `IndexOutOfBounds` errors in high failure cases.
 
+### Changed
+- Beamable requests have a 15 second application level timeout.
+
 ## [1.3.3]
 
 ### Added

--- a/client/Packages/com.beamable/Common/Runtime/Constants/Implementations/RequesterConstants.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Constants/Implementations/RequesterConstants.cs
@@ -8,7 +8,7 @@ namespace Beamable.Common
 			public const string ERROR_PREFIX_WEBSOCKET_RES = "WSS Error";
 			public const string ERROR_PREFIX_MICROSERVICE = "Service Error";
 
-			public const int DEFAULT_APPLICATION_TIMEOUT_SECONDS = 10;
+			public const int DEFAULT_APPLICATION_TIMEOUT_SECONDS = 15;
 
 			/// <summary>
 			/// The header describing the customer's cid. This _can_ be alias.


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3005

# Brief Description

Our backend will timeout a request if it takes longer than 10 seconds to process.
The timeout in this PR is going from 10 seconds, to 15 seconds. This timeout is the application level timeout, where the Unity will give up listening for a response and simply fail the initiated Promise. 


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
