### PR TITLE
[BEAM-3063] Possibility to fold style card

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/SelectedElementVisualElement/SelectedElementVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/SelectedElementVisualElement/SelectedElementVisualElement.uss
@@ -101,4 +101,3 @@ LabeledObjectField #label {
 .hidden{
     display: none;
 }
-

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StyleCardVisualElement/StyleCardModel.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StyleCardVisualElement/StyleCardModel.cs
@@ -50,6 +50,7 @@ namespace Beamable.Editor.UI.Components
 		private PropertySourceDatabase PropertiesDatabase { get; }
 		private IEnumerable<BussStyleSheet> WritableStyleSheets { get; }
 		public bool IsWritable => StyleSheet.IsWritable;
+		public bool IsFolded => StyleRule.Folded;
 		public bool ShowAll { get; private set; }
 		private bool Sorted { get; set; }
 		private BussElement SelectedElement { get; }
@@ -316,6 +317,13 @@ namespace Beamable.Editor.UI.Components
 			}
 
 			Change?.Invoke();
+		}
+
+		public void FoldButtonClicked(MouseDownEvent evt)
+		{
+			StyleRule.SetFolded(!StyleRule.Folded);
+			AssetDatabase.SaveAssets();
+			_globalRefresh?.Invoke();
 		}
 	}
 }

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StyleCardVisualElement/StyleCardVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StyleCardVisualElement/StyleCardVisualElement.cs
@@ -9,19 +9,20 @@ namespace Beamable.Editor.UI.Components
 	{
 		private readonly StyleCardModel _model;
 
+		private BussSelectorLabelVisualElement _selectorLabelComponent;
 		private VisualElement _addRuleButton;
 		private VisualElement _addVariableButton;
 		private VisualElement _cleanAllButton;
 		private VisualElement _colorBlock;
 		private VisualElement _optionsButton;
 		private VisualElement _propertiesParent;
-		private BussSelectorLabelVisualElement _selectorLabelComponent;
 		private VisualElement _selectorLabelParent;
 		private VisualElement _showAllButton;
 		private TextElement _showAllButtonText;
 		private VisualElement _sortButton;
 		private VisualElement _undoButton;
 		private VisualElement _variablesParent;
+		private Image _foldIcon;
 
 		public StyleCardVisualElement(StyleCardModel model) : base(
 			$"{BUSS_THEME_MANAGER_PATH}/{nameof(StyleCardVisualElement)}/{nameof(StyleCardVisualElement)}")
@@ -36,7 +37,10 @@ namespace Beamable.Editor.UI.Components
 			_selectorLabelParent = Root.Q<VisualElement>("selectorLabelParent");
 			_variablesParent = Root.Q<VisualElement>("variables");
 			_propertiesParent = Root.Q<VisualElement>("properties");
-			_colorBlock = Root.Q<VisualElement>("colorBlock");
+			_colorBlock = Root.Q<VisualElement>("foldIconParent");
+			
+			_foldIcon = new Image { name = "foldIcon" };
+			_colorBlock.Add(_foldIcon);
 
 			_optionsButton = Root.Q<VisualElement>("optionsButton");
 			_optionsButton.tooltip = Tooltips.Buss.OPTIONS;
@@ -59,8 +63,25 @@ namespace Beamable.Editor.UI.Components
 			RefreshProperties();
 			UpdateShowAllStatus();
 			RefreshButtons();
+			SetFold();
+
 			_colorBlock.EnableInClassList("active", _model.IsSelected);
 			_model.Change += OnChange;
+
+			_colorBlock.RegisterCallback<MouseDownEvent>(_model.FoldButtonClicked);
+		}
+
+		private void SetFold()
+		{
+			_foldIcon.ToggleInClassList(_model.IsFolded ? "folded" : "unfolded");
+
+			if (!_model.IsFolded)
+			{
+				return;
+			}
+
+			_variablesParent.AddToClassList("hidden");
+			_propertiesParent.AddToClassList("hidden");
 		}
 
 		protected override void OnDestroy()

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StyleCardVisualElement/StyleCardVisualElement.dark.uss
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StyleCardVisualElement/StyleCardVisualElement.dark.uss
@@ -2,14 +2,6 @@
     color: rgb(255, 255, 255);
 }
 
