### PR TITLE
[BEAM-3134] BUSS - Optimize cards refreshing

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StylePropertyVisualElement/StylePropertyVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StylePropertyVisualElement/StylePropertyVisualElement.cs
@@ -142,7 +142,6 @@ namespace Beamable.Editor.UI.Components
 			{
 				_variableConnection = new VariableConnectionVisualElement(_model);
 				_variableConnection.Init();
-				_variableConnection.Refresh();
 				_variableParent.Add(_variableConnection);
 			}
 		}


### PR DESCRIPTION
# Brief Description

We refresh BUSS ui twice so it took time and generate garbage. I fixed that.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
