### PR TITLE
[BEAM-3019] Add utility methods for setting expiration on Mail

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `long` PlayerId version of `InviteToParty`, `PromoteToLeader` and `KickPlayer` methods of the `IPartyApi` interface.
+- Utility apis for setting expiration on Mail Update and Mail Send requests
 
 ### Fixed
 - ActionBarVisualElement buttons behaviour is fixed when Docker is not running.

--- a/client/Packages/com.beamable/Common/Runtime/Api/Mail/AbsMailApi.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/Mail/AbsMailApi.cs
@@ -1,9 +1,11 @@
 using Beamable.Common.Api.Inventory;
 using Beamable.Common.Inventory;
 using Beamable.Common.Pooling;
+using Beamable.Content.Utility;
 using Beamable.Serialization.SmallerJSON;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Beamable.Common.Api.Mail
 {
@@ -353,6 +355,56 @@ namespace Beamable.Common.Api.Mail
 		public string body;
 		public string expires;
 		public MailRewards rewards;
+
+		/// <summary>
+		/// Sets the mail expiration based on the iso date time format (yyyy-MM-ddTHH:mm:ssZ)
+		/// </summary>
+		/// <param name="expirationIsoDateTime"></param>
+		/// <returns></returns>
+		public MailSendEntry SetExpiration(string expirationIsoDateTime)
+		{
+			if (expirationIsoDateTime != null)
+			{
+				var date = DateTimeOffset.ParseExact(expirationIsoDateTime, DateUtility.ISO_FORMAT, CultureInfo.InvariantCulture,
+				                                     DateTimeStyles.None);
+				expires = date.ToUniversalTime().ToString(DateUtility.ISO_FORMAT);
+			}
+
+			return this;
+		}
+		
+		/// <summary>
+		/// Sets the mail expiration based on a specified unix timestamp (milliseconds)
+		/// </summary>
+		/// <param name="expirationTimestampMillis"></param>
+		/// <returns></returns>
+		public MailSendEntry SetExpiration(long expirationTimestampMillis)
+		{
+			expires = DateTimeOffset.FromUnixTimeMilliseconds(expirationTimestampMillis).ToString(DateUtility.ISO_FORMAT);
+			return this;
+		}
+
+		/// <summary>
+		/// Sets the mail expiration based on a specified Date Time (UTC)
+		/// </summary>
+		/// <param name="expirationDateTime"></param>
+		/// <returns></returns>
+		public MailSendEntry SetExpiration(DateTimeOffset expirationDateTime)
+		{
+			expires = expirationDateTime.ToUniversalTime().ToString(DateUtility.ISO_FORMAT);
+			return this;
+		}
+		
+		/// <summary>
+		/// Sets the mail expiration based on a timespan relative to the current date time (e.g. in 10 minutes)
+		/// </summary>
+		/// <param name="expiresInTimespan"></param>
+		/// <returns></returns>
+		public MailSendEntry SetExpiresIn(TimeSpan expiresInTimespan)
+		{
+			expires = DateTimeOffset.UtcNow.Add(expiresInTimespan).ToString(DateUtility.ISO_FORMAT);
+			return this;
+		}
 	}
 
 	[Serializable]
@@ -389,6 +441,63 @@ namespace Beamable.Common.Api.Mail
 			this.acceptAttachments = acceptAttachments;
 			this.expires = expires;
 		}
