### PR TITLE
[BEAM-3083] Reversing filtered rules order while context (selected element) is not null

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussCardFilter.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussCardFilter.cs
@@ -22,7 +22,7 @@ namespace Beamable.Editor.UI.Buss
 		}
 
 		public Dictionary<BussStyleRule, BussStyleSheet> GetFiltered(List<BussStyleSheet> styleSheets,
-																	 BussElement selectedElement)
+		                                                             BussElement selectedElement)
 		{
 			Dictionary<BussStyleRule, BussStyleSheet> rules = new Dictionary<BussStyleRule, BussStyleSheet>();
 
@@ -42,13 +42,27 @@ namespace Beamable.Editor.UI.Buss
 				}
 			}
 
-			return rules;
+			if (selectedElement == null)
+			{
+				return rules;
+			}
+
+			// Reversing filtered rules order
+			Dictionary<BussStyleRule, BussStyleSheet> sortedRules = new Dictionary<BussStyleRule, BussStyleSheet>();
+
+			for (int i = rules.Count-1; i >= 0; i--)
+			{
+				var pair = rules.ElementAt(i);
+				sortedRules.Add(pair.Key, pair.Value);
+			}
+			
+			return sortedRules;
 		}
 
 		private bool CardFilter(BussStyleRule styleRule, BussElement selectedElement)
 		{
 			bool contains = styleRule.Properties.Any(property => property.Key.ToLower().Contains(CurrentFilter)) ||
-							styleRule.Properties.Count == 0;
+			                styleRule.Properties.Count == 0;
 
 			return selectedElement == null
 				? CurrentFilter.Length <= 0 || contains

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussStyleListVisualElement/BussStyleListVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussStyleListVisualElement/BussStyleListVisualElement.cs
@@ -1,5 +1,4 @@
-﻿using Beamable.Editor.Common;
-using Beamable.Editor.UI.Common;
+﻿using Beamable.Editor.UI.Common;
 using Beamable.Editor.UI.Components;
 using Beamable.UI.Buss;
 using System;

--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/BussSelector.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/BussSelector.cs
@@ -56,6 +56,11 @@ namespace Beamable.UI.Buss
 			if (classCountComparison != 0) return classCountComparison;
 			return ElementCount.CompareTo(other.ElementCount);
 		}
+
+		public override string ToString()
+		{
+			return $"Id: {IdCount}, class: {ClassCount}, element: {ElementCount}";
+		}
 	}
 
 	public class UniversalSelector : BussSelector


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3083

# Brief Description

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
