### PR TITLE
[BEAM-3035] Add additional info to the test report

### DIFF
--- a/client/Assets/BeamSemiAutomatedTester/Scripts/Core/Models/RegisteredTest.cs
+++ b/client/Assets/BeamSemiAutomatedTester/Scripts/Core/Models/RegisteredTest.cs
@@ -19,6 +19,8 @@ namespace Beamable.BSAT.Core.Models
 				TestResult.NotSet;
 		public List<RegisteredTestRule> RegisteredTestRules => _registeredTestRules;
 		
+		public TimeSpan ElapsedTime => new TimeSpan(RegisteredTestRules.Sum(x => x.ElapsedTime.Ticks));
+		
 		[SerializeField] private string _testClassName;
 		[SerializeField] private TestResult _testResult;
 		[SerializeField, HideInInspector] private TestDescriptor _testDescriptor;
@@ -62,6 +64,7 @@ namespace Beamable.BSAT.Core.Models
 			return new ArrayDict
 			{
 				{ "TestResult", TestResult},
+				{ "TimeStamp", ElapsedTime.ToString("g") },
 				{ "Title", TestDescriptor.Title },
 				{ "Description", TestDescriptor.Description },
 				{ "TestRules", data}

--- a/client/Assets/BeamSemiAutomatedTester/Scripts/Core/Models/RegisteredTestRule.cs
+++ b/client/Assets/BeamSemiAutomatedTester/Scripts/Core/Models/RegisteredTestRule.cs
@@ -20,6 +20,8 @@ namespace Beamable.BSAT.Core.Models
 				TestResult.NotSet;
 		
 		public List<RegisteredTestRuleMethod> RegisteredTestRuleMethods => _registeredTestRuleMethods;
+		
+		public TimeSpan ElapsedTime => new TimeSpan(RegisteredTestRuleMethods.Sum(x => x.ElapsedTime.Ticks));
 
 		[SerializeField] private string _testMethodName;
 		[SerializeField] private int _order;
@@ -66,6 +68,7 @@ namespace Beamable.BSAT.Core.Models
 			return new ArrayDict
 			{
 				{ "TestResult", TestResult},
+				{ "TimeStamp", ElapsedTime.ToString("g") },
 				{ "Title", _registeredTestRuleMethods[0].Title },
 				{ "Description", _registeredTestRuleMethods[0].Description },
 				{ "TestRuleMethods", data },

--- a/client/Assets/BeamSemiAutomatedTester/Scripts/Core/Models/RegisteredTestRuleMethod.cs
+++ b/client/Assets/BeamSemiAutomatedTester/Scripts/Core/Models/RegisteredTestRuleMethod.cs
@@ -57,6 +57,8 @@ namespace Beamable.BSAT.Core.Models
 				return _methodInfo;
 			}
 		}
+		public TimeSpan ElapsedTime { get; set; } = TimeSpan.Zero;
+		
 		private MethodInfo _methodInfo;
 		public object[] Arguments => TestHelper.ConvertStringToObject(_argumentsRaw);
 		public string[] ArgumentsRaw => _argumentsRaw;
@@ -95,6 +97,7 @@ namespace Beamable.BSAT.Core.Models
 			return new ArrayDict
 			{
 				{ "TestResult", TestResult},
+				{ "TimeStamp", ElapsedTime.ToString("g") },
 				{ "Arguments", ArgumentsRaw }
 			};
 		}

--- a/client/Assets/BeamSemiAutomatedTester/Scripts/Core/Models/RegisteredTestScene.cs
+++ b/client/Assets/BeamSemiAutomatedTester/Scripts/Core/Models/RegisteredTestScene.cs
@@ -18,6 +18,8 @@ namespace Beamable.BSAT.Core.Models
 				TestResult.NotSet;
 		public List<RegisteredTest> RegisteredTests => _registeredTests;
 
+		public TimeSpan ElapsedTime => new TimeSpan(RegisteredTests.Sum(x => x.ElapsedTime.Ticks));
+		
 		[SerializeField] private string _sceneName;
 		[SerializeField] private TestResult _testResult;
 		[SerializeField, HideInInspector] private TestSceneDescriptor _testSceneDescriptor;
