### PR TITLE
task allocation in content download

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Downloading content allocates less memory due to avoid async/await `Task` allocation.
+
 ## [1.9.0]
 ### Added
 - `Context.ThrowIfCancelled()` method to force end a client-callable request if it has timed out.

--- a/microservice/microservice/dbmicroservice/IContentResolver.cs
+++ b/microservice/microservice/dbmicroservice/IContentResolver.cs
@@ -20,10 +20,9 @@ namespace Beamable.Server
 		   client = new HttpClient();
 	   }
 
-	   public async Task<string> RequestContent(string uri)
+	   public Task<string> RequestContent(string uri)
 	   {
-		   var result = await client.GetStringAsync(uri);
-		   return result;
+		   return client.GetStringAsync(uri);
 	   }
    }
 }


### PR DESCRIPTION
# Ticket
--

# Brief Description
I don't think this is a big deal, but in cases where customers have a lot of content, it _could_ result in an early need for garbage collection for Microservices. So this is about microservice startup performance I suppose.
In the resolve content method, we were doing `async/await` on a very simple task that doesn't need it. By doing so, we are allocating extra `Task` instances that don't need to be allocated.

I didn't see any noticeable speed improvement here, but I do think this is technically an improvement, and what the hay, right?

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
