### PR TITLE
beam 3110 - stats is obsolete

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Content Manager exception when search doesn't match. 
 
 ### Changed
-- The `[Agnostic]` attribute is no obsolete. It is still usable, but assembly definitions should be used instead for code sharing.
+- The `[Agnostic]` attribute is now obsolete. It is still usable, but assembly definitions should be used instead for code sharing.
+- The `Stats` accessor on `IBeamableAPI` is now obsolete. Use `StatsService` instead.
 
 ## [1.4.0]
 ### Added

--- a/client/Packages/com.beamable/Runtime/Player/ApiServices.cs
+++ b/client/Packages/com.beamable/Runtime/Player/ApiServices.cs
@@ -72,6 +72,8 @@ namespace Beamable.Player
 		public LeaderboardService LeaderboardService => _ctx.ServiceProvider.GetService<LeaderboardService>();
 		public IBeamableRequester Requester => _ctx.ServiceProvider.GetService<IBeamableRequester>();
 		public StatsService StatsService => _ctx.ServiceProvider.GetService<StatsService>();
+
+		[Obsolete("Use " + nameof(StatsService) + " instead.")]
 		public StatsService Stats => _ctx.ServiceProvider.GetService<StatsService>();
 		public SessionService SessionService => _ctx.ServiceProvider.GetService<SessionService>();
 		public IAnalyticsTracker AnalyticsTracker => _ctx.ServiceProvider.GetService<IAnalyticsTracker>();


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3110

# Brief Description
Silly- the interface has the obsolete marking, but the hard class didn't... Meh.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
