### PR TITLE
[BEAM-3077] Variable dropdown automatically adjusts its width

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StylePropertyVisualElement/StylePropertyVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StylePropertyVisualElement/StylePropertyVisualElement.uss
@@ -25,6 +25,7 @@ CustomMessageBussPropertyVisualElement > Label {
 
 #globalVariable {
     width: 140px;
+    flex-grow: 1;
 }
 
 .dropdown {

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StylePropertyVisualElement/VariableConnectionVisualElement/VariableConnectionVisualElement.uss
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StylePropertyVisualElement/VariableConnectionVisualElement/VariableConnectionVisualElement.uss
@@ -1,3 +1,7 @@
+#root {
+    flex-grow: 1;
+}
+
 #button {
     width: 30px;
     height: 30px;
@@ -8,12 +12,17 @@
     justify-content: center;
 }
 
+#variableConnectionElement {
+    flex-grow: 1;
+}
+
 DropdownVisualElement{
     margin: 5px;
+    flex-grow: 1;
 }
 
 DropdownVisualElement #mainVisualElement{
-    width: 100px;
+    width: auto;
 }
 
 DropdownVisualElement #mainContainer{


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3077

# Brief Description
Variable dropdown adjusts its width automatically to parent's max width
![image](https://user-images.githubusercontent.com/6697418/192769674-da56a767-9434-420b-930e-5bdd93d4f802.png)


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
