### PR TITLE
beam 3051 - stat search criteria for valid types

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `long` PlayerId version of `InviteToParty`, `PromoteToLeader` and `KickPlayer` methods of the `IPartyApi` interface.
 - Utility apis for setting expiration on Mail Update and Mail Send requests
+- `SearchStats` method can now accept criteria values for `int`, `long`, `double`, `bool`, `string`, and their associated `List<T>` types.
 
 ### Fixed
 - ActionBarVisualElement buttons behaviour is fixed when Docker is not running.

--- a/client/Packages/com.beamable/Common/Runtime/Api/Stats/AbsStatsApi.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/Stats/AbsStatsApi.cs
@@ -2,6 +2,7 @@ using Beamable.Common.Dependencies;
 using Beamable.Serialization.SmallerJSON;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using UnityEngine;
 
@@ -122,7 +123,7 @@ namespace Beamable.Common.Api.Stats
 			  {
 				  {"stat", criteria.Stat},
 				  {"rel", criteria.Rel},
-				  {"value", criteria.Value}
+				  {"value", criteria.RawValue}
 			  };
 			}
 
@@ -161,6 +162,8 @@ namespace Beamable.Common.Api.Stats
 		public long[] ids;
 	}
 
+
+
 	/// <summary>
 	/// A definition of a comparison (<see cref="Rel"/>) to be run against the specified <see cref="Stat"/>.
 	/// </summary>
@@ -189,17 +192,116 @@ namespace Beamable.Common.Api.Stats
 		/// <summary>
 		/// The RHS of the comparison.
 		/// </summary>
-		public string Value { get; }
+		[Obsolete("Value will assume that you passed a string as the value. Use the correct type accessor instead.")]
+		public string Value => TextValue;
+
+		public long LongValue => RawValue is long ? (long)RawValue : 0;
+		public bool BoolValue => RawValue is bool ? (bool)RawValue : false;
+		public double DoubleValue => RawValue is double ? (double)RawValue : 0;
+		public int IntValue => RawValue is int ? (int)RawValue : 0;
+		public string TextValue => RawValue as string;
+		public List<long> LongListValue => RawValue as List<long>;
+		public List<bool> BoolListValue => RawValue as List<bool>;
+		public List<double> DoubleListValue => RawValue as List<double>;
+		public List<int> IntListValue => RawValue as List<int>;
+		public List<string> TextListValue => RawValue as List<string>;
+
+		/// <summary>
+		/// The RHS of the comparison. This is the raw value. Use one of the following to get the typed version.
+		/// <see cref="TextValue"/>,
+		/// <see cref="DoubleValue"/>,
+		/// <see cref="BoolValue"/>,
+		/// <see cref="IntValue"/>,
+		/// <see cref="LongValue"/>,
+		/// <see cref="TextListValue"/>,
+		/// <see cref="DoubleListValue"/>,
+		/// <see cref="BoolListValue"/>,
+		/// <see cref="IntListValue"/>,
+		/// <see cref="LongListValue"/>,
+		/// </summary>
+		public object RawValue { get; }
 
 
-		/// <param name="stat"><see cref="Stat"/></param>
+		/// <param name="stat"><inheritdoc cref="Stat"/></param>
 		/// <param name="rel"><see cref="Rel"/></param>
 		/// <param name="value"><see cref="Value"/></param>
 		public Criteria(string stat, string rel, string value)
 		{
 			Stat = stat;
 			Rel = rel;
-			Value = value;
+			RawValue = value;
+		}
+
+		/// <inheritdoc cref="Criteria(string, string, string)"/>
+		public Criteria(string stat, string rel, long value)
+		{
+			Stat = stat;
+			Rel = rel;
+			RawValue = value;
+		}
+
+		/// <inheritdoc cref="Criteria(string, string, string)"/>
+		public Criteria(string stat, string rel, int value)
+		{
+			Stat = stat;
+			Rel = rel;
+			RawValue = value;
+		}
+
+		/// <inheritdoc cref="Criteria(string, string, string)"/>
+		public Criteria(string stat, string rel, double value)
+		{
+			Stat = stat;
+			Rel = rel;
+			RawValue = value;
+		}
+
+		/// <inheritdoc cref="Criteria(string, string, string)"/>
+		public Criteria(string stat, string rel, bool value)
+		{
+			Stat = stat;
+			Rel = rel;
+			RawValue = value;
+		}
+
+		/// <inheritdoc cref="Criteria(string, string, string)"/>
+		public Criteria(string stat, string rel, IEnumerable<bool> value)
+		{
+			Stat = stat;
+			Rel = rel;
+			RawValue = value.ToList();
+		}
+
+		/// <inheritdoc cref="Criteria(string, string, string)"/>
+		public Criteria(string stat, string rel, IEnumerable<int> value)
+		{
+			Stat = stat;
+			Rel = rel;
+			RawValue = value.ToList();
+		}
+
+		/// <inheritdoc cref="Criteria(string, string, string)"/>
+		public Criteria(string stat, string rel, IEnumerable<long> value)
+		{
+			Stat = stat;
+			Rel = rel;
+			RawValue = value.ToList();
+		}
+
+		/// <inheritdoc cref="Criteria(string, string, string)"/>
+		public Criteria(string stat, string rel, IEnumerable<double> value)
+		{
+			Stat = stat;
+			Rel = rel;
+			RawValue = value.ToList();
+		}
+
+		/// <inheritdoc cref="Criteria(string, string, string)"/>
+		public Criteria(string stat, string rel, IEnumerable<string> value)
+		{
+			Stat = stat;
+			Rel = rel;
+			RawValue = value.ToList();
 		}
 	}
 }

