### PR TITLE
change ws err to debug

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Internal dependency-injection system uses `IDependencyBuilder` and `IDependencyProvider`. 
+- Websocket connection recovery log level changed from Error to Debug.
 
 ### Fixed
 - Custom `[InitializeService]` and `[ConfigureServices]` callbacks no longer run for each connection.

--- a/microservice/microservice/dbmicroservice/EasyWebSocket.cs
+++ b/microservice/microservice/dbmicroservice/EasyWebSocket.cs
@@ -362,7 +362,7 @@ namespace Beamable.Server
 
             catch (Exception ex)
             {
-	            Log.Error($"Websocket error=[{ex.GetType().FullName}] message=[{ex.Message}] stack=[{ex.StackTrace}]");
+	            Log.Debug($"Websocket error=[{ex.GetType().FullName}] message=[{ex.Message}] stack=[{ex.StackTrace}]");
 	            CallOnDisconnected(false);
 
             }


### PR DESCRIPTION

# Brief Description

In SDK 1.7, I added a log output when the WS gets an error and goes into reconnection mode. Its been confusing people because its marked as ERROR, but really, this is an expected process, so I'm moving the log level to DEBUG.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