+		
+		public MailUpdate(long mailId, MailState state, bool acceptAttachments)
+		{
+			this.mailId = mailId;
+			this.state = state.ToString();
+			this.acceptAttachments = acceptAttachments;
+		}
+		
+		/// <summary>
+		/// Sets the mail expiration based on the iso date time format (yyyy-MM-ddTHH:mm:ssZ)
+		/// </summary>
+		/// <param name="expirationIsoDateTime"></param>
+		/// <returns></returns>
+		public MailUpdate SetExpiration(string expirationIsoDateTime)
+		{
+			if (expirationIsoDateTime != null)
+			{
+				var date = DateTimeOffset.ParseExact(expirationIsoDateTime, DateUtility.ISO_FORMAT, CultureInfo.InvariantCulture,
+				                                     DateTimeStyles.None);
+				expires = date.ToUniversalTime().ToString(DateUtility.ISO_FORMAT);
+			}
+
+			return this;
+		}
+		
+		/// <summary>
+		/// Sets the mail expiration based on a specified unix timestamp (milliseconds)
+		/// </summary>
+		/// <param name="expirationTimestampMillis"></param>
+		/// <returns></returns>
+		public MailUpdate SetExpiration(long expirationTimestampMillis)
+		{
+			expires = DateTimeOffset.FromUnixTimeMilliseconds(expirationTimestampMillis).ToString(DateUtility.ISO_FORMAT);
+			return this;
+		}
+
+		/// <summary>
+		/// Sets the mail expiration based on a specified Date Time (UTC)
+		/// </summary>
+		/// <param name="expirationDateTimeOffset"></param>
+		/// <returns></returns>
+		public MailUpdate SetExpiration(DateTimeOffset expirationDateTimeOffset)
+		{
+			expires = expirationDateTimeOffset.ToUniversalTime().ToString(DateUtility.ISO_FORMAT);
+			return this;
+		}
+		
+		/// <summary>
+		/// Sets the mail expiration based on a timespan relative to the current date time (e.g. in 10 minutes)
+		/// </summary>
+		/// <param name="expiresInTimespan"></param>
+		/// <returns></returns>
+		public MailUpdate SetExpiresIn(TimeSpan expiresInTimespan)
+		{
+			expires = DateTimeOffset.UtcNow.Add(expiresInTimespan).ToString(DateUtility.ISO_FORMAT);
+			return this;
+		}
 	}
 
 	[Serializable]
