### PR TITLE
beam 3239 - prefab edit mode

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussPropertyVisualElements/TextAlignmentBussPropertyVisualElement/TextAlignmentBussPropertyVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/BussPropertyVisualElements/TextAlignmentBussPropertyVisualElement/TextAlignmentBussPropertyVisualElement.cs
@@ -67,6 +67,7 @@ namespace Beamable.Editor.UI.Components
 			var intValue = (int)Property.Enum;
 			Property.Enum = (TextAlignmentOptions)GetValue(value, GetVerticalAlignmentGridValue(intValue));
 			UpdateHorizontalToggle();
+			OnValueChanged?.Invoke(Property);
 		}
 
 		private void SetVerticalValue(int value)
@@ -75,6 +76,7 @@ namespace Beamable.Editor.UI.Components
 			var intValue = (int)Property.Enum;
 			Property.Enum = (TextAlignmentOptions)GetValue(GetHorizontalAlignmentGridValue(intValue), value);
 			UpdateVerticalToggle();
+			OnValueChanged?.Invoke(Property);
 		}
 
 		private void UpdateHorizontalToggle()

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/ThemeManagerModel.cs
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/ThemeManagerModel.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
+using UnityEditor.SceneManagement;
 using UnityEngine;
 using static Beamable.Common.Constants.Features.Buss.ThemeManager;
 using Object = UnityEngine.Object;
@@ -243,15 +244,24 @@ namespace Beamable.Editor.UI.Buss
 		{
 			FoundElements.Clear();
 
-			foreach (Object foundObject in Object.FindObjectsOfType(typeof(GameObject)))
+			var currentPrefab = PrefabStageUtility.GetCurrentPrefabStage();
+
+			if (currentPrefab == null)
 			{
-				GameObject gameObject = (GameObject)foundObject;
-				if (gameObject.transform.parent == null)
+				foreach (Object foundObject in Object.FindObjectsOfType(typeof(GameObject)))
 				{
-					Traverse(gameObject, 0);
+					GameObject gameObject = (GameObject)foundObject;
+					if (gameObject.transform.parent == null)
+					{
+						Traverse(gameObject, 0);
+					}
 				}
 			}
-
+			else
+			{
+				Traverse(currentPrefab.prefabContentsRoot, 0);
+			}
+			
 			ForceRefresh();
 		}
 

--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/Styles/BUSSStyle_PropertyBinders.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/Styles/BUSSStyle_PropertyBinders.cs
@@ -49,7 +49,7 @@ namespace Beamable.UI.Buss
 
 		// Background
 		public static readonly PropertyBinding<IVertexColorBussProperty> BackgroundColor =
-			new PropertyBinding<IVertexColorBussProperty>("backgroundColor", new SingleColorBussProperty(Color.white));
+			new PropertyBinding<IVertexColorBussProperty>("backgroundColor", new SingleColorBussProperty(Color.clear));
 
 		public static readonly PropertyBinding<IFloatFromFloatBussProperty> RoundCorners =
 			new PropertyBinding<IFloatFromFloatBussProperty>("roundCorners", new FloatBussProperty());


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3239

# Brief Description
Now, if you enter a prefab, the Theme Manager will show the gameobjects relative to the prefab, not the scene. 

![image](https://user-images.githubusercontent.com/3848374/199298502-083af7a3-f0c1-44d5-b744-5b01c10f3695.png)

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