--- a/wiki/features/beam-3051.md
+++ b/wiki/features/beam-3051.md
@@ -1,0 +1,76 @@
+
+### Why
+Our scala backend supports searching for numeric stats, but our SDK forced the type to be a string. That prevented folks from using more complex searching relationships like `gt` .
+
+### Configuration
+None
+
+### How
+The old way, you had to set the criteria value in the constructor of the criteria. That is still how it works now, but now there are many constructor overloads so you can use the one with the right type. 
+```csharp
+
+[ClientCallable]
+public async Promise<List<long>> SearchIt_Numeric(string stat, string comparison, int num)
+{
+    var criteriaList = new List<Criteria> {new Criteria(stat, comparison, num)};
+    var data = await Services.Stats.SearchStats("game", "private", "player", criteriaList);
+    return data.ids.ToList();
+}
+
+[ClientCallable]
+public async Promise<List<long>> SearchIt_String(string stat, string comparison, string filter)
+{
+    var criteriaList = new List<Criteria> {new Criteria(stat, comparison, filter)};
+    var data = await Services.Stats.SearchStats("game", "private", "player", criteriaList);
+    return data.ids.ToList();
+}
+
+
+[ClientCallable]
+public async Promise<List<long>> SearchIt_ListOf(string stat, string comparison, List<string> filter)
+{
+    var criteriaList = new List<Criteria> {new Criteria(stat, comparison, filter)};
+    var data = await Services.Stats.SearchStats("game", "private", "player", criteriaList);
+    return data.ids.ToList();
+}
+```
+
+### Notes
+
+If you created a criteria, and access the `Value`, you can still do that, but it'll appear as obsolete- because we don't know if thats really the right type... Meh?
+
+On the backend, we support the following relationships...
+
+```scala
+val rel = part.rel match {
+case "equal" | "eq" => "$eq"
+case "notequal" | "neq" => "$ne"
+case "lessthan" | "lt" => "$lt"
+case "lessthanequal" | "lte" => "$lte"
+case "greaterthan" | "gt" => "$gt"
+case "greaterthanequal" | "gte" => "$gte"
+case "in" => "$in"
+case "notin" | "nin" => "$nin"
+case relation => throw ServiceError(ServiceErrorStatus.BAD_REQUEST, "stats", "InvalidRelation", relation)
+}
+```
+And the following value types (all of which are now supported)
+```scala
+          val valueMatch = partValue match {
+            case v: String => Document(rel -> v)
+            case v: Long => Document(rel -> v)
+            case v: Int => Document(rel -> v)
+            case v: Double => Document(rel -> v)
+            case v: Boolean => Document(rel -> v)
+            case v: List[_] if v.isEmpty => Document(rel -> List[String]())
+            case v: List[_] if v.nonEmpty => v.head match {
+              case _: String => Document(rel -> v.asInstanceOf[List[String]])
+              case _: Long => Document(rel -> v.asInstanceOf[List[Long]])
+              case _: Int => Document(rel -> v.asInstanceOf[List[Int]])
+              case _: Double => Document(rel -> v.asInstanceOf[List[Double]])
+              case _: Boolean => Document(rel -> v.asInstanceOf[List[Boolean]])
+            }
+            case v => throw ServiceError(ServiceErrorStatus.BAD_REQUEST, "stats", "UnknownType", v.getClass.getName)
+          }
+```
+


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3051

# Brief Description
It used to be the case that our C# code would force the `value` of the criteria to be string. Luckily, the old code was already doing some custom JSON setting, so all we had to do was _not_ send in a `string`. Instead, I store the value as an `object`, and allow it to be boxed / unboxed when a developer sets it/ reads it. Its essentially read-only, and this datatype is never consumed over the wire, only sent. 


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [X] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [X] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
