### PR TITLE
use serial key overrides

### DIFF
--- a/.github/workflows/buildPR.yml
+++ b/.github/workflows/buildPR.yml
@@ -118,13 +118,13 @@ jobs:
           - 2021.3.2f1
         include:
           - unityVersion: 2020.3.19f1
-            unityEmailOverride: ${{ secrets.UNITY_EMAIL_DEVOPS }}
-            unityPasswordOverride: ${{ secrets.UNITY_PASSWORD_DEVOPS }}
-            unitySerialOverride: ${{ secrets.UNITY_SERIAL_DEVOPS }}
+            unityEmailOverride: UNITY_EMAIL_DEVOPS
+            unityPasswordOverride: UNITY_PASSWORD_DEVOPS
+            unitySerialOverride: UNITY_SERIAL_DEVOPS
           - unityVersion: 2021.3.2f1
-            unityEmailOverride: ${{ secrets.UNITY_EMAIL_BUILD }}
-            unityPasswordOverride: ${{ secrets.UNITY_PASSWORD_BUILD }}
-            unitySerialOverride: ${{ secrets.UNITY_SERIAL_BUILD }}
+            unityEmailOverride: UNITY_EMAIL_BUILD
+            unityPasswordOverride: UNITY_PASSWORD_BUILD
+            unitySerialOverride: UNITY_SERIAL_BUILD
     steps:
       - uses: actions/checkout@v2
       - name: Login to Docker Hub
@@ -163,9 +163,9 @@ jobs:
         id: tests
         timeout-minutes: 30
         env:
-          UNITY_EMAIL: ${{ matrix.unityEmailOverride || secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ matrix.unityPasswordOverride || secrets.UNITY_PASSWORD }}
-          UNITY_SERIAL: ${{ matrix.unitySerialOverride || secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets[matrix.unityEmailOverride] || secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets[matrix.unityPasswordOverride] || secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets[matrix.unitySerialOverride] || secrets.UNITY_SERIAL }}
         with:
           customParameters: -warnaserror+
           projectPath: ${{ matrix.projectPath }}
@@ -209,13 +209,13 @@ jobs:
           - client
         include:
           - targetPlatform: Android
-            unityEmailOverride: ${{ secrets.UNITY_EMAIL_DEVOPS }}
-            unityPasswordOverride: ${{ secrets.UNITY_PASSWORD_DEVOPS }}
-            unitySerialOverride: ${{ secrets.UNITY_SERIAL_DEVOPS }}
+            unityEmailOverride: UNITY_EMAIL_DEVOPS
+            unityPasswordOverride: UNITY_PASSWORD_DEVOPS
+            unitySerialOverride: UNITY_SERIAL_DEVOPS
           - targetPlatform: StandaloneOSX
-            unityEmailOverride: ${{ secrets.UNITY_EMAIL_BUILD }}
-            unityPasswordOverride: ${{ secrets.UNITY_PASSWORD_BUILD }}
-            unitySerialOverride: ${{ secrets.UNITY_SERIAL_BUILD }}
+            unityEmailOverride: UNITY_EMAIL_BUILD
+            unityPasswordOverride: UNITY_PASSWORD_BUILD
+            unitySerialOverride: UNITY_SERIAL_BUILD
     steps:
       - uses: actions/checkout@v2
         with:
@@ -274,9 +274,9 @@ jobs:
       - uses: game-ci/unity-builder@v2.0.4
         timeout-minutes: 30
         env:
-          UNITY_EMAIL: ${{ matrix.unityEmailOverride || secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ matrix.unityPasswordOverride || secrets.UNITY_PASSWORD }}
-          UNITY_SERIAL: ${{ matrix.unitySerialOverride || secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets[matrix.unityEmailOverride] || secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets[matrix.unityPasswordOverride] || secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets[matrix.unitySerialOverride] || secrets.UNITY_SERIAL }}
         with:
           targetPlatform: ${{ matrix.targetPlatform }}
           unityVersion: ${{ matrix.unityVersion }}


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3014

# Brief Description
A lot of our builds fail because the many concurrent github action builds are vying for the single Unity Serial Key.
Buuut, as luck would have it, we have a few spare keys laying around, so we can put them to work and dedicate them to certain types of builds. 

The action file uses the matrix field to provide matrix-keys in certain build conditions, and then the serial key entry in the gameCI steps check for the overrides before falling back to the standard key. 



# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
