### PR TITLE
[BEAM-3116] Additional contain check and ensure that variables database exists on editor startup

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussCardFilter.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussCardFilter.cs
@@ -22,7 +22,7 @@ namespace Beamable.Editor.UI.Buss
 		}
 
 		public Dictionary<BussStyleRule, BussStyleSheet> GetFiltered(List<BussStyleSheet> styleSheets,
-																	 BussElement selectedElement)
+		                                                             BussElement selectedElement)
 		{
 			Dictionary<BussStyleRule, BussStyleSheet> rules = new Dictionary<BussStyleRule, BussStyleSheet>();
 
@@ -30,7 +30,12 @@ namespace Beamable.Editor.UI.Buss
 			{
 				foreach (var rule in styleSheet.Styles)
 				{
-					if (CardFilter(rule, selectedElement))
+					if (!CardFilter(rule, selectedElement))
+					{
+						continue;
+					}
+
+					if (!rules.ContainsKey(rule))
 					{
 						rules.Add(rule, styleSheet);
 					}
@@ -43,7 +48,7 @@ namespace Beamable.Editor.UI.Buss
 		private bool CardFilter(BussStyleRule styleRule, BussElement selectedElement)
 		{
 			bool contains = styleRule.Properties.Any(property => property.Key.ToLower().Contains(CurrentFilter)) ||
-							styleRule.Properties.Count == 0;
+			                styleRule.Properties.Count == 0;
 
 			return selectedElement == null
 				? CurrentFilter.Length <= 0 || contains

--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/BussConfiguration.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/BussConfiguration.cs
@@ -51,7 +51,7 @@ namespace Beamable.UI.Buss
 					 .Where(styleSheet => !styleSheet.IsReadOnly).ToList();
 
 		public List<BussElement> RootBussElements => _rootBussElements;
-		public VariableDatabase VariableDatabase => _variableDatabase;
+		public VariableDatabase VariableDatabase => _variableDatabase ?? (_variableDatabase = new VariableDatabase(this));
 
 		public static void UseConfig(Action<BussConfiguration> callback)
 		{
@@ -146,12 +146,7 @@ namespace Beamable.UI.Buss
 			Weights.Clear();
 			element.Style.Clear();
 
-			if (_variableDatabase == null)
-			{
-				_variableDatabase = new VariableDatabase(this);
-			}
-
-			_variableDatabase.ReconsiderAllStyleSheets();
+			VariableDatabase.ReconsiderAllStyleSheets();
 
 			// Applying default bemable styles
 			foreach (BussStyleSheet styleSheet in FactoryStyleSheets)

--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/VariableDatabase.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/VariableDatabase.cs
@@ -40,7 +40,7 @@ namespace Beamable.UI.Buss
 		private readonly Dictionary<string, PropertyReference> _variables = new Dictionary<string, PropertyReference>();
 
 		private readonly IVariablesProvider _variablesProvider;
-
+		
 		public VariableDatabase(IVariablesProvider variablesProvider)
 		{
 			_variablesProvider = variablesProvider;


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3116

# Brief Description
I've fixed also an exception raised due to variables database being null with Theme Manager opened on startup.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
