### PR TITLE
[BEAM-3075] Refresh after duplicating style rule

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StyleCardVisualElement/StyleCardModel.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StyleCardVisualElement/StyleCardModel.cs
@@ -173,6 +173,7 @@ namespace Beamable.Editor.UI.Components
 				commands.Add(new GenericMenuCommand(Constants.Features.Buss.MenuItems.DUPLICATE, () =>
 				{
 					BussStyleSheetUtility.CopySingleStyle(StyleSheet, StyleRule);
+					_globalRefresh.Invoke();
 				}));
 			}
 
@@ -187,8 +188,8 @@ namespace Beamable.Editor.UI.Components
 									 $"{Constants.Features.Buss.MenuItems.COPY_TO}/{targetStyleSheet.name}",
 									 () =>
 									 {
-										 BussStyleSheetUtility.CopySingleStyle(
-											 targetStyleSheet, StyleRule);
+										 BussStyleSheetUtility.CopySingleStyle(targetStyleSheet, StyleRule);
+										 _globalRefresh.Invoke();
 									 }));
 				}
 			}


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3075

# Brief Description
Forcing refresh after dupicating style rule

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
