### PR TITLE
beam 3104 - recover from publish timeouts

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [Unreleased]
 ### Fixed
 - Fixed empty reply from server when publishing a Microservice (curl error 52).
+- Cancellation exceptions when publishing a Microservice (timeouts). 
 
 ### [1.5.1]
 ### Added

--- a/client/Packages/com.beamable.server/Editor/ReflectionCache/UserSystems/MicroserviceReflectionCache.cs
+++ b/client/Packages/com.beamable.server/Editor/ReflectionCache/UserSystems/MicroserviceReflectionCache.cs
@@ -458,20 +458,6 @@ namespace Beamable.Server.Editor
 					// Try to start the image and talk to it's healthcheck endpoint.
 					try
 					{
-						// We are now verifying the image we just built
-						UpdateServiceDeployStatus(descriptor, ServicePublishState.Verifying);
-
-						// Check to see if the storage descriptor is running.
-						var connectionStrings = await GetConnectionStringEnvironmentVariables((MicroserviceDescriptor)descriptor);
-
-						// Create a build that will build an image that doesn't run the custom initialization hooks
-						// Let's run it locally.
-						// At the moment we disable running custom hooks for this verification.
-						// This is because we cannot guarantee the user won't do anything in them to break this.
-						// TODO: Change algorithm to always have StorageObjects running locally during verification process.
-						// TODO: Allow users to enable running custom hooks on specific C#MSs instances --- this implies they'd know what they are doing.
-						var runServiceCommand = new RunServiceCommand(descriptor, de.CurrentCustomer.Cid, de.CurrentRealm.Pid, secret, connectionStrings, false, false);
-						runServiceCommand.Start();
 
 						async Promise<string> CheckHealthStatus()
 						{
@@ -480,17 +466,32 @@ namespace Beamable.Server.Editor
 
 							if (!dockerPortResult.ContainerExists)
 								return "false";
-							
+
 							var res = await de.ServiceScope.GetService<IEditorHttpRequester>()
 							                  .ManualRequest<string>(
-								                  Method.GET, $"http://{dockerPortResult.LocalFullAddress}/health", parser: x => x);
-							
+								                  Method.GET, $"http://{dockerPortResult.LocalFullAddress}/health",
+								                  parser: x => x);
 							return res;
 						}
 
 
 						if (MicroserviceConfiguration.Instance.EnablePrePublishHealthCheck)
 						{
+							// We are now verifying the image we just built
+							UpdateServiceDeployStatus(descriptor, ServicePublishState.Verifying);
+
+							// Check to see if the storage descriptor is running.
+							var connectionStrings = await GetConnectionStringEnvironmentVariables((MicroserviceDescriptor)descriptor);
+
+							// Create a build that will build an image that doesn't run the custom initialization hooks
+							// Let's run it locally.
+							// At the moment we disable running custom hooks for this verification.
+							// This is because we cannot guarantee the user won't do anything in them to break this.
+							// TODO: Change algorithm to always have StorageObjects running locally during verification process.
+							// TODO: Allow users to enable running custom hooks on specific C#MSs instances --- this implies they'd know what they are doing.
+							var runServiceCommand = new RunServiceCommand(descriptor, de.CurrentCustomer.Cid, de.CurrentRealm.Pid, secret, connectionStrings, false, false);
+							runServiceCommand.Start();
+
 							var healthcheckTimeout = MicroserviceConfiguration.Instance.PrePublishHealthCheckTimeout.GetOrElse(10);
 
 							// Wait until the container has completely booted up and it's Start function has finished.

--- a/client/Packages/com.beamable.server/Editor/Uploader/ContainerUploader.cs
+++ b/client/Packages/com.beamable.server/Editor/Uploader/ContainerUploader.cs
@@ -110,22 +110,85 @@ namespace Beamable.Server.Editor.Uploader
 			}
 
 			// Upload manifest JSON.
-			await UploadManifestJson(uploadManifest, _imageId);
+			await UploadManifestJson(uploadManifest, _imageId, token);
 		}
 
 		/// <summary>
 		/// Upload the manifest JSON to complete the Docker image push.
 		/// </summary>
 		/// <param name="uploadManifest">Data structure containing image data.</param>
-		private async Task UploadManifestJson(Dictionary<string, object> uploadManifest, string imageId)
+		private async Task UploadManifestJson(Dictionary<string, object> uploadManifest, string imageId, CancellationToken token)
 		{
 			var manifestJson = Json.Serialize(uploadManifest, new StringBuilder());
 			var uri = new Uri($"{_uploadBaseUri}/manifests/{imageId}");
-			var content = new StringContent(manifestJson, Encoding.Default, MediaManifest);
-			var response = await _client.PutAsync(uri, content);
+			var response = await SendPutRequest("uploading image manifest json", uri, () => new StringContent(manifestJson, Encoding.Default, MediaManifest), token);
 			response.EnsureSuccessStatusCode();
 			_harness.Log("image manifest uploaded");
 		}