@@ -56,6 +58,7 @@ namespace Beamable.BSAT.Core.Models
 			return new ArrayDict
 			{
 				{ "TestResult", TestResult},
+				{ "TimeStamp", ElapsedTime.ToString("g") },
 				{ "Title", TestSceneDescriptor.GetTestDescriptor().Title },
 				{ "Description", TestSceneDescriptor.GetTestDescriptor().Description },
 				{ "Tests", data }

--- a/client/Assets/BeamSemiAutomatedTester/Scripts/Core/TestConfiguration.cs
+++ b/client/Assets/BeamSemiAutomatedTester/Scripts/Core/TestConfiguration.cs
@@ -17,6 +17,8 @@ namespace Beamable.BSAT.Core
 			RegisteredTestScenes.All(x => x.TestResult == TestResult.Passed) ? TestResult.Passed :
 			TestResult.NotSet;
 		
+		public TimeSpan ElapsedTime => new TimeSpan(RegisteredTestScenes.Sum(x => x.ElapsedTime.Ticks));
+		
 		public KeyCode ToggleTestUIKey => toggleTestUIKey;
 
 		[SerializeField] private KeyCode toggleTestUIKey = KeyCode.Semicolon;
@@ -49,7 +51,11 @@ namespace Beamable.BSAT.Core
 			var json = Json.Serialize(new ArrayDict
 			{
 				{ "ReportGenerateTimeUTC", DateTime.UtcNow.ToString("yyyy.MM.dd hh:mm:ss tt")},
+				{ "TargetPlatform", Application.platform },
+				{ "UnityVersion", Application.unityVersion },
+				{ "BeamableVersion", BeamableEnvironment.SdkVersion },
 				{ "TestResult", TestResult },
+				{ "TimeStamp", ElapsedTime.ToString("g") },
 				{ "TestScenes", data }
 			}, new StringBuilder());
 

--- a/client/Assets/BeamSemiAutomatedTester/Scripts/Core/TestController.cs
+++ b/client/Assets/BeamSemiAutomatedTester/Scripts/Core/TestController.cs
@@ -2,6 +2,7 @@ using Beamable.BSAT.Core.Models;
 using Beamable.BSAT.Extensions;
 using System;
 using System.Collections;
+using System.Diagnostics;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -29,7 +30,7 @@ namespace Beamable.BSAT.Core
 					if (TestConfiguration == null)
 					{
 						TestableDebug.LogError("Cannot load test configuration file!");
-						Debug.Break();
+						UnityEngine.Debug.Break();
 					}
 				}
 				return _testConfiguration;
@@ -45,6 +46,7 @@ namespace Beamable.BSAT.Core
 		private int _currentTestIndex = 0, _currentOrderIndex = 0, _currentCaseIndex = 0;
 
 		private Coroutine _coroutine;
