### PR TITLE
beam 3337- fix autogenerated sdk for sub fields

### DIFF
--- a/cli/cli/Services/UnitySourceGenerator.cs
+++ b/cli/cli/Services/UnitySourceGenerator.cs
@@ -1004,7 +1004,7 @@ public static class UnityHelper
 		field.Attributes = MemberAttributes.Public;
 
 		// the init expression is only required when its an object of some sort...
-		if (!isRequired || schema.Type == "object")
+		if (!isRequired || schema.Type == "object" || schema.Reference != null)
 		{
 			field.InitExpression = new CodeObjectCreateExpression(field.Type);
 		}
@@ -1196,8 +1196,10 @@ public static class UnityHelper
 				return true;
 			default:
 				// we just cannot support the serialization of unspecified object types, so don't serialize.
-				if (string.IsNullOrEmpty(schema.Type) || schema.Type == "object") return false;
-
+				var isTypeEmptyOrObject = string.IsNullOrEmpty(schema.Type) || schema.Type == "object";
+				var hasReference = schema.Reference != null;
+				
+				if (isTypeEmptyOrObject && !hasReference) return false;
 
 				// use the default serialize method.
 				methodExpr = new CodeMethodReferenceExpression(new CodeArgumentReferenceExpression(PARAM_SERIALIZER),


### PR DESCRIPTION

# Brief Description
The issue was that we hadn't seen a schema yet that only had a reference listed in a sub prop.
So take this section of openAPI spec,

```yml
    RealmConfiguration:
      properties:
        websocketConfig:
          $ref: '#/components/schemas/WebSocketConfiguration'
```

That `websocketConfig` property wasn't getting recognized as anything other than `object`, which means that it wouldn't get serialized.

But now, we just need to allow that a sub prop may not specify a `type`, and thats _fine_. 

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
