### PR TITLE
[BEAM-3102] Create Authorized BeamContext method

### DIFF
--- a/client/Packages/com.beamable/Runtime/BeamContext.cs
+++ b/client/Packages/com.beamable/Runtime/BeamContext.cs
@@ -259,8 +259,16 @@ namespace Beamable
 		/// <returns>New instance of the <see cref="BeamContext"/></returns>
 		public static BeamContext CreateAuthorizedContext(string playerCode, TokenResponse token)
 		{
-			if (_playerCodeToContext.ContainsKey(playerCode))
+			bool isDefault = string.IsNullOrWhiteSpace(playerCode);
+			if (isDefault || _playerCodeToContext.ContainsKey(playerCode))
 			{
+#if UNITY_EDITOR
+				const string log =
+					@"<b>BeamContext</b> with id <b>{0}</b> already exists. " +
+					"In order to update existing BeamContext it is recommended to use <b>" + 
+					nameof(ChangeAuthorizedPlayer) + "</b> method instead.";
+				Debug.LogError(string.Format(log, isDefault ? "Default" : playerCode));
+#endif
 				throw new BeamContextInitException(_playerCodeToContext[playerCode], 
 				                                   new []{new Exception($"BeamContext with \"{playerCode}\" prefix already exist.")});
 			}


### PR DESCRIPTION
# Ticket

# Brief Description

CreateAuthorizedContext method will allow game makers to create BeamContext with predefined credentials, example code:

```csharp
	public static async Promise<BeamContext> GetContextWithCredentials(string forPlayer, string email, string password)
	{
		await BeamContext.Default.OnReady;
		var isEmailAvailable = await BeamContext.Default.Api.AuthService.IsEmailAvailable(email);
		if (isEmailAvailable)
		{
			await BeamContext.Default.Api.AuthService.RegisterDBCredentials(email, password);
		}
		var token = await BeamContext.Default.Api.AuthService.Login(email, password, false);
		return BeamContext.CreateAuthorizedContext(forPlayer, token);
	}
```

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
