### PR TITLE
beam 3166- make sdk use partial classes for model types

### DIFF
--- a/cli/cli/Services/UnitySourceGenerator.cs
+++ b/cli/cli/Services/UnitySourceGenerator.cs
@@ -944,6 +944,9 @@ public static class UnityHelper
 
 		var type = new CodeTypeDeclaration(SanitizeClassName(name));
 
+		// make the type partial, so that we can extend it manually...
+		type.IsPartial = true;
+
 		// make sure the model is serializable
 		type.CustomAttributes.Add(
 			new CodeAttributeDeclaration(new CodeTypeReference(typeof(SerializableAttribute))));

--- a/cli/tests/ModelGenerationTests.cs
+++ b/cli/tests/ModelGenerationTests.cs
@@ -130,7 +130,7 @@ namespace Test
 {
     
 	[System.SerializableAttribute()]
-	public class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
+	public partial class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
 	{
 		public long foo;
         public virtual void Serialize(Beamable.Serialization.JsonSerializable.IStreamSerializer s)
@@ -175,7 +175,7 @@ namespace Test
 {
     
 	[System.SerializableAttribute()]
-	public class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
+	public partial class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
 	{
 		public InvitationDirection foo;
         public virtual void Serialize(Beamable.Serialization.JsonSerializable.IStreamSerializer s)
@@ -214,7 +214,7 @@ namespace Test
 {
     
 	[System.SerializableAttribute()]
-	public class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
+	public partial class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
 	{
 		public string foo;
         public virtual void Serialize(Beamable.Serialization.JsonSerializable.IStreamSerializer s)
@@ -261,7 +261,7 @@ namespace Test
 {
     
 	[System.SerializableAttribute()]
-	public class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
+	public partial class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
 	{
 		public string FIELD;
         public virtual void Serialize(Beamable.Serialization.JsonSerializable.IStreamSerializer s)
@@ -304,7 +304,7 @@ namespace Test
 {
     
 	[System.SerializableAttribute()]
-	public class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
+	public partial class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
 	{
 		public long[] foo;
         public virtual void Serialize(Beamable.Serialization.JsonSerializable.IStreamSerializer s)
@@ -349,7 +349,7 @@ namespace Test
 {
     
 	[System.SerializableAttribute()]
-	public class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
+	public partial class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
 	{
 		public MapOfLong foo = new MapOfLong();
         public virtual void Serialize(Beamable.Serialization.JsonSerializable.IStreamSerializer s)
@@ -388,7 +388,7 @@ namespace Test
 {
     
 	[System.SerializableAttribute()]
-	public class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
+	public partial class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
 	{
 		public OptionalLong foo = new OptionalLong();
         public virtual void Serialize(Beamable.Serialization.JsonSerializable.IStreamSerializer s)
@@ -437,7 +437,7 @@ namespace Test
 {
     
 	[System.SerializableAttribute()]
-	public class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
+	public partial class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
 	{
 		public OptionalLongArray foo = new OptionalLongArray();
         public virtual void Serialize(Beamable.Serialization.JsonSerializable.IStreamSerializer s)
@@ -488,7 +488,7 @@ namespace Test
 {
     
 	[System.SerializableAttribute()]
-	public class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
+	public partial class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
 	{
 		public OptionalMapOfLong foo = new OptionalMapOfLong();
         public virtual void Serialize(Beamable.Serialization.JsonSerializable.IStreamSerializer s)
@@ -543,7 +543,7 @@ namespace Test
 {
     
 	[System.SerializableAttribute()]
-	public class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
+	public partial class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
 	{
 		public OptionalMapOfLongArray foo = new OptionalMapOfLongArray();
         public virtual void Serialize(Beamable.Serialization.JsonSerializable.IStreamSerializer s)
@@ -597,7 +597,7 @@ namespace Test
 {
     
 	[System.SerializableAttribute()]
-	public class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
+	public partial class Tuna : Beamable.Serialization.JsonSerializable.ISerializable
 	{
 		public MapOfLongArray foo = new MapOfLongArray();
         public virtual void Serialize(Beamable.Serialization.JsonSerializable.IStreamSerializer s)


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3166

# Brief Description
There will be times when we'll need to add manual backwards compatibility or general capability to our model types-
But without them being `partial`, we can't extend the types. 
So; let's just make them partial, so that we can write our own extension versions of those types by hand later


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
