### PR TITLE
[BEAM-3108] Skipping "empty" (without any options) configuration files and preventing from rendering them

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Config/BeamableSettingsProvider.cs
+++ b/client/Packages/com.beamable/Editor/UI/Config/BeamableSettingsProvider.cs
@@ -1,4 +1,3 @@
-using Beamable.Editor.UI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -104,9 +103,17 @@ namespace Beamable.Editor.Config
 				{
 					ConfigManager.Initialize(); // re-initialize every time the window is activated, so that we make sure the SO's always exist.
 
-					var providers = ConfigManager.ConfigObjects.Select(config =>
+					List<SettingsProvider> providers = new List<SettingsProvider>();
+					
+					foreach (BaseModuleConfigurationObject config in ConfigManager.ConfigObjects)
 					{
 						var options = ConfigManager.GenerateOptions(config);
+
+						if (options.Count == 0)
+						{
+							continue;
+						}
+						
 						var settingsProvider = new SettingsProvider($"Project/Beamable/{options[0].Module}", SettingsScope.Project)
 						{
 							activateHandler = (searchContext, rootElement) =>
@@ -120,10 +127,10 @@ namespace Beamable.Editor.Config
 							keywords = new HashSet<string>(options.Select(o => o.Name))
 						};
 
-						return settingsProvider;
-					}).ToArray();
+						providers.Add(settingsProvider);
+					}
 
-					provider = providers;
+					provider = providers.ToArray();
 				}
 				catch (Exception ex)
 				{


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3108
# Brief Description
During one of last tickets I've removed last public field from BussConfiguration (which is ModuleConfiguration object) making it empty one. This caused a problem where we had an array with 0 elements (options) for BussConfiguration and while ProjectSettings were trying to iterate over options to render them there was exception thrown.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