@@ -403,15 +512,35 @@ namespace Beamable.Common.Api.Mail
 	{
 		public List<MailUpdateEntry> updateMailRequests = new List<MailUpdateEntry>();
 
+		public MailUpdateRequest Add(long id, MailUpdate mailUpdate)
+		{
+			updateMailRequests.Add(new MailUpdateEntry {id = id, update = mailUpdate});
+			return this;
+		}
+
+		public MailUpdateRequest Add(long id, MailState state, bool acceptAttachments)
+		{
+			return Add(id, new MailUpdate(id, state, acceptAttachments));
+		}
+		
 		public MailUpdateRequest Add(long id, MailState state, bool acceptAttachments, string expires)
 		{
-			var entry = new MailUpdateEntry
-			{
-				id = id,
-				update = new MailUpdate(id, state, acceptAttachments, expires)
-			};
-			updateMailRequests.Add(entry);
-			return this;
+			return Add(id, new MailUpdate(id, state, acceptAttachments).SetExpiration(expires));
+		}
+		
+		public MailUpdateRequest Add(long id, MailState state, bool acceptAttachments, long expirationTimestampMillis)
+		{
+			return Add(id, new MailUpdate(id, state, acceptAttachments).SetExpiration(expirationTimestampMillis));
+		}
+		
+		public MailUpdateRequest Add(long id, MailState state, bool acceptAttachments, DateTimeOffset expirationDateTimeOffset)
+		{
+			return Add(id, new MailUpdate(id, state, acceptAttachments).SetExpiration(expirationDateTimeOffset));
+		}
+		
+		public MailUpdateRequest Add(long id, MailState state, bool acceptAttachments, TimeSpan expiresIn)
+		{
+			return Add(id, new MailUpdate(id, state, acceptAttachments).SetExpiresIn(expiresIn));
 		}
 	}
 

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Platform/Mail.meta
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Platform/Mail.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 65f72933eec7400cb5dedf0ce1a43a51
+timeCreated: 1663173400

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Platform/Mail/MailTests.cs
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Platform/Mail/MailTests.cs
@@ -1,0 +1,67 @@
+﻿using Beamable.Common.Api;
+using Beamable.Common.Api.Mail;
+using Beamable.Content.Utility;
+using NUnit.Framework;
+using System;
+
+namespace Beamable.Platform.Tests.Mail
+{
+	public class MailTests
+	{
+		[Test]
+		public void ValidSendMailExpiration()
+		{
+			string isoDateString = "2022-09-14T20:00:00Z";
+			var expiresOffset = DateTimeOffset.Parse(isoDateString);
+			var expiresMillis = expiresOffset.ToUnixTimeMilliseconds();
+
+			var mailSendEntry = new MailSendEntry();
+			Assert.AreEqual(null, mailSendEntry.expires);
+			
+			mailSendEntry.SetExpiration(isoDateString);
+			Assert.AreEqual(isoDateString, mailSendEntry.expires);
+
+			mailSendEntry.expires = null;
+			mailSendEntry.SetExpiration(expiresMillis);
+			Assert.AreEqual(isoDateString, mailSendEntry.expires);
+
+			mailSendEntry.expires = null;
+			mailSendEntry.SetExpiration(expiresOffset);
+			Assert.AreEqual(isoDateString, mailSendEntry.expires);
+			
+			mailSendEntry.expires = null;
+			var now = DateTimeOffset.UtcNow;
+			mailSendEntry.SetExpiresIn(TimeSpan.FromHours(1.0));
+			var inAnHour = now.AddHours(1.0);
+			Assert.AreEqual(inAnHour.ToString(DateUtility.ISO_FORMAT), mailSendEntry.expires);
+		}
+		
+		[Test]
+		public void ValidUpdateMailExpiration()
+		{
+			string isoDateString = "2022-09-14T20:00:00Z";
+			var expiresOffset = DateTimeOffset.Parse(isoDateString);
+			var expiresMillis = expiresOffset.ToUnixTimeMilliseconds();
+
+			var mailUpdate = new MailUpdate(1L, MailState.Read, true);
+			Assert.AreEqual(null, mailUpdate.expires);
+			
+			mailUpdate.SetExpiration(isoDateString);
+			Assert.AreEqual(isoDateString, mailUpdate.expires);
+
+			mailUpdate.expires = null;
+			mailUpdate.SetExpiration(expiresMillis);
+			Assert.AreEqual(isoDateString, mailUpdate.expires);
+
+			mailUpdate.expires = null;
+			mailUpdate.SetExpiration(expiresOffset);
+			Assert.AreEqual(isoDateString, mailUpdate.expires);
+			
+			mailUpdate.expires = null;
+			var now = DateTimeOffset.UtcNow;
+			mailUpdate.SetExpiresIn(TimeSpan.FromHours(1.0));
+			var inAnHour = now.AddHours(1.0);
+			Assert.AreEqual(inAnHour.ToString(DateUtility.ISO_FORMAT), mailUpdate.expires);
+		}
+	}
+}

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Platform/Mail/MailTests.cs.meta
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Platform/Mail/MailTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a3b391ecff5d458289ecd3963a819caa
+timeCreated: 1663173438

--- a/wiki/features/beam-3019.md
+++ b/wiki/features/beam-3019.md
@@ -1,0 +1,32 @@
+### Why
+Updating or sending mail with an expiration is error-prone. The expiration being sent expects an ISO Date String, but the expiration field when fetching mail is a unix timestmap (milliseconds). 
+
+### Configuration
+none
+
+### How
+
+```csharp
+[ClientCallable]
+public void SendMail()
+{
+    var message = new MailSendEntry
+    {
+        senderGamerTag = 0L,
+        receiverGamerTag = Context.UserId,
+        category = "SYSTEM.DB",
+        subject = "Hello World",
+        body = "This is my body."
+    };
+    
+    message.SetExpiration("2022-09-14T20:00:00Z");
+    message.SetExpiration(1663185600000L);
+    message.SetExpiration(DateTimeOffset.Now);
+    message.SetExpiresIn(TimeSpan.FromHours(1.0));
+    
+    Services.Mail.SendMail(new MailSendRequest().Add(message));
+}
+```
+
+### Notes
+N/A


### PR DESCRIPTION
# Ticket
BEAM-3019

# Brief Description
Updating or sending mail with an expiration is error-prone. The expiration being sent expects an ISO Date String, but the expiration field when fetching mail is a unix timestmap (milliseconds). I've added utility methods for setting the expiration in the following formats:
- DateTimeOffset
- Timespan
- Long (Unix Timestamp Milliseconds)
- String (ISO String Format) with validation

Also added unit tests to validate this.

# Checklist
* [x] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [x] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevant JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
