### PR TITLE
beam 3346 - skip null content

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.1]
+no changes
+
 ## [1.10.0]
 ### Added
 - `[InitializeService]` exposes `IDependencyProvider` as `Provider`, and `[ConfigureServices]` exposes `IDependencyBuilder` as `Builder`

--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.1]
+### Fixed
+- possible `NullReferenceException` during Content Manager initialization
+
 ## [1.10.0]
 ### Added
 - Player Account PSDK

--- a/client/Packages/com.beamable/Editor/Modules/Content/ContentIO.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/ContentIO.cs
@@ -536,6 +536,8 @@ namespace Beamable.Editor.Content
 			foreach (var entry in ContentDatabase.GetAllContent())
 			{
 				var content = AssetDatabase.LoadAssetAtPath<ContentObject>(entry.assetPath);
+				if (!content || content == null) continue;
+
 				content.SetIdAndVersion(entry.contentId, "");
 
 				var manifestEntry = new LocalContentManifestEntry


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3346

# Brief Description
Russell and PN found a null reference bug when updating from 1.9.1 to 1.10; because the local manifest was returning nulls from the `AssetDatabase` load function-
This can happen sometimes, and there isn't really a way to fix it except, "wait and try again later". Fortunately, this error is rare, and if it happens, the user would just need to refresh CMV2. 

So all I did was to add a skip for content that fails to load.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
