### PR TITLE
beam 3148 - microservice startup seq no elements

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [Unreleased]
+### Fixed
+- `SequenceContainsNoElements` error when building Microservices.
+
 ### [1.4.0]
 ### Added
 - Added `long` PlayerId version of `InviteToParty`, `PromoteToLeader` and `KickPlayer` methods of the `IPartyApi` interface.

--- a/client/Packages/com.beamable.server/Editor/BeamServicesCodeWatcher.cs
+++ b/client/Packages/com.beamable.server/Editor/BeamServicesCodeWatcher.cs
@@ -148,22 +148,30 @@ namespace Beamable.Server.Editor
 			var config = MicroserviceConfiguration.Instance;
 			var currCodeHandles = config.ServiceCodeHandlesOnLastDomainReload;
 
-			if (currCodeHandles != null && currCodeHandles.Count > 0)
+			if (currCodeHandles == null || currCodeHandles.Count <= 0)
 			{
-				var serviceToUpdate = currCodeHandles.First(h => h.ServiceName == serviceName);
-
-				var builtCodeHandles = serviceToUpdate.AsmDefInfo.References
-													  .Select(asmName => currCodeHandles.FirstOrDefault(
-																  c => c.AsmDefInfo.Name == asmName))
-													  .Where(handle => handle.CodeClass != BeamCodeClass.Invalid)
-													  .ToList();
-
-				config.LastBuiltDockerImagesCodeHandles.Remove(serviceToUpdate);
-				config.LastBuiltDockerImagesCodeHandles.RemoveAll(h => builtCodeHandles.Contains(h));
-
-				config.LastBuiltDockerImagesCodeHandles.Add(serviceToUpdate);
-				config.LastBuiltDockerImagesCodeHandles.AddRange(builtCodeHandles);
+				// there are no current code handles, so there is nothing to check.
+				return;
 			}
+
+			var serviceToUpdate = currCodeHandles.FirstOrDefault(h => h.ServiceName == serviceName);
+			if (string.IsNullOrEmpty(serviceToUpdate.ServiceName))
+			{
+				// none of the existing code handles reference this service yet, so there is nothing to do.
+				return;
+			}
+
+			var builtCodeHandles = serviceToUpdate.AsmDefInfo.References
+			                                      .Select(asmName => currCodeHandles.FirstOrDefault(
+				                                              c => c.AsmDefInfo.Name == asmName))
+			                                      .Where(handle => handle.CodeClass != BeamCodeClass.Invalid)
+			                                      .ToList();
+
+			config.LastBuiltDockerImagesCodeHandles.Remove(serviceToUpdate);
+			config.LastBuiltDockerImagesCodeHandles.RemoveAll(h => builtCodeHandles.Contains(h));
+
+			config.LastBuiltDockerImagesCodeHandles.Add(serviceToUpdate);
+			config.LastBuiltDockerImagesCodeHandles.AddRange(builtCodeHandles);
 		}
 
 		public void CheckForMissingMongoDependenciesOnMicroservices()


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3148

# Brief Description
There was a bug where during the build of a Microservice we'd try to refresh some internal editor state about the service and invalidate some caches. 
However, we were using a linq based `First` method, which throws an error if there is no matching sequence element.
I changed it to `FirstOrDefault`, and then used a null string check to see if we got a valid service reference. (the elements aren't nullable, so we can't just check for null or default(T)`. 

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
