### PR TITLE
[BEAM-3142] GroupsService.CheckAvailable should not hang when called from C#MS

### DIFF
--- a/client/Packages/com.beamable/Common/Runtime/Api/Groups/GroupsApi.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/Groups/GroupsApi.cs
@@ -129,11 +129,11 @@ namespace Beamable.Common.Api.Groups
 		public Promise<AvailabilityResponse> CheckAvailability(string name, string tag)
 		{
 			string query = "";
-			if (name != null)
+			if (!string.IsNullOrEmpty(name))
 			{
 				query += "name=" + name;
 			}
-			if (tag != null)
+			if (!string.IsNullOrEmpty(tag))
 			{
 				if (name != null) { query += "&"; }
 				query += "tag=" + tag;


### PR DESCRIPTION
# Brief Description
To fix problem with check available group name request from MS we need to handle both situations for null and empty string.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