+		
+		private async Task<HttpResponseMessage> SendRequestWithRetries(string name, Func<Task<HttpResponseMessage>> requestGenerator, CancellationToken cancellationToken, int maxAttempts = 500)
+		{
+			var attemptCount = 0;
+			var timeoutStatusCodes = new HttpStatusCode[]
+			{
+				HttpStatusCode.BadGateway, HttpStatusCode.GatewayTimeout, HttpStatusCode.GatewayTimeout
+			};
+			async Task<HttpResponseMessage> Attempt()
+			{
+				if (attemptCount++ >= maxAttempts)
+				{
+					throw new HttpRequestException("Request timed out, and exhausted all retries.");
+				}
+				cancellationToken.ThrowIfCancellationRequested();
+				try
+				{
+					var result = await requestGenerator();
+					if (timeoutStatusCodes.Contains(result.StatusCode))
+					{
+						// failed, try again :( 
+						Debug.LogWarning(
+							$"Request failed with bad status code, trying again... name=[{name}] attempt=[{attemptCount}] status=[{result.StatusCode}]");
+						return await Attempt();
+					}
+
+					return result;
+				}
+
+				catch (IOException io)
+				{
+					Debug.LogWarning($"Request failed out due to io, trying again... name=[{name}] attempt=[{attemptCount}] message=[{io.Message}]");
+					return await Attempt();
+				}
+				catch (HttpRequestException ex) when (ex.InnerException is IOException inner)
+				{
+					Debug.LogWarning($"Request failed out due to inner io, trying again... name=[{name}] attempt=[{attemptCount}] message=[{ex.Message}] inner=[{inner.Message}]");
+					return await Attempt();
+				}
+				catch (TaskCanceledException)
+				{
+					Debug.LogWarning($"Request timed out, trying again... name=[{name}] attempt=[{attemptCount}]");
+					return await Attempt();
+				}
+				catch (Exception ex)
+				{
+					Debug.Log("Unknown upload exception!!");
+					Debug.LogException(ex);
+					throw;
+				}
+			}
+
+			return await Attempt();
+		}
+
+
+		private async Task<HttpResponseMessage> SendRequest(string name,
+		                                                    Func<HttpRequestMessage> requestGenerator,
+		                                                    CancellationToken token) =>
+			await SendRequestWithRetries(name, () => _client.SendAsync(requestGenerator()), token);
+		private async Task<HttpResponseMessage> SendPutRequest(string name, Uri uri, Func<StringContent> contentGenerator, CancellationToken token) =>
+			await SendRequestWithRetries(name,() => _client.PutAsync(uri, contentGenerator()), token);
+		private async Task<HttpResponseMessage> SendPostRequest(string name, Uri uri, Func<StringContent> contentGenerator, CancellationToken token) =>
+			await SendRequestWithRetries(name,() => _client.PostAsync(uri, contentGenerator()), token);
 
 		/// <summary>
 		/// Upload one layer of a Docker image, adding its digest to the upload