-#colorBlock {
-    background-color: rgb(144,144,144);
-}
-
-#colorBlock.active {
-    background-color: rgb(0,145,255);
-}
-
 #sectionHeader {
     color: rgb(255,255,255);
     background-color: rgb(89,89,89);
@@ -65,4 +57,12 @@
 
 .cleanAll {
     background-image: resource("Packages/com.beamable/Editor/UI/Buss/ThemeManager/Assets/cleanAll.png");
+}
+
+.unfolded {
+    background-image: resource("Packages/com.beamable/Editor/UI/Common/Icons/triangle_down_light.png");
+}
+
+.folded {
+    background-image: resource("Packages/com.beamable/Editor/UI/Common/Icons/triangle_right_light.png");
 }

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StyleCardVisualElement/StyleCardVisualElement.light.uss
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StyleCardVisualElement/StyleCardVisualElement.light.uss
@@ -2,14 +2,6 @@
     color: rgb(37, 37, 37);
 }
 
-#colorBlock {
-    background-color: rgb(144,144,144);
-}
-
-#colorBlock.active {
-    background-color: rgb(0,145,255);
-}
-
 #sectionHeader {
     color: rgb(37, 37, 37);
     background-color: rgb(180, 180, 180);
@@ -66,4 +58,12 @@
 
 .cleanAll {
     background-image: resource("Packages/com.beamable/Editor/UI/Buss/ThemeManager/Assets/Erase_dark.png");
+}
+
+.unfolded {
+    background-image: resource("Packages/com.beamable/Editor/UI/Common/Icons/triangle_down_dark.png");
+}
+
+.folded {
+    background-image: resource("Packages/com.beamable/Editor/UI/Common/Icons/triangle_right_dark.png");
 }

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StyleCardVisualElement/StyleCardVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StyleCardVisualElement/StyleCardVisualElement.uss
@@ -19,12 +19,14 @@
     justify-content: center;
 }
 
-#colorBlock {
-    margin-top: 5px;
-    margin-bottom: 5px;
+#foldIconParent {
+    justify-content: center;
     margin-left:10px;
-    width: 5px;
-    background-color: rgb(144, 144, 144);
+}
+
+#foldIcon {
+    height: 7px;
+    width: 7px;
 }
 
 #colorBlock.active {
@@ -101,8 +103,7 @@
 }
 
 .hidden {
-    visibility: hidden;
-    height: 0;
+    display: none;
 }
 
 #removeButtonContainer {

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StyleCardVisualElement/StyleCardVisualElement.uxml
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StyleCardVisualElement/StyleCardVisualElement.uxml
@@ -7,7 +7,7 @@
 
     <engine:VisualElement name="cardContainer">
         <engine:VisualElement name="cardHeader">
-            <engine:VisualElement name="colorBlock"/>
+            <engine:VisualElement name="foldIconParent"/>
             <engine:VisualElement name="selectorLabelParent"/>
             <engine:VisualElement name="optionsButton" class="button smallButton edit"/>
             <engine:VisualElement name="undoButton" class="button smallButton undo"/>

--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/Styles/BussStyleSheet.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/Styles/BussStyleSheet.cs
@@ -146,9 +146,14 @@ namespace Beamable.UI.Buss
 	[Serializable]
 	public class BussStyleDescription
 	{
+		// Style card state related data
+		[SerializeField] private bool _folded;
+		
 		[SerializeField] protected List<BussPropertyProvider> _properties = new List<BussPropertyProvider>();
 		[SerializeField] protected List<BussPropertyProvider> _cachedProperties = new List<BussPropertyProvider>();
 		public List<BussPropertyProvider> Properties => _properties;
+
+		public bool Folded => _folded;
 
 		public bool HasProperty(string key)
 		{
@@ -205,6 +210,11 @@ namespace Beamable.UI.Buss
 					_cachedProperties.RemoveAt(index);
 				}
 			}
+		}
+
+		public void SetFolded(bool value)
+		{
+			_folded = value;
 		}
 	}
 


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3063

# Brief Description
Removed rectangle and added folding/unfolding feature to a style card. Data is serialized to scriptable object so fold state is persistent between sessions.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
