### PR TITLE
[BEAM-3033] Display info about wrong fields types.

### DIFF
--- a/client/Packages/com.beamable/Editor/Modules/Content/UI/ContentObjectEditor.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/UI/ContentObjectEditor.cs
@@ -109,9 +109,17 @@ namespace Beamable.Editor.Content.UI
 
 		public override void OnInspectorGUI()
 		{
-
 			var contentObject = target as ContentObject;
 			if (contentObject == null) return;
+			var wrongFields = target.GetType().GetFields().ToList()
+			                      .Where(info => typeof(ScriptableObject).IsAssignableFrom(info.FieldType));
+			foreach(var wrongField in wrongFields)
+			{
+				var gui = new GUIStyle(GUI.skin.textArea) {padding = new RectOffset(15, 15, 15, 15), richText = true};
+				EditorGUILayout.LabelField($"<b>{wrongField.Name}</b> field should not have type <b>{wrongField.FieldType.Name}</b>. \n" +
+				                           "You should use Addressables <b>AssetReference</b> instead of direct <b>ScriptableObject</b> reference."
+				                           ,gui);
+			}
 
 			if (contentObject.SerializeToConsoleRequested)
 			{


### PR DESCRIPTION
# Ticket

## Example

Code:
```csharp

[CreateAssetMenu(fileName = "RarityColors", menuName = "RarityColors", order = 0)]
public class RarityColors : ScriptableObject
{
	public int das;
}

[ContentType("MyCustomContent")]
[System.Serializable]
[Agnostic]
public class MyCustomContent : ContentObject
{
	public AssetReferenceT<RarityColors> rarityColors;
	public RarityColors rarityColorsDirectly;
	public ScriptableObject Test;
}
```

Inspector

![Unity_F7nvCtSz5S](https://user-images.githubusercontent.com/13188195/189956508-1e0207df-7e03-4f59-93a9-9a224a42243c.png)

# Brief Description

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
