### PR TITLE
beam 3246 - keep default content behaviour

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -6,11 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Local content mode
+- Local content mode 
 - Added `OnLeft`,`OnPromoted` and `OnKicked` event support in `PartyMember` class.
-
-### Changed
-- By default, content will be put into local mode. Remote content can be configured by disabling the _Project Setting/Beamable/Content/Enable Local Content In Editor_  option.
 
 ### Fixed
 - `NotificationService.Unsubscribe<T>` now correctly unsubscribes from events.

--- a/client/Packages/com.beamable/Runtime/Modules/Content/ContentConfiguration.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/Content/ContentConfiguration.cs
@@ -31,7 +31,7 @@ namespace Beamable.Content
 #endif
 
 		[Tooltip("When enabled, any content requests for the editor manifest will be resolved using your on-disk Scriptable Object content items, and any content from another manifest will be fetched from the remote realm. When disabled, all content is fetched from the remote realm.")]
-		public bool EnableLocalContentInEditor = true;
+		public bool EnableLocalContentInEditor = false;
 
 		[Tooltip("When using Local Content Mode In Editor, simulate how long each content reference will take to fetch.")]
 		public OptionalFloat LocalContentReferenceDelaySeconds;


### PR DESCRIPTION
Need to flip the content behaviour back to normal before shipping 1.7, because remote based content is odd.