### PR TITLE
[BEAM-3159] Removed unecessary refresh

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/ThemeManager.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/ThemeManager.cs
@@ -9,10 +9,6 @@ namespace Beamable.Editor.UI.Buss
 	public class ThemeManager : BeamEditorWindow<ThemeManager>
 	{
 		private ThemeManagerBreadcrumbsVisualElement _breadcrumbs;
-		private BeamablePopupWindow _confirmationPopup;
-		private LabeledCheckboxVisualElement _filterToggle;
-		private LabeledCheckboxVisualElement _hideOverridenToggle;
-		private bool _inStyleSheetChangedLoop;
 		private ThemeManagerModel _model;
 		private NavigationVisualElement _navigationWindow;
 		private ScrollView _scrollView;
@@ -38,11 +34,6 @@ namespace Beamable.Editor.UI.Buss
 			_navigationWindow?.Destroy();
 			_selectedElement?.Destroy();
 			_model?.Clear();
-		}
-
-		private void OnFocus()
-		{
-			_model?.ForceRefresh();
 		}
 
 		[MenuItem(


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3159

# Brief Description
This callback was added in the early stage and probably it's not needed right now. After it has been removed also other parts of theme manager (for example quick clicking between elements in navigation window) seems to work smoother.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
