### PR TITLE
[BEAM-3084] Forced global refresh after adding new stylesheet with rule overriding another one

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/NewStyleSheetWindow/NewStyleSheetVisualElement/NewStyleSheetVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/NewStyleSheetWindow/NewStyleSheetVisualElement/NewStyleSheetVisualElement.cs
@@ -97,7 +97,7 @@ namespace Beamable.Editor.UI.Buss
 			}
 
 			BussStyleSheetUtility.CreateNewStyleSheetWithInitialRules(_styleSheetName.Value, _initialRule);
-
+			BussConfiguration.OptionalInstance.Value.ForceRefresh();
 			NewStyleSheetWindow.CloseWindow();
 		}
 

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/ThemeManager.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/ThemeManager.cs
@@ -46,7 +46,7 @@ namespace Beamable.Editor.UI.Buss
 
 		private void OnFocus()
 		{
-			_model?.OnFocus();
+			_model?.ForceRefresh();
 		}
 
 		[MenuItem(

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/ThemeModel.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/ThemeModel.cs
@@ -46,11 +46,6 @@ namespace Beamable.Editor.UI.Buss
 			Selection.activeGameObject = Selection.activeGameObject == element.gameObject ? null : element.gameObject;
 		}
 
-		public void OnFocus()
-		{
-			Change?.Invoke();
-		}
-
 		#region Action bar buttons' actions
 
 		public void OnAddStyleButtonClicked()

--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/BussConfiguration.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/BussConfiguration.cs
@@ -19,7 +19,7 @@ namespace Beamable.UI.Buss
 			{
 				try
 				{
-					return new Optional<BussConfiguration> { Value = Instance, HasValue = true };
+					return new Optional<BussConfiguration> {Value = Instance, HasValue = true};
 				}
 				catch (ModuleConfigurationNotReadyException)
 				{
@@ -27,6 +27,7 @@ namespace Beamable.UI.Buss
 				}
 			}
 		}
+
 		private static BussConfiguration Instance => Get<BussConfiguration>();
 		private static readonly Dictionary<string, SelectorWeight> Weights = new Dictionary<string, SelectorWeight>();
 		private static VariableDatabase _variableDatabase;
@@ -37,9 +38,9 @@ namespace Beamable.UI.Buss
 			get
 			{
 				BussStyleSheet[] bussStyleSheets = Resources
-												   .LoadAll<BussStyleSheet>(
-													   Constants.Features.Buss.Paths.FACTORY_STYLES_RESOURCES_PATH)
-												   .Where(styleSheet => styleSheet.IsReadOnly).ToArray();
+				                                   .LoadAll<BussStyleSheet>(
+					                                   Constants.Features.Buss.Paths.FACTORY_STYLES_RESOURCES_PATH)
+				                                   .Where(styleSheet => styleSheet.IsReadOnly).ToArray();
 
 				return bussStyleSheets.OrderBy(s => s.SortingOrder).ToList();
 			}
@@ -47,7 +48,7 @@ namespace Beamable.UI.Buss
 
 		public List<BussStyleSheet> DeveloperStyleSheets =>
 			Resources.LoadAll<BussStyleSheet>("")
-					 .Where(styleSheet => !styleSheet.IsReadOnly).ToList();
+			         .Where(styleSheet => !styleSheet.IsReadOnly).ToList();
 
 		public List<BussElement> RootBussElements => _rootBussElements;
 		public VariableDatabase VariableDatabase => _variableDatabase;
@@ -55,17 +56,6 @@ namespace Beamable.UI.Buss
 		public static void UseConfig(Action<BussConfiguration> callback)
 		{
 			OptionalInstance.DoIfExists(callback);
-		}
-
-		public void AddDeveloperStyleSheet(BussStyleSheet styleSheet)
-		{
-			if (DeveloperStyleSheets.Contains(styleSheet))
-			{
-				return;
-			}
-
-			DeveloperStyleSheets.Add(styleSheet);
-			UpdateStyleSheet(styleSheet);
 		}
 
 		public void RegisterObserver(BussElement bussElement)
@@ -214,7 +204,7 @@ namespace Beamable.UI.Buss
 			foreach (BussPropertyProvider property in descriptor.Properties)
 			{
 				if (!Weights.TryGetValue(property.Key, out SelectorWeight currentWeight) ||
-					weight.CompareTo(currentWeight) >= 0)
+				    weight.CompareTo(currentWeight) >= 0)
 				{
 					IBussProperty prop = property.GetProperty();
 
@@ -235,16 +225,16 @@ namespace Beamable.UI.Buss
 		}
 
 		private static void ApplyDescriptorWithPseudoClass(BussElement element,
-														   string pseudoClass,
-														   BussStyleDescription descriptor,
-														   SelectorWeight weight)
+		                                                   string pseudoClass,
+		                                                   BussStyleDescription descriptor,
+		                                                   SelectorWeight weight)
 		{
 			if (element == null || descriptor == null) return;
 			foreach (BussPropertyProvider property in descriptor.Properties)
 			{
 				string weightKey = pseudoClass + property.Key;
 				if (!Weights.TryGetValue(weightKey, out SelectorWeight currentWeight) ||
-					weight.CompareTo(currentWeight) >= 0)
+				    weight.CompareTo(currentWeight) >= 0)
 				{
 					element.Style[pseudoClass, property.Key] = property.GetProperty();
 					Weights[weightKey] = weight;

--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/Styles/BussStyleSheetUtility.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/Styles/BussStyleSheetUtility.cs
@@ -140,8 +140,6 @@ namespace Beamable.UI.Buss
 				CopySingleStyle(newStyleSheet, styleRule);
 			}
 
-			BussConfiguration.OptionalInstance.Value.AddDeveloperStyleSheet(newStyleSheet);
-
 #if UNITY_EDITOR
 			AssetDatabase.CreateAsset(newStyleSheet, $"Assets/Resources/{fileName}.asset");
 			AssetDatabase.SaveAssets();


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3084

# Brief Description
Calling global refresh on BussConfiguration (highest possible "manager" in core buss system hierarchy) to recalculate specificity after new style sheet with overriding rule has been created.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
