### PR TITLE
beam 3171 - add throw statements if swagger document has errors or warnings

### DIFF
--- a/cli/cli/Services/SwaggerService.cs
+++ b/cli/cli/Services/SwaggerService.cs
@@ -1,6 +1,7 @@
 using Beamable.Common;
 using cli.Utils;
 using Microsoft.OpenApi;
+using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers;
@@ -293,12 +294,14 @@ public class SwaggerService
 					{
 						Log.Warning("found warning for {url}. {message} . from {pointer}", url, warning.Message,
 							warning.Pointer);
+						throw new OpenApiException($"invalid document {url} - {warning.Message} - {warning.Pointer}");
 					}
 
 					foreach (var error in res.Diagnostic.Errors)
 					{
 						Log.Error("found ERROR for {url}. {message} . from {pointer}", url, error.Message,
 							error.Pointer);
+						throw new OpenApiException($"invalid document {url} - {error.Message} - {error.Pointer}");
 					}
 
 					res.Descriptor = api;


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3171

# Brief Description
I think this has something to do with a bad network call or something, but somehow when the autogen runs, _sometimes_ it finds a `MailBasicBulkSendRequest`, and sometimes it finds a `BulkSendRequest`. We should always be getting the second one.

Not totally sure whats going on, because when I run it locally against dev, I always get the correct answer. Indeed, I noticed that eventually the auto-generated Pr was closed, because the result returned to normal :/ 

So I'm adding a bit more rigidity to the download section, I want errors or warnings to break the build.

# Checklist
* [] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
