### PR TITLE
[BEAM-3128] Additional SetDirty call to ensure that class will be applied for selected buss element

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/SelectedElementVisualElement/SelectedElementVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/SelectedElementVisualElement/SelectedElementVisualElement.cs
@@ -228,12 +228,7 @@ namespace Beamable.Editor.UI.Components
 			TextField textField = (TextField)element.Children().ToList()[1];
 			textField.value = BussNameUtility.AsClassSelector(_classesList.itemsSource[index] as string);
 			textField.isDelayed = true;
-
-#if UNITY_2018
-			textField.OnValueChanged(ClassValueChanged);
-#elif UNITY_2019_1_OR_NEWER
 			textField.RegisterValueChangedCallback(ClassValueChanged);
-#endif
 
 			void ClassValueChanged(ChangeEvent<string> evt)
 			{
@@ -241,6 +236,7 @@ namespace Beamable.Editor.UI.Components
 				_classesList.itemsSource[index] = newValue;
 				textField.SetValueWithoutNotify(newValue);
 				_model.SelectedElement.UpdateClasses(BussNameUtility.AsCleanList((List<string>)_classesList.itemsSource));
+				EditorUtility.SetDirty(_model.SelectedElement);
 				_model.ForceRefresh();
 			}
 		}


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3128

# Brief Description

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