@@ -156,7 +219,7 @@ namespace Beamable.Server.Editor.Uploader
 			using (var fileStream = File.OpenRead(filename))
 			{
 				var digest = HashDigest(fileStream);
-				if (await CheckBlobExistence(digest))
+				if (await CheckBlobExistence(digest, token))
 				{
 					return new FileBlobResult
 					{
@@ -165,7 +228,7 @@ namespace Beamable.Server.Editor.Uploader
 					};
 				}
 				fileStream.Position = 0;
-				var location = NormalizeWithDigest(await PrepareUploadLocation(), digest);
+				var location = NormalizeWithDigest(await PrepareUploadLocation(token), digest);
 				while (fileStream.Position < fileStream.Length)
 				{
 					token.ThrowIfCancellationRequested();
@@ -199,18 +262,33 @@ namespace Beamable.Server.Editor.Uploader
 		{
 			var uri = location;
 			var method = chunk.IsLast ? HttpMethod.Put : new HttpMethod("PATCH");
-			var request = new HttpRequestMessage(method, uri) { Content = new StreamContent(chunk.Stream) };
-			request.Content.Headers.ContentLength = chunk.Length;
-			request.Content.Headers.ContentRange = new ContentRangeHeaderValue(chunk.Start, chunk.End, chunk.FullLength);
-			var response = await _client.SendAsync(request, token);
+			var content = new StreamContent(chunk.Stream);
+			
+			HttpRequestMessage Generator()
+			{
+				var request = new HttpRequestMessage(method, uri) {Content = content};
+				request.Content.Headers.ContentLength = chunk.Length;
+				request.Content.Headers.ContentRange = new ContentRangeHeaderValue(chunk.Start, chunk.End, chunk.FullLength);
+				return request;
+			}
+
+			var response = await SendRequest("uploading chunk " + location, Generator, token);
 			try
 			{
 				response.EnsureSuccessStatusCode();
 			}
 			catch (HttpRequestException ex)
 			{
-				var body = await response.Content.ReadAsStringAsync();
-				Debug.LogError($"Failed to upload image chunk. message=[{ex.Message}] body=[{body}]");
+				try
+				{
+					var body = await response.Content.ReadAsStringAsync();
+					Debug.LogError($"Failed to upload image chunk. message=[{ex.Message}] body=[{body}]");
+				}
+				catch (ObjectDisposedException disposedException)
+				{
+					Debug.LogError($"Failed to upload image chunk. message=[{ex.Message} Cannot display body. {disposedException.Message}]");
+				}
+
 				throw ex;
 			}
 			return response;
@@ -221,11 +299,10 @@ namespace Beamable.Server.Editor.Uploader
 		/// </summary>
 		/// <param name="digest"></param>
 		/// <returns></returns>
-		private async Task<bool> CheckBlobExistence(string digest)
+		private async Task<bool> CheckBlobExistence(string digest, CancellationToken token)
 		{
 			var uri = new Uri($"{_uploadBaseUri}/blobs/{digest}");
-			var request = new HttpRequestMessage(HttpMethod.Head, uri);
-			var response = await _client.SendAsync(request);
+			var response = await SendRequest("checking blob existence " + digest, () => new HttpRequestMessage(HttpMethod.Head, uri), token);
 			return response.StatusCode == HttpStatusCode.OK;
 		}
 
@@ -234,10 +311,10 @@ namespace Beamable.Server.Editor.Uploader
 		/// upload path.
 		/// </summary>
 		/// <returns>The upload location URI.</returns>
-		private async Task<Uri> PrepareUploadLocation()
+		private async Task<Uri> PrepareUploadLocation(CancellationToken token)
 		{
 			var uri = new Uri($"{_uploadBaseUri}/blobs/uploads/");
-			var response = await _client.PostAsync(uri, new StringContent(""));
+			var response = await SendPostRequest("preparing upload location", uri, () => new StringContent(""), token);
 			try
 			{
 				response.EnsureSuccessStatusCode();

--- a/client/Packages/com.beamable/Editor/Environment/BeamableEditorWebRequester.cs
+++ b/client/Packages/com.beamable/Editor/Environment/BeamableEditorWebRequester.cs
@@ -5,58 +5,58 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Net.Http;
 using UnityEngine;
 
 public class BeamableEditorWebRequester : IEditorHttpRequester
 {
-	public Promise<T> ManualRequest<T>(Method method,
-	                                   string url,
-	                                   object body = null,
-	                                   Dictionary<string, string> headers = null,
-	                                   string contentType = "application/json",
-	                                   Func<string, T> parser = null)
+	public async Promise<T> ManualRequest<T>(Method method,
+	                                         string url,
+	                                         object body = null,
+	                                         Dictionary<string, string> headers = null,
+	                                         string contentType = "application/json",
+	                                         Func<string, T> parser = null)
 	{
 		if (body != null)
 			throw new NotImplementedException();
-		
-		var result = new Promise<T>();
-		var request = WebRequest.Create(url);
-		
+
+		var client = new HttpClient();
+		HttpMethod httpMethod;
+		switch (method)
+		{
+			case Method.DELETE:
+				httpMethod = HttpMethod.Delete;
+				break;
+			case Method.POST:
+				httpMethod = HttpMethod.Post;
+				break;
+			case Method.PUT:
+				httpMethod = HttpMethod.Put;
+				break;
+			default:
+			case Method.GET:
+				httpMethod = HttpMethod.Get;
+				break;
+		}
+
+		var clientRequest = new HttpRequestMessage(httpMethod, url);
 		if (headers != null)
 		{
 			var headerCollection = new WebHeaderCollection();
-			
+
 			foreach (var header in headers)
 			{
 				headerCollection.Add(header.Key, header.Value);
+				client.DefaultRequestHeaders.Add(header.Key, header.Value);
 			}
-			
-			request.Headers = headerCollection;
 		}
-		
-		var response = request.GetResponseAsync();
-		
-		response.ToPromise().Then(value =>
-		{
-			try
-			{
-				using (var streamReader = new StreamReader(value.GetResponseStream()))
-				{
-					var responsePayload = streamReader.ReadToEnd();
+		var httpResponse = await client.SendAsync(clientRequest);
+		var responsePayload = await httpResponse.Content.ReadAsStringAsync();
+		T parsedResult = parser == null
+			? JsonUtility.FromJson<T>(responsePayload)
+			: parser(responsePayload);
 
-					T parsedResult = parser == null
-						? JsonUtility.FromJson<T>(responsePayload)
-						: parser(responsePayload);
-
-					result.CompleteSuccess(parsedResult);
-				}
-			}
-			catch (Exception ex)
-			{
-				result.CompleteError(ex);
-			}
-		});
-		
-		return result;
+		return parsedResult;
 	}
+
 }


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3104

# Brief Description
We used to get these `TaskCancelled` exceptions every now and then when publishing microservices; as many people have recently learned (myself now included), _HTTP timeouts_ masquerade as task cancellations... 
![image](https://user-images.githubusercontent.com/3848374/197368583-e29b6937-10a8-4b00-a3a9-eb5b1b1a0b14.png)




So I added in some retry logic, and it works!

I also changed the editor web request to use `HttpClient` instead of `WebRequest`. It was throwing an error in poor network conditions as well.

I tested this with the network link degradation tool.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
