### PR TITLE
[BEAM-3156] Inline style prop source tracker null and property refreshing fixed

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/PropertySourceTracker.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/PropertySourceTracker.cs
@@ -10,7 +10,6 @@ namespace Beamable.UI.Buss
 		private readonly Dictionary<string, SourceData> _sources = new Dictionary<string, SourceData>();
 		public BussElement Element { get; }
 
-
 		public PropertySourceTracker(BussElement element)
 		{
 			Element = element;
@@ -66,7 +65,8 @@ namespace Beamable.UI.Buss
 			{
 				foreach (var reference in _sources[key].Properties)
 				{
-					if (reference.PropertyProvider.IsPropertyOfType(baseType) || reference.PropertyProvider.IsPropertyOfType(typeof(VariableProperty)))
+					if (reference.PropertyProvider.IsPropertyOfType(baseType) ||
+					    reference.PropertyProvider.IsPropertyOfType(typeof(VariableProperty)))
 					{
 						return reference.PropertyProvider;
 					}
@@ -87,7 +87,8 @@ namespace Beamable.UI.Buss
 			{
 				foreach (var reference in _sources[key].Properties)
 				{
-					if (reference.PropertyProvider.IsPropertyOfType(baseType) || reference.PropertyProvider.IsPropertyOfType(typeof(VariableProperty)))
+					if (reference.PropertyProvider.IsPropertyOfType(baseType) ||
+					    reference.PropertyProvider.IsPropertyOfType(typeof(VariableProperty)))
 					{
 						return reference;
 					}
@@ -117,14 +118,19 @@ namespace Beamable.UI.Buss
 			}
 		}
 
-		private void AddPropertySource(BussStyleSheet styleSheet, BussStyleRule styleRule, BussPropertyProvider propertyProvider)
+		private void AddPropertySource(BussStyleSheet styleSheet,
+		                               BussStyleRule styleRule,
+		                               BussPropertyProvider propertyProvider)
 		{
 			var key = propertyProvider.Key;
 
-			if (!styleRule.Selector.CheckMatch(Element))
+			if (styleRule != null)
 			{
-				// this is an inherited property, but maybe the property isn't inheritable?
-				if (!BussStyle.TryGetBinding(key, out var binding) || !binding.Inheritable) return;
+				if (!styleRule.Selector.CheckMatch(Element))
+				{
+					// this is an inherited property, but maybe the property isn't inheritable?
+					if (!BussStyle.TryGetBinding(key, out var binding) || !binding.Inheritable) return;
+				}
 			}
 
 			var propertyReference = new PropertyReference(key, styleSheet, styleRule, propertyProvider);
@@ -165,7 +171,8 @@ namespace Beamable.UI.Buss
 
 	public class PropertySourceDatabase
 	{
-		private readonly Dictionary<BussElement, PropertySourceTracker> _trackers = new Dictionary<BussElement, PropertySourceTracker>();
+		private readonly Dictionary<BussElement, PropertySourceTracker> _trackers =
+			new Dictionary<BussElement, PropertySourceTracker>();
 
 		public PropertySourceTracker GetTracker(BussElement bussElement)
 		{
@@ -190,6 +197,7 @@ namespace Beamable.UI.Buss
 					pair.Key.StyleRecalculated -= pair.Value.Recalculate;
 				}
 			}
+
 			_trackers.Clear();
 		}
 	}

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StylePropertyVisualElement/StylePropertyModel.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StylePropertyVisualElement/StylePropertyModel.cs
@@ -1,5 +1,6 @@
 ﻿using Beamable.Common;
 using Beamable.Editor.Common;
+using Beamable.Editor.UI.Validation;
 using Beamable.UI.Buss;
 using System;
 using System.Collections.Generic;
@@ -35,13 +36,13 @@ namespace Beamable.Editor.UI.Components
 			PropertyProvider != PropertySourceTracker.GetUsedPropertyProvider(PropertyProvider.Key);
 
 		public StylePropertyModel(BussStyleSheet styleSheet,
-								  BussStyleRule styleRule,
-								  BussPropertyProvider propertyProvider,
-								  VariableDatabase variablesDatabase,
-								  PropertySourceTracker propertySourceTracker,
-								  BussElement inlineStyleOwner,
-								  Action<string> removePropertyAction,
-								  Action globalRefresh)
+		                          BussStyleRule styleRule,
+		                          BussPropertyProvider propertyProvider,
+		                          VariableDatabase variablesDatabase,
+		                          PropertySourceTracker propertySourceTracker,
+		                          BussElement inlineStyleOwner,
+		                          Action<string> removePropertyAction,
+		                          Action globalRefresh)
 		{
 			_removePropertyAction = removePropertyAction;
 			_globalRefresh = globalRefresh;
@@ -56,7 +57,10 @@ namespace Beamable.Editor.UI.Components
 			{
 				VariableDatabase.PropertyReference reference =
 					PropertySourceTracker.GetUsedPropertyReference(PropertyProvider.Key);
-				Tooltip = $"Property is overriden by {reference.StyleRule.SelectorString} rule from {reference.StyleSheet.name} stylesheet";
+
+				Tooltip = reference.StyleRule != null
+					? $"Property is overriden by {reference.StyleRule.SelectorString} rule from {reference.StyleSheet.name} stylesheet"
+					: "Property is overriden by inline style";
 			}
 			else
 			{
@@ -67,7 +71,7 @@ namespace Beamable.Editor.UI.Components
 		public void GetResult(out IBussProperty bussProperty, out VariableDatabase.PropertyReference propertyReference)
 		{
 			VariablesDatabase.TryGetProperty(PropertyProvider, StyleRule, out IBussProperty property,
-											 out VariableDatabase.PropertyReference variableSource);
+			                                 out VariableDatabase.PropertyReference variableSource);
 
 			bussProperty = property;
 			propertyReference = variableSource;
@@ -204,7 +208,7 @@ namespace Beamable.Editor.UI.Components
 
 			if (InlineStyleOwner != null)
 			{
-				InlineStyleOwner.RecalculateStyle();
+				InlineStyleOwner.Reenable();
 			}
 		}
 	}

--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/BussElement.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/BussElement.cs
@@ -187,6 +187,12 @@ namespace Beamable.UI.Buss
 
 		#endregion
 
+		public void Reenable()
+		{
+			enabled = false;
+			enabled = true;
+		}
+
 		/// <summary>
 		/// Used when the parent or the style sheet is changed.
 		/// Recalculates the list of style sheets that are used for this BussElement and then recalculates BussStyle.


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3156

# Brief Description

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