+		private Stopwatch _watch = new Stopwatch();
 		
 		private void Awake()
 		{
@@ -138,7 +140,11 @@ namespace Beamable.BSAT.Core
 		}
 		private async void HandleTestReadyToInvoke()
 		{
+			_watch.Restart();
 			var result = await CurrentTestRuleMethod.InvokeTest(displayLogs, _currentOrderIndex, _currentCaseIndex - 1);
+			_watch.Stop();
+			CurrentTestRuleMethod.ElapsedTime = _watch.Elapsed;
+			
 			if (stopOnFirstFailed && result == TestResult.Failed)
 			{
 				TestableDebug.Log($"Testing tool stopped due to failed test.");


### PR DESCRIPTION
# [Ticket](https://disruptorbeam.atlassian.net/browse/BEAM-3035)

# Brief Description

Added new fields to test report result:
* TargetPlatform
* UnityVersion
* BeamableVersion
* TimeStamp (for each test)

## Example output
```json
{
  "ReportGenerateTimeUTC": "2022.09.16 04:21:31 PM",
  "TargetPlatform": "WindowsEditor",
  "UnityVersion": "2019.4.32f1",
  "BeamableVersion": "0.0.0",
  "TestResult": "Passed",
  "TimeStamp": "0:00:08,4944996",
  "TestScenes": [
    {
      "BeamContextLifecycle": {
        "TestResult": "Passed",
        "TimeStamp": "0:00:01,6852299",
        "Title": "",
        "Description": "",
        "Tests": [
          {
            "BeamContextLifecycleScript": {
              "TestResult": "Passed",
              "TimeStamp": "0:00:01,6852299",
              "Title": "",
              "Description": "",
              "TestRules": [
                {
                  "DefaultBeamContextInitTest": {
                    "TestResult": "Passed",
                    "TimeStamp": "0:00:01,6826423",
                    "Title": "BeamContext initialization",
                    "Description": "Test if default BeamContext initalizes correctly.",
                    "TestRuleMethods": [
                      {
                        "0": {
                          "TestResult": "Passed",
                          "TimeStamp": "0:00:01,6826423",
                          "Arguments": []
                        }
                      }
                    ]
                  }
                },
                {
                  "OtherBeamContextInitTest": {
                    "TestResult": "Passed",
                    "TimeStamp": "0:00:00,0025876",
                    "Title": "Other BeamContext initialization",
                    "Description": "Test if other than default BeamContext initializes correctly and has different player ID.",
                    "TestRuleMethods": [
                      {
                        "0": {
                          "TestResult": "Passed",
                          "TimeStamp": "0:00:00,0025876",
                          "Arguments": []
                        }
                      }
                    ]
                  }
                }
              ]
            }
          }
        ]
      }
    },
    {
      "FriendsPSDK": {
        "TestResult": "Passed",
        "TimeStamp": "0:00:04,3468749",
        "Title": "",
        "Description": "",
        "Tests": [
          {
            "FriendsPSDKScript": {
              "TestResult": "Passed",
              "TimeStamp": "0:00:04,3468749",
              "Title": "",
              "Description": "",
              "TestRules": [
                {
                  "Setup": {
                    "TestResult": "Passed",
                    "TimeStamp": "0:00:01,2738775",
                    "Title": "Beamable setup",
                    "Description": "This is going to set up 2 beam contexts, and then move to the next step if everything works well...",
                    "TestRuleMethods": [
                      {
                        "0": {
                          "TestResult": "Passed",
                          "TimeStamp": "0:00:01,2738775",
                          "Arguments": []
                        }
                      }
                    ]
                  }
                },
                {
                  "Invite": {
                    "TestResult": "Passed",
                    "TimeStamp": "0:00:01,8538415",
                    "Title": "Invite",
                    "Description": "Test if players can send and accept friend invites and also unfriend.",
                    "TestRuleMethods": [
                      {
                        "0": {
                          "TestResult": "Passed",
                          "TimeStamp": "0:00:01,8538415",
                          "Arguments": []
                        }
                      }
                    ]
                  }
                },
                {
                  "Block": {
                    "TestResult": "Passed",
                    "TimeStamp": "0:00:01,2191559",
                    "Title": "Block players",
                    "Description": "Test if players can block each other and if the block is actually effective.",
                    "TestRuleMethods": [
                      {
                        "0": {
                          "TestResult": "Passed",
                          "TimeStamp": "0:00:01,2191559",
                          "Arguments": []
                        }
                      }
                    ]
                  }
                }
              ]
            }
          }
        ]
      }
    },
    {
      "Inventory": {
        "TestResult": "Passed",
        "TimeStamp": "0:00:02,4623948",
        "Title": "",
        "Description": "",
        "Tests": [
          {
            "InventoryScript": {
              "TestResult": "Passed",
              "TimeStamp": "0:00:02,4623948",
              "Title": "",
              "Description": "",
              "TestRules": [
                {
                  "ReferencesPreCheck": {
                    "TestResult": "Passed",
                    "TimeStamp": "0:00:00,0012152",
                    "Title": "Reference pre check",
                    "Description": "Checks if required references are connected in the inspector.",
                    "TestRuleMethods": [
                      {
                        "0": {
                          "TestResult": "Passed",
                          "TimeStamp": "0:00:00,0012152",
                          "Arguments": []
                        }
                      }
                    ]
                  }
                },
                {
                  "InitDefaultBeamContext": {
                    "TestResult": "Passed",
                    "TimeStamp": "0:00:00,0012575",
                    "Title": "Init Beam context",
                    "Description": "Test if default BeamContext initalizes correctly.",
                    "TestRuleMethods": [
                      {
                        "0": {
                          "TestResult": "Passed",
                          "TimeStamp": "0:00:00,0012575",
                          "Arguments": []
                        }
                      }
                    ]
                  }
                },
                {
                  "ChangeAuthorizedPlayer": {
                    "TestResult": "Passed",
                    "TimeStamp": "0:00:01,3275518",
                    "Title": "Change authorized player",
                    "Description": "Change authorized player to get a fresh account to perform tests (with clear inventory)",
                    "TestRuleMethods": [
                      {
                        "0": {
                          "TestResult": "Passed",
                          "TimeStamp": "0:00:01,3275518",
                          "Arguments": []
                        }
                      }
                    ]
                  }
                },
                {
                  "AddOneItem": {
                    "TestResult": "Passed",
                    "TimeStamp": "0:00:00,4720741",
                    "Title": "Add one item",
                    "Description": "Adds one item to the inventory",
                    "TestRuleMethods": [
                      {
                        "0": {
                          "TestResult": "Passed",
                          "TimeStamp": "0:00:00,4720741",
                          "Arguments": []
                        }
                      }
                    ]
                  }
                },
                {
                  "GetItems": {
                    "TestResult": "Passed",
                    "TimeStamp": "0:00:00,2131014",
                    "Title": "Get items from inventory",
                    "Description": "Checks if there is at least one item",
                    "TestRuleMethods": [
                      {
                        "0": {
                          "TestResult": "Passed",
                          "TimeStamp": "0:00:00,2131014",
                          "Arguments": []
                        }
                      }
                    ]
                  }
                },
                {
                  "DeleteOneItem": {
                    "TestResult": "Passed",
                    "TimeStamp": "0:00:00,4471948",
                    "Title": "Delete one item",
                    "Description": "Deletes one item",
                    "TestRuleMethods": [
                      {
                        "0": {
                          "TestResult": "Passed",
                          "TimeStamp": "0:00:00,4471948",
                          "Arguments": []
                        }
                      }
                    ]
                  }
                }
              ]
            }
          }
        ]
      }
    }
  ]
}
```

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
