### PR TITLE
[BEAM-3347] Added support for Unreal semantic type code gen

### DIFF
--- a/cli/cli/Services/UnrealSourceGenerator/Declarations/UnrealPropertyDeclaration.cs
+++ b/cli/cli/Services/UnrealSourceGenerator/Declarations/UnrealPropertyDeclaration.cs
@@ -10,17 +10,23 @@ public struct UnrealPropertyDeclaration
 	public string PropertyName;
 	public string PropertyDisplayName;
 
-	public string FirstTemplateParameter;
-
 	/// <summary>
-	/// Used for and optionals.
+	/// This is the type the optional wraps around. 
 	/// </summary>
 	public string NonOptionalTypeName;
 
 	/// <summary>
-	/// Used for and optionals.
+	/// For optional arrays and maps, the (de)serialization code output needs to know what the type of the array/map is. This holds that variable.
+	/// If said type is a Semantic Type, <see cref="SemTypeSerializationType"/> will contain the (de)serialization type for each element of the array. 
 	/// </summary>
 	public string NonOptionalTypeNameRelevantTemplateParam;
+
+	/// <summary>
+	/// If this property represents a Semantic Type (<see cref="UnrealSourceGenerator.UNREAL_ALL_SEMTYPES"/>), this contains the underlying primitive type that we expect to receive.
+	/// For example, <see cref="UnrealSourceGenerator.UNREAL_U_SEMTYPE_CID"/> can be either a '<see cref="UnrealSourceGenerator.UNREAL_STRING"/>' or a '<see cref="UnrealSourceGenerator.UNREAL_LONG"/>'
+	/// for (de)serialization purposes. In each declaration, this variable would hold either of those values so that we can appropriately call the serialize functions.
+	/// </summary>
+	public string SemTypeSerializationType;
 
 
 	public string BriefCommentString;
@@ -35,6 +41,7 @@ public struct UnrealPropertyDeclaration
 		helperDict.Add(nameof(NonOptionalTypeName), NonOptionalTypeName);
 		helperDict.Add(nameof(NonOptionalTypeNameRelevantTemplateParam), NonOptionalTypeNameRelevantTemplateParam);
 		helperDict.Add(nameof(BriefCommentString), BriefCommentString);
+		helperDict.Add(nameof(SemTypeSerializationType), SemTypeSerializationType);
 	}
 
 	public const string U_PROPERTY_DECLARATION =
@@ -55,8 +62,11 @@ public struct UnrealPropertyDeclaration
 	public const string DOUBLE_U_PROPERTY_DESERIALIZE = $@"₢{nameof(PropertyName)}₢ = Bag->GetNumberField(TEXT(""₢{nameof(RawFieldName)}₢""));";
 	public const string GUID_U_PROPERTY_DESERIALIZE = $@"FGuid::Parse(Bag->GetStringField(TEXT(""₢{nameof(RawFieldName)}₢"")), ₢{nameof(PropertyName)}₢);";
 
-	public const string U_ENUM_U_PROPERTY_SERIALIZE = $@"Serializer->WriteValue(TEXT(""₢{nameof(RawFieldName)}₢""), U₢{nameof(PropertyNamespacedType)}₢Library::₢{nameof(PropertyNamespacedType)}₢ToSerializationName(₢{nameof(PropertyName)}₢));";
-	public const string U_ENUM_U_PROPERTY_DESERIALIZE = $@"₢{nameof(PropertyName)}₢ = U₢{nameof(PropertyNamespacedType)}₢Library::SerializationNameTo₢{nameof(PropertyNamespacedType)}₢(Bag->GetStringField(TEXT(""₢{nameof(RawFieldName)}₢"")));";
+	public const string U_ENUM_U_PROPERTY_SERIALIZE =
+		$@"Serializer->WriteValue(TEXT(""₢{nameof(RawFieldName)}₢""), U₢{nameof(PropertyNamespacedType)}₢Library::₢{nameof(PropertyNamespacedType)}₢ToSerializationName(₢{nameof(PropertyName)}₢));";
+
+	public const string U_ENUM_U_PROPERTY_DESERIALIZE =
+		$@"₢{nameof(PropertyName)}₢ = U₢{nameof(PropertyNamespacedType)}₢Library::SerializationNameTo₢{nameof(PropertyNamespacedType)}₢(Bag->GetStringField(TEXT(""₢{nameof(RawFieldName)}₢"")));";
 
 	public const string U_OBJECT_U_PROPERTY_SERIALIZE =
 		$@"UBeamJsonUtils::SerializeUObject<₢{nameof(PropertyUnrealType)}₢>(""₢{nameof(RawFieldName)}₢"", ₢{nameof(PropertyName)}₢, Serializer);";
@@ -69,24 +79,54 @@ public struct UnrealPropertyDeclaration
 
 	public const string ARRAY_U_PROPERTY_DESERIALIZE =
 		$@"UBeamJsonUtils::DeserializeArray<₢{nameof(NonOptionalTypeNameRelevantTemplateParam)}₢>(Bag->GetArrayField(TEXT(""₢{nameof(RawFieldName)}₢"")), ₢{nameof(PropertyName)}₢, OuterOwner);";
+	
+	public const string ARRAY_SEMTYPE_U_PROPERTY_SERIALIZE =
+		$@"UBeamJsonUtils::SerializeArray<₢{nameof(NonOptionalTypeNameRelevantTemplateParam)}₢, ₢{nameof(SemTypeSerializationType)}₢>(TEXT(""₢{nameof(RawFieldName)}₢""), ₢{nameof(PropertyName)}₢, Serializer);";
+
+	public const string ARRAY_SEMTYPE_U_PROPERTY_DESERIALIZE =
+		$@"UBeamJsonUtils::DeserializeArray<₢{nameof(NonOptionalTypeNameRelevantTemplateParam)}₢, ₢{nameof(SemTypeSerializationType)}₢>(Bag->GetArrayField(TEXT(""₢{nameof(RawFieldName)}₢"")), ₢{nameof(PropertyName)}₢, OuterOwner);";
 
 	public const string MAP_U_PROPERTY_SERIALIZE =
 		$@"UBeamJsonUtils::SerializeMap<₢{nameof(NonOptionalTypeNameRelevantTemplateParam)}₢>(TEXT(""₢{nameof(RawFieldName)}₢""), ₢{nameof(PropertyName)}₢, Serializer);";
 
 	public const string MAP_U_PROPERTY_DESERIALIZE =
 		$@"UBeamJsonUtils::DeserializeMap<₢{nameof(NonOptionalTypeNameRelevantTemplateParam)}₢>(Bag->GetObjectField(TEXT(""₢{nameof(RawFieldName)}₢"")), ₢{nameof(PropertyName)}₢, OuterOwner);";
+	
+	public const string MAP_SEMTYPE_U_PROPERTY_SERIALIZE =
+		$@"UBeamJsonUtils::SerializeMap<₢{nameof(NonOptionalTypeNameRelevantTemplateParam)}₢, ₢{nameof(SemTypeSerializationType)}₢>(TEXT(""₢{nameof(RawFieldName)}₢""), ₢{nameof(PropertyName)}₢, Serializer);";
 
+	public const string MAP_SEMTYPE_U_PROPERTY_DESERIALIZE =
+		$@"UBeamJsonUtils::DeserializeMap<₢{nameof(NonOptionalTypeNameRelevantTemplateParam)}₢, ₢{nameof(SemTypeSerializationType)}₢>(Bag->GetObjectField(TEXT(""₢{nameof(RawFieldName)}₢"")), ₢{nameof(PropertyName)}₢, OuterOwner);";
+
+	public const string SEMTYPE_U_PROPERTY_SERIALIZE =
+		$@"UBeamJsonUtils::SerializeSemanticType<₢{nameof(SemTypeSerializationType)}₢>(TEXT(""₢{nameof(RawFieldName)}₢""), &₢{nameof(PropertyName)}₢, Serializer);";
+
+	public const string SEMTYPE_U_PROPERTY_DESERIALIZE =
+		$@"UBeamJsonUtils::DeserializeSemanticType<₢{nameof(SemTypeSerializationType)}₢>(Bag->TryGetField(TEXT(""₢{nameof(RawFieldName)}₢"")), ₢{nameof(PropertyName)}₢, OuterOwner);";
+	
 	public const string OPTIONAL_U_PROPERTY_SERIALIZE =
 		$@"UBeamJsonUtils::SerializeOptional<₢{nameof(NonOptionalTypeName)}₢>(TEXT(""₢{nameof(RawFieldName)}₢""), &₢{nameof(PropertyName)}₢, Serializer);";
 
 	public const string OPTIONAL_U_PROPERTY_DESERIALIZE =
 		$@"UBeamJsonUtils::DeserializeOptional<₢{nameof(NonOptionalTypeName)}₢>(""₢{nameof(RawFieldName)}₢"", Bag, ₢{nameof(PropertyName)}₢, OuterOwner);";
+	
+	public const string OPTIONAL_SEMTYPE_U_PROPERTY_SERIALIZE =
+		$@"UBeamJsonUtils::SerializeOptional<₢{nameof(NonOptionalTypeName)}₢, ₢{nameof(SemTypeSerializationType)}₢>(TEXT(""₢{nameof(RawFieldName)}₢""), &₢{nameof(PropertyName)}₢, Serializer);";
+
+	public const string OPTIONAL_SEMTYPE_U_PROPERTY_DESERIALIZE =
+		$@"UBeamJsonUtils::DeserializeOptional<₢{nameof(NonOptionalTypeName)}₢, ₢{nameof(SemTypeSerializationType)}₢>(""₢{nameof(RawFieldName)}₢"", Bag, ₢{nameof(PropertyName)}₢, OuterOwner);";
 
 	public const string OPTIONAL_WRAPPER_U_PROPERTY_SERIALIZE =
 		$@"UBeamJsonUtils::SerializeOptional<₢{nameof(NonOptionalTypeName)}₢, ₢{nameof(NonOptionalTypeNameRelevantTemplateParam)}₢>(TEXT(""₢{nameof(RawFieldName)}₢""), &₢{nameof(PropertyName)}₢, Serializer);";
 
 	public const string OPTIONAL_WRAPPER_U_PROPERTY_DESERIALIZE =
 		$@"UBeamJsonUtils::DeserializeOptional<₢{nameof(NonOptionalTypeName)}₢, ₢{nameof(NonOptionalTypeNameRelevantTemplateParam)}₢>(""₢{nameof(RawFieldName)}₢"", Bag, ₢{nameof(PropertyName)}₢, OuterOwner);";
+	
+	public const string OPTIONAL_WRAPPER_SEMTYPE_U_PROPERTY_SERIALIZE =
+		$@"UBeamJsonUtils::SerializeOptional<₢{nameof(NonOptionalTypeName)}₢, ₢{nameof(NonOptionalTypeNameRelevantTemplateParam)}₢, ₢{nameof(SemTypeSerializationType)}₢>(TEXT(""₢{nameof(RawFieldName)}₢""), &₢{nameof(PropertyName)}₢, Serializer);";
+
+	public const string OPTIONAL_WRAPPER_SEMTYPE_U_PROPERTY_DESERIALIZE =
+		$@"UBeamJsonUtils::DeserializeOptional<₢{nameof(NonOptionalTypeName)}₢, ₢{nameof(NonOptionalTypeNameRelevantTemplateParam)}₢, ₢{nameof(SemTypeSerializationType)}₢>(""₢{nameof(RawFieldName)}₢"", Bag, ₢{nameof(PropertyName)}₢, OuterOwner);";
 
 	public static string ExtractFirstTemplateParamFromType(string unrealType)
 	{
@@ -116,44 +156,56 @@ public struct UnrealPropertyDeclaration
 		return unrealType.AsSpan(startIdx, endIdx - startIdx).ToString().Trim();
 	}
 
-	public static string GetSerializeTemplateForUnrealType(string unrealType)
+	public string GetSerializeTemplateForUnrealType(string unrealType)
 	{
 		if (unrealType.StartsWith(UnrealSourceGenerator.UNREAL_OPTIONAL))
 		{
+			var isSemType = UnrealSourceGenerator.UNREAL_ALL_SEMTYPES_NAMESPACED_NAMES.Any(unrealType.Contains);
 			if (unrealType.StartsWith(UnrealSourceGenerator.UNREAL_OPTIONAL_MAP) || unrealType.StartsWith(UnrealSourceGenerator.UNREAL_OPTIONAL_ARRAY))
-				return OPTIONAL_WRAPPER_U_PROPERTY_SERIALIZE;
+				return isSemType ? OPTIONAL_WRAPPER_SEMTYPE_U_PROPERTY_SERIALIZE : OPTIONAL_WRAPPER_U_PROPERTY_SERIALIZE;
 
-			return OPTIONAL_U_PROPERTY_SERIALIZE;
+			return isSemType ? OPTIONAL_SEMTYPE_U_PROPERTY_SERIALIZE : OPTIONAL_U_PROPERTY_SERIALIZE;
 		}
 
 		if (unrealType.StartsWith(UnrealSourceGenerator.UNREAL_U_ENUM_PREFIX))
 			return U_ENUM_U_PROPERTY_SERIALIZE;
 
 		if (unrealType.StartsWith(UnrealSourceGenerator.UNREAL_MAP))
-			return MAP_U_PROPERTY_SERIALIZE;
+		{
+			var isSemType = UnrealSourceGenerator.UNREAL_ALL_SEMTYPES_NAMESPACED_NAMES.Any(unrealType.Contains);
+			return isSemType ? MAP_SEMTYPE_U_PROPERTY_SERIALIZE : MAP_U_PROPERTY_SERIALIZE;
+		}
 
 		if (unrealType.StartsWith(UnrealSourceGenerator.UNREAL_ARRAY))
-			return ARRAY_U_PROPERTY_SERIALIZE;
+		{
+			var isSemType = UnrealSourceGenerator.UNREAL_ALL_SEMTYPES_NAMESPACED_NAMES.Any(unrealType.Contains);
+			return isSemType ? ARRAY_SEMTYPE_U_PROPERTY_SERIALIZE : ARRAY_U_PROPERTY_SERIALIZE;
+		}
 
 		if (unrealType.StartsWith(UnrealSourceGenerator.UNREAL_GUID))
 			return GUID_U_PROPERTY_SERIALIZE;
 
+		// Semantic types serialization
+		if (UnrealSourceGenerator.UNREAL_ALL_SEMTYPES.Contains(unrealType))
+			return SEMTYPE_U_PROPERTY_SERIALIZE;
+		
 		if (unrealType.StartsWith(UnrealSourceGenerator.UNREAL_U_OBJECT_PREFIX))
 			return U_OBJECT_U_PROPERTY_SERIALIZE;
 
 		return PRIMITIVE_U_PROPERTY_SERIALIZE;
 	}
 
-	public static string GetDeserializeTemplateForUnrealType(string unrealType)
+	public string GetDeserializeTemplateForUnrealType(string unrealType)
 	{
 		if (unrealType.StartsWith(UnrealSourceGenerator.UNREAL_OPTIONAL))
 		{
+			var isSemType = UnrealSourceGenerator.UNREAL_ALL_SEMTYPES_NAMESPACED_NAMES.Any(unrealType.EndsWith);
 			if (unrealType.StartsWith(UnrealSourceGenerator.UNREAL_OPTIONAL_MAP) || unrealType.StartsWith(UnrealSourceGenerator.UNREAL_OPTIONAL_ARRAY))
 			{
-				return OPTIONAL_WRAPPER_U_PROPERTY_DESERIALIZE;
+				return isSemType ? OPTIONAL_WRAPPER_SEMTYPE_U_PROPERTY_DESERIALIZE : OPTIONAL_WRAPPER_U_PROPERTY_DESERIALIZE;
 			}
 
-			return OPTIONAL_U_PROPERTY_DESERIALIZE;
+			return isSemType ? OPTIONAL_SEMTYPE_U_PROPERTY_DESERIALIZE : OPTIONAL_U_PROPERTY_DESERIALIZE;
 		}
 
 		if (unrealType.StartsWith(UnrealSourceGenerator.UNREAL_U_ENUM_PREFIX))
@@ -163,10 +215,16 @@ public struct UnrealPropertyDeclaration
 			return U_OBJECT_U_PROPERTY_DESERIALIZE;
 
 		if (unrealType.StartsWith(UnrealSourceGenerator.UNREAL_MAP))
-			return MAP_U_PROPERTY_DESERIALIZE;
+		{
+			var isSemType = UnrealSourceGenerator.UNREAL_ALL_SEMTYPES_NAMESPACED_NAMES.Any(unrealType.Contains);
+			return isSemType ? MAP_SEMTYPE_U_PROPERTY_DESERIALIZE : MAP_U_PROPERTY_DESERIALIZE;
+		}
 
 		if (unrealType.StartsWith(UnrealSourceGenerator.UNREAL_ARRAY))
-			return ARRAY_U_PROPERTY_DESERIALIZE;
+		{
+			var isSemType = UnrealSourceGenerator.UNREAL_ALL_SEMTYPES_NAMESPACED_NAMES.Any(unrealType.Contains);
+			return isSemType ? ARRAY_SEMTYPE_U_PROPERTY_DESERIALIZE : ARRAY_U_PROPERTY_DESERIALIZE;
+		}
 
 		if (unrealType.StartsWith(UnrealSourceGenerator.UNREAL_STRING))
 			return STRING_U_PROPERTY_DESERIALIZE;
@@ -197,6 +255,10 @@ public struct UnrealPropertyDeclaration
 
 		if (unrealType.StartsWith(UnrealSourceGenerator.UNREAL_GUID))
 			return GUID_U_PROPERTY_DESERIALIZE;
+		
+		// Semantic types serialization
+		if (UnrealSourceGenerator.UNREAL_ALL_SEMTYPES.Contains(unrealType))
+			return SEMTYPE_U_PROPERTY_DESERIALIZE;
 
 		return STRING_U_PROPERTY_DESERIALIZE;
 	}

--- a/cli/cli/Services/UnrealSourceGenerator/Declarations/UnrealSerializableTypeDeclaration.cs
+++ b/cli/cli/Services/UnrealSourceGenerator/Declarations/UnrealSerializableTypeDeclaration.cs
@@ -77,7 +77,7 @@ public struct UnrealSerializableTypeDeclaration
 		{
 			ud.IntoProcessMap(processDictionary);
 
-			var decl = UnrealPropertyDeclaration.GetSerializeTemplateForUnrealType(ud.PropertyUnrealType).ProcessReplacement(processDictionary);
+			var decl = ud.GetSerializeTemplateForUnrealType(ud.PropertyUnrealType).ProcessReplacement(processDictionary);
 			processDictionary.Clear();
 			return decl;
 		}));
@@ -86,7 +86,7 @@ public struct UnrealSerializableTypeDeclaration
 		{
 			ud.IntoProcessMap(processDictionary);
 
-			var decl = UnrealPropertyDeclaration.GetDeserializeTemplateForUnrealType(ud.PropertyUnrealType).ProcessReplacement(processDictionary);
+			var decl = ud.GetDeserializeTemplateForUnrealType(ud.PropertyUnrealType).ProcessReplacement(processDictionary);
 			processDictionary.Clear();
 			return decl;
 		}));
@@ -143,7 +143,7 @@ void U{NamespacedTypeName}::DeserializeRequestResponse(UObject* RequestData, FSt
 		processDictionary.Add(nameof(_inheritResponseBodyInterface), _inheritResponseBodyInterface);
 		processDictionary.Add(nameof(_declareResponseBodyInterface), _declareResponseBodyInterface);
 		processDictionary.Add(nameof(_defineResponseBodyInterface), _defineResponseBodyInterface);
-
+		
 
 		processDictionary.Add(nameof(_uPropertySerialize), propertySerialization);
 		processDictionary.Add(nameof(_uPropertyDeserialize), propertyDeserialization);

--- a/cli/cli/Services/UnrealSourceGenerator/UnrealApiSubsystemDeclaration.cs
+++ b/cli/cli/Services/UnrealSourceGenerator/UnrealApiSubsystemDeclaration.cs
@@ -81,22 +81,6 @@ public struct UnrealApiSubsystemDeclaration
 			return ufunctionDeclaration;
 		}));
 
-		var ufunctionsWithRetry = string.Join("\n\t\t", EndpointUFunctionDeclarations.Select(d =>
-		{
-			d.IntoProcessMap(helperDict);
-			var ufunction = UnrealEndpointDeclaration.U_FUNCTION_WITH_RETRY_DECLARATION.ProcessReplacement(helperDict);
-			helperDict.Clear();
-			return ufunction;
-		}));
-
-		var authUfunctionsWithRetry = string.Join("\n\t\t", AuthenticatedEndpointUFunctionDeclarations.Select(d =>
-		{
-			d.IntoProcessMap(helperDict);
-			var ufunction = UnrealEndpointDeclaration.U_FUNCTION_WITH_RETRY_AUTH_DECLARATION.ProcessReplacement(helperDict);
-			helperDict.Clear();
-			return ufunction;
-		}));
-
 
 		helperDict.Add(nameof(SubsystemName), SubsystemName);
 
@@ -110,9 +94,6 @@ public struct UnrealApiSubsystemDeclaration
 
 		helperDict.Add(nameof(EndpointUFunctionDeclarations), ufunctions);
 		helperDict.Add(nameof(AuthenticatedEndpointUFunctionDeclarations), authUFunctions);
-
-		helperDict.Add(nameof(EndpointUFunctionWithRetryDeclarations), ufunctionsWithRetry);
-		helperDict.Add(nameof(AuthenticatedEndpointUFunctionWithRetryDeclarations), authUfunctionsWithRetry);
 	}
 
 	public void IntoProcessMapCpp(Dictionary<string, string> helperDict)
@@ -169,22 +150,6 @@ public struct UnrealApiSubsystemDeclaration
 			return ufunction;
 		}));
 
-		var ufunctionsWithRetry = string.Join("\n\t\t", EndpointUFunctionDeclarations.Select(d =>
-		{
-			d.IntoProcessMap(helperDict);
-			var ufunction = UnrealEndpointDeclaration.U_FUNCTION_WITH_RETRY_DEFINITION.ProcessReplacement(helperDict);
-			helperDict.Clear();
-			return ufunction;
-		}));
-
-		var authUfunctionsWithRetry = string.Join("\n\t\t", AuthenticatedEndpointUFunctionDeclarations.Select(d =>
-		{
-			d.IntoProcessMap(helperDict);
-			var ufunction = UnrealEndpointDeclaration.U_FUNCTION_WITH_RETRY_AUTH_DEFINITION.ProcessReplacement(helperDict);
-			helperDict.Clear();
-			return ufunction;
-		}));
-
 		helperDict.Add(nameof(SubsystemName), SubsystemName);
 
 		helperDict.Add(nameof(EndpointRawFunctionDeclarations), endpointRawFunctions);
@@ -195,9 +160,6 @@ public struct UnrealApiSubsystemDeclaration
 
 		helperDict.Add(nameof(EndpointUFunctionDeclarations), ufunctions);
 		helperDict.Add(nameof(AuthenticatedEndpointUFunctionDeclarations), authUFunctions);
-
-		helperDict.Add(nameof(EndpointUFunctionWithRetryDeclarations), ufunctionsWithRetry);
-		helperDict.Add(nameof(AuthenticatedEndpointUFunctionWithRetryDeclarations), authUfunctionsWithRetry);
 	}
 
 
@@ -207,6 +169,7 @@ public struct UnrealApiSubsystemDeclaration
 
 #include ""CoreMinimal.h""
 #include ""BeamBackend/BeamBackend.h""
+#include ""BeamBackend/ResponseCache/BeamResponseCache.h""
 #include ""RequestTracker/BeamRequestTracker.h""
 
 ₢{nameof(IncludeStatements)}₢
@@ -234,6 +197,9 @@ private:
 	UPROPERTY()
 	UBeamRequestTracker* RequestTracker;
 
+	UPROPERTY()
+	UBeamResponseCache* ResponseCache;
+
 	₢{nameof(EndpointRawFunctionDeclarations)}₢
 
 	₢{nameof(AuthenticatedEndpointRawFunctionDeclarations)}₢
@@ -250,11 +216,7 @@ public:
 
 	₢{nameof(EndpointUFunctionDeclarations)}₢
 
-	₢{nameof(AuthenticatedEndpointUFunctionDeclarations)}₢	
-
-	₢{nameof(EndpointUFunctionWithRetryDeclarations)}₢
-
-	₢{nameof(AuthenticatedEndpointUFunctionWithRetryDeclarations)}₢
+	₢{nameof(AuthenticatedEndpointUFunctionDeclarations)}₢
 }};
 ";
 
@@ -268,6 +230,7 @@ void UBeam₢{nameof(SubsystemName)}₢Api::Initialize(FSubsystemCollectionBase&
 	Super::Initialize(Collection);
 	Backend = Cast<UBeamBackend>(Collection.InitializeDependency(UBeamBackend::StaticClass()));
 	RequestTracker = Cast<UBeamRequestTracker>(Collection.InitializeDependency(UBeamRequestTracker::StaticClass()));
+	ResponseCache = Cast<UBeamResponseCache>(Collection.InitializeDependency(UBeamResponseCache::StaticClass()));
 }}
 
 void UBeam₢{nameof(SubsystemName)}₢Api::Deinitialize()
@@ -287,11 +250,6 @@ void UBeam₢{nameof(SubsystemName)}₢Api::Deinitialize()
 
 ₢{nameof(EndpointUFunctionDeclarations)}₢
 
-₢{nameof(AuthenticatedEndpointUFunctionDeclarations)}₢	
-
-₢{nameof(EndpointUFunctionWithRetryDeclarations)}₢
-
-₢{nameof(AuthenticatedEndpointUFunctionWithRetryDeclarations)}₢
-
+₢{nameof(AuthenticatedEndpointUFunctionDeclarations)}₢
 ";
 }

--- a/cli/cli/Services/UnrealSourceGenerator/UnrealEndpointDeclaration.cs
+++ b/cli/cli/Services/UnrealSourceGenerator/UnrealEndpointDeclaration.cs
@@ -21,8 +21,10 @@ public struct UnrealEndpointDeclaration
 	public string ResponseBodyUnrealType;
 	public string ResponseBodyNamespacedType;
 	public string ResponseBodyNonPtrUnrealType;
-
-
+	
+	
+	private string _responseBodyIncludeStatement;
+	
 	private string _capitalizedEndpointVerb;
 	private string _buildBodyImpl;
 	private string _buildRouteImpl;
@@ -40,7 +42,7 @@ public struct UnrealEndpointDeclaration
 			.Union(RequestBodyParameters)
 			.DistinctBy(p => p.PropertyUnrealType)
 			.Select(p => p.PropertyUnrealType)
-			.Union(new[] { ResponseBodyUnrealType }).ToList();
+			.Union(new[] { ResponseBodyUnrealType }.Where(t => t != null)).ToList();
 	}
 
 	public void IntoProcessMap(Dictionary<string, string> helperDict, List<UnrealSerializableTypeDeclaration> serializableTypes = null)
@@ -69,6 +71,9 @@ public struct UnrealEndpointDeclaration
 			return propertyDeclaration;
 		}));
 
+		// Handle getting the include statement for the response body
+		_responseBodyIncludeStatement = UnrealSourceGenerator.GetIncludeStatementForUnrealType(ResponseBodyUnrealType);
+		
 		// Handle Capitalizing the Verb so it matches UE's expected value
 		_capitalizedEndpointVerb = EndpointVerb.ToUpper();
 		// Handle BuildBody code generation
@@ -192,8 +197,8 @@ public struct UnrealEndpointDeclaration
 							if (tp.PropertyUnrealType.StartsWith(UnrealSourceGenerator.UNREAL_U_OBJECT_PREFIX))
 							{
 								return $"// Assumes the object is constructed and have the new request take ownership of the memory for it\n\t" +
-									   $"Req->{p.PropertyName}->{tp.PropertyName} = {GetBodyParamName(nonBodyParamsDeclarations, tp)};\n\t" +
-									   $"Req->{p.PropertyName}->{tp.PropertyName}->Rename(nullptr, Req);";
+								       $"Req->{p.PropertyName}->{tp.PropertyName} = {GetBodyParamName(nonBodyParamsDeclarations, tp)};\n\t" +
+								       $"Req->{p.PropertyName}->{tp.PropertyName}->Rename(nullptr, Req);";
 							}
 
 							return $"Req->{p.PropertyName}->{tp.PropertyName} = {GetBodyParamName(nonBodyParamsDeclarations, tp)};";
@@ -216,6 +221,8 @@ public struct UnrealEndpointDeclaration
 		helperDict.Add(nameof(GlobalNamespacedEndpointName), GlobalNamespacedEndpointName);
 		helperDict.Add(nameof(SubsystemNamespacedEndpointName), SubsystemNamespacedEndpointName);
 
+		helperDict.Add(nameof(_responseBodyIncludeStatement), _responseBodyIncludeStatement);
+		
 		helperDict.Add(nameof(NamespacedOwnerServiceName), NamespacedOwnerServiceName);
 		helperDict.Add(nameof(EndpointVerb), EndpointVerb);
 		helperDict.Add(nameof(EndpointPath), EndpointPath);
@@ -247,13 +254,20 @@ public struct UnrealEndpointDeclaration
 				return $"Route = Route.Replace(TEXT(\"{{{routeParameterDeclaration.RawFieldName}}}\"), *{routeParameterDeclaration.PropertyName});";
 			case UnrealSourceGenerator.UNREAL_BYTE or UnrealSourceGenerator.UNREAL_SHORT or UnrealSourceGenerator.UNREAL_INT or UnrealSourceGenerator.UNREAL_LONG:
 				return $"Route = Route.Replace(TEXT(\"{{{routeParameterDeclaration.RawFieldName}}}\"), *FString::FromInt({routeParameterDeclaration.PropertyName}));";
+			
 			default:
 			{
 				// We handle the enum case that we can't pattern match here
 				if (routeParameterDeclaration.PropertyUnrealType.StartsWith(UnrealSourceGenerator.UNREAL_U_ENUM_PREFIX))
+				{
 					return
 						$"Route = Route.Replace(TEXT(\"{{{routeParameterDeclaration.RawFieldName}}}\"), " +
 						$"*U{routeParameterDeclaration.PropertyNamespacedType}Library::{routeParameterDeclaration.PropertyNamespacedType}ToSerializableName({routeParameterDeclaration.PropertyName}));";
+				}
+				else if (UnrealSourceGenerator.UNREAL_ALL_SEMTYPES.Contains(routeParameterDeclaration.PropertyUnrealType))
+				{
+					return $"Route = Route.Replace(TEXT(\"{{{routeParameterDeclaration.RawFieldName}}}\"), *static_cast<FString>({routeParameterDeclaration.PropertyName}));";
+				}
 
 				// We fail the gen loudly if we ever see a type that doesn't match this. It should be impossible.
 				throw new NotImplementedException("No definition for how to embed a path parameter of this type into the route string. Please add a conditional to handle this case.");
@@ -310,6 +324,13 @@ public struct UnrealEndpointDeclaration
 						queryAppend.Append(
 							$"QueryParams.Appendf(TEXT(\"%s=%s\"), TEXT(\"{q.RawFieldName}\"), *U{q.PropertyNamespacedType}Library::{q.PropertyNamespacedType}ToSerializationName({q.PropertyName}));\n\t");
 				}
+				else if (UnrealSourceGenerator.UNREAL_ALL_SEMTYPES.Contains(q.NonOptionalTypeName))
+				{
+					if(isOptional)
+						queryAppend.Append($"\tQueryParams.Appendf(TEXT(\"%s=%s\"), TEXT(\"{q.RawFieldName}\"), *static_cast<FString>({q.PropertyName}.Val));\n\t");
+					else
+						queryAppend.Append($"QueryParams.Appendf(TEXT(\"%s=%s\"), TEXT(\"{q.RawFieldName}\"), *static_cast<FString>({q.PropertyName}));\n\t");
+				}
 				// https://disruptorbeam.atlassian.net/browse/PLAT-4672
 				// TODO This is a known issue --- so we are ignoring this case for now. Once this gets fixed, remove this thing.
 				else if (!q.NonOptionalTypeName.StartsWith(UnrealSourceGenerator.UNREAL_MAP) && !q.NonOptionalTypeName.StartsWith(UnrealSourceGenerator.UNREAL_ARRAY))
@@ -342,14 +363,14 @@ template TUnrealRequestPtr UBeamBackend::CreateRequest(int64&, const FBeamRealmH
 template TUnrealRequestPtr UBeamBackend::CreateAuthenticatedRequest(int64&, const FBeamRealmHandle&, const FBeamRetryConfig&, const FBeamAuthToken&, const U₢{nameof(GlobalNamespacedEndpointName)}₢Request*);
 
 template FBeamRequestProcessor UBeamBackend::MakeBlueprintRequestProcessor<U₢{nameof(GlobalNamespacedEndpointName)}₢Request, ₢{nameof(ResponseBodyNonPtrUnrealType)}₢>(
-	const int64&, U₢{nameof(GlobalNamespacedEndpointName)}₢Request*, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete);
+	const int64&, U₢{nameof(GlobalNamespacedEndpointName)}₢Request*, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete, const UObject*);
 
 template FBeamRequestProcessor UBeamBackend::MakeAuthenticatedBlueprintRequestProcessor<U₢{nameof(GlobalNamespacedEndpointName)}₢Request, ₢{nameof(ResponseBodyNonPtrUnrealType)}₢>(
-	const int64&, const FBeamRealmHandle&, const FBeamAuthToken&, U₢{nameof(GlobalNamespacedEndpointName)}₢Request*, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete);
+	const int64&, const FBeamRealmHandle&, const FBeamAuthToken&, U₢{nameof(GlobalNamespacedEndpointName)}₢Request*, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete, const UObject*);
 
-template FBeamRequestProcessor UBeamBackend::MakeCodeRequestProcessor(const int64&, U₢{nameof(GlobalNamespacedEndpointName)}₢Request*, TBeamFullResponseHandler<U₢{nameof(GlobalNamespacedEndpointName)}₢Request*, ₢{nameof(ResponseBodyUnrealType)}₢>);
+template FBeamRequestProcessor UBeamBackend::MakeCodeRequestProcessor(const int64&, U₢{nameof(GlobalNamespacedEndpointName)}₢Request*, TBeamFullResponseHandler<U₢{nameof(GlobalNamespacedEndpointName)}₢Request*, ₢{nameof(ResponseBodyUnrealType)}₢>, const UObject*);
 template FBeamRequestProcessor UBeamBackend::MakeAuthenticatedCodeRequestProcessor(const int64&, const FBeamRealmHandle&, const FBeamAuthToken&, U₢{nameof(GlobalNamespacedEndpointName)}₢Request*,
-                                                                                   TBeamFullResponseHandler<U₢{nameof(GlobalNamespacedEndpointName)}₢Request*, ₢{nameof(ResponseBodyUnrealType)}₢>);
+                                                                                   TBeamFullResponseHandler<U₢{nameof(GlobalNamespacedEndpointName)}₢Request*, ₢{nameof(ResponseBodyUnrealType)}₢>, const UObject*);
 
 ";
 
@@ -445,27 +466,36 @@ U₢{nameof(GlobalNamespacedEndpointName)}₢Request* U₢{nameof(GlobalNamespac
 	 */
 	void BP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(const FBeamRealmHandle& TargetRealm, const FBeamRetryConfig& RetryConfig, FBeamConnectivity& ConnectivityStatus, U₢{nameof(GlobalNamespacedEndpointName)}₢Request* RequestData,
 	                                const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success& OnSuccess, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error& OnError, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete& OnComplete,
-	                                int64& OutRequestId, FBeamOperationHandle OpHandle = FBeamOperationHandle()) const;";
+	                                int64& OutRequestId, FBeamOperationHandle OpHandle = FBeamOperationHandle(), const UObject* CallingContext = nullptr) const;";
 
 	public const string RAW_BP_DEFINITION = $@"
 void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::BP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(const FBeamRealmHandle& TargetRealm, const FBeamRetryConfig& RetryConfig, FBeamConnectivity& ConnectivityStatus, U₢{nameof(GlobalNamespacedEndpointName)}₢Request* RequestData,
                                                   const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success& OnSuccess, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error& OnError, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete& OnComplete,
-                                                  int64& OutRequestId, FBeamOperationHandle OpHandle) const
+                                                  int64& OutRequestId, FBeamOperationHandle OpHandle, const UObject* CallingContext) const
 {{
 	// AUTO-GENERATED...	
 	const auto Request = Backend->CreateRequest(OutRequestId, TargetRealm, RetryConfig, RequestData);
 
-	// Binds the handler to the static response handler (pre-generated)
-	const auto BeamRequestProcessor = Backend->MakeBlueprintRequestProcessor<U₢{nameof(GlobalNamespacedEndpointName)}₢Request, ₢{nameof(ResponseBodyNonPtrUnrealType)}₢, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete>
-		(OutRequestId, RequestData, OnSuccess, OnError, OnComplete);
-	Request->OnProcessRequestComplete().BindLambda(BeamRequestProcessor);
-
-	// Logic that actually talks to the backend --- if you pass in some other delegate, that means you can avoid making the actual back-end call.
-	Backend->ExecuteRequestDelegate.ExecuteIfBound(OutRequestId, ConnectivityStatus);
-	
 	// If we are making this request as part of an operation, we add it to it.
 	if(OpHandle.OperationId >= 0)
 		RequestTracker->AddRequestToOperation(OpHandle, OutRequestId);
+
+	// If cached...
+	if(FString CachedResponse; ResponseCache->TryHitResponseCache(RequestData, Request, CallingContext,  CachedResponse))
+	{{
+		UE_LOG(LogBeamBackend, Verbose, TEXT(""Found data in cache.REQUEST_TYPE=%s\\n%s""), *RequestData->GetRequestType().Name, *CachedResponse);
+		Backend->RunBlueprintRequestProcessor<U₢{nameof(GlobalNamespacedEndpointName)}₢Request, ₢{nameof(ResponseBodyNonPtrUnrealType)}₢, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete>
+			(200, CachedResponse, EHttpRequestStatus::Succeeded, OutRequestId, RequestData, OnSuccess, OnError, OnComplete);		
+	}}
+	// If not cached...
+	else
+	{{			
+		// Binds the handler to the static response handler (pre-generated)
+		const auto BeamRequestProcessor = Backend->MakeBlueprintRequestProcessor<U₢{nameof(GlobalNamespacedEndpointName)}₢Request, ₢{nameof(ResponseBodyNonPtrUnrealType)}₢, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete>
+			(OutRequestId, RequestData, OnSuccess, OnError, OnComplete);
+		Request->OnProcessRequestComplete().BindLambda(BeamRequestProcessor);
+		Backend->ExecuteRequestDelegate.ExecuteIfBound(OutRequestId, ConnectivityStatus);		
+	}}	
 }}
 ";
 
@@ -476,28 +506,39 @@ void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::BP_₢{nameof(Subsystem
 	 */
 	void BP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(const FBeamRealmHandle& TargetRealm, const FBeamRetryConfig& RetryConfig, const FBeamAuthToken& AuthToken, FBeamConnectivity& ConnectivityStatus, U₢{nameof(GlobalNamespacedEndpointName)}₢Request* RequestData,
 	                  const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success& OnSuccess, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error& OnError, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete& OnComplete, 
-					  int64& OutRequestId, FBeamOperationHandle OpHandle = FBeamOperationHandle()) const;";
+					  int64& OutRequestId, FBeamOperationHandle OpHandle = FBeamOperationHandle(), const UObject* CallingContext = nullptr) const;";
 
 
 	public const string RAW_AUTH_BP_DEFINITION = $@"
 void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::BP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(const FBeamRealmHandle& TargetRealm, const FBeamRetryConfig& RetryConfig, const FBeamAuthToken& AuthToken, FBeamConnectivity& ConnectivityStatus,
                                 U₢{nameof(GlobalNamespacedEndpointName)}₢Request* RequestData, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success& OnSuccess, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error& OnError, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete& OnComplete, 
-								int64& OutRequestId, FBeamOperationHandle OpHandle) const
+								int64& OutRequestId, FBeamOperationHandle OpHandle, const UObject* CallingContext) const
 {{
 	// AUTO-GENERATED...	
 	const auto Request = Backend->CreateAuthenticatedRequest(OutRequestId, TargetRealm, RetryConfig, AuthToken, RequestData);
 
-	// Binds the handler to the static response handler (pre-generated)
-	const auto BeamRequestProcessor = Backend->MakeAuthenticatedBlueprintRequestProcessor<U₢{nameof(GlobalNamespacedEndpointName)}₢Request, ₢{nameof(ResponseBodyNonPtrUnrealType)}₢, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete>
-		(OutRequestId, TargetRealm, AuthToken, RequestData, OnSuccess, OnError, OnComplete);
-	Request->OnProcessRequestComplete().BindLambda(BeamRequestProcessor);
-
-	// Logic that actually talks to the backend --- if you pass in some other delegate, that means you can avoid making the actual back-end call.	
-	Backend->ExecuteRequestDelegate.ExecuteIfBound(OutRequestId, ConnectivityStatus);
-
 	// If we are making this request as part of an operation, we add it to it.
 	if(OpHandle.OperationId >= 0)
 		RequestTracker->AddRequestToOperation(OpHandle, OutRequestId);
+
+	// If cached...
+	if(FString CachedResponse; ResponseCache->TryHitResponseCache(RequestData, Request, CallingContext,  CachedResponse))
+	{{
+		UE_LOG(LogBeamBackend, Verbose, TEXT(""Found data in cache.REQUEST_TYPE=%s\\n%s""), *RequestData->GetRequestType().Name, *CachedResponse);
+		Backend->RunAuthenticatedBlueprintRequestProcessor<U₢{nameof(GlobalNamespacedEndpointName)}₢Request, ₢{nameof(ResponseBodyNonPtrUnrealType)}₢, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete>
+			(200, CachedResponse, EHttpRequestStatus::Succeeded, OutRequestId, TargetRealm, AuthToken, RequestData, OnSuccess, OnError, OnComplete);		
+	}}
+	// If not cached...
+	else
+	{{
+		// Binds the handler to the static response handler (pre-generated)
+		const auto BeamRequestProcessor = Backend->MakeAuthenticatedBlueprintRequestProcessor<U₢{nameof(GlobalNamespacedEndpointName)}₢Request, ₢{nameof(ResponseBodyNonPtrUnrealType)}₢, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error, FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete>
+			(OutRequestId, TargetRealm, AuthToken, RequestData, OnSuccess, OnError, OnComplete);
+		Request->OnProcessRequestComplete().BindLambda(BeamRequestProcessor);
+	    
+		// Logic that actually talks to the backend --- if you pass in some other delegate, that means you can avoid making the actual back-end call.	
+		Backend->ExecuteRequestDelegate.ExecuteIfBound(OutRequestId, ConnectivityStatus);	
+	}}
 }}
 ";
 
@@ -507,26 +548,38 @@ void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::BP_₢{nameof(Subsystem
 	 * @brief Overload version for binding lambdas when in C++ land. Prefer the BP version whenever possible, this is here mostly for quick experimentation purposes.	 
 	 */
 	void CPP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(const FBeamRealmHandle& TargetRealm, const FBeamRetryConfig& RetryConfig, FBeamConnectivity& ConnectivityStatus, U₢{nameof(GlobalNamespacedEndpointName)}₢Request* RequestData,
-	                                 const FOn₢{nameof(GlobalNamespacedEndpointName)}₢FullResponse& Handler, int64& OutRequestId, FBeamOperationHandle OpHandle = FBeamOperationHandle()) const;
+	                                 const FOn₢{nameof(GlobalNamespacedEndpointName)}₢FullResponse& Handler, int64& OutRequestId, FBeamOperationHandle OpHandle = FBeamOperationHandle(), const UObject* CallingContext = nullptr) const;
 ";
 
 	public const string RAW_CPP_DEFINITION = $@"
 void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::CPP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(const FBeamRealmHandle& TargetRealm, const FBeamRetryConfig& RetryConfig, FBeamConnectivity& ConnectivityStatus,
-                                               U₢{nameof(GlobalNamespacedEndpointName)}₢Request* RequestData, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢FullResponse& Handler, int64& OutRequestId, FBeamOperationHandle OpHandle) const
+                                               U₢{nameof(GlobalNamespacedEndpointName)}₢Request* RequestData, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢FullResponse& Handler, int64& OutRequestId, FBeamOperationHandle OpHandle, const UObject* CallingContext) const
 {{
 	// AUTO-GENERATED...	
 	const auto Request = Backend->CreateRequest(OutRequestId, TargetRealm, RetryConfig, RequestData);
 
-	// Binds the handler to the static response handler (pre-generated)	
-	auto ResponseProcessor = Backend->MakeCodeRequestProcessor<U₢{nameof(GlobalNamespacedEndpointName)}₢Request, ₢{nameof(ResponseBodyNonPtrUnrealType)}₢>(OutRequestId, RequestData, Handler);
-	Request->OnProcessRequestComplete().BindLambda(ResponseProcessor);
-
-	// Logic that actually talks to the backend --- if you pass in some other delegate, that means you can avoid making the actual back-end call.	
-	Backend->ExecuteRequestDelegate.ExecuteIfBound(OutRequestId, ConnectivityStatus);
-
 	// If we are making this request as part of an operation, we add it to it.
 	if(OpHandle.OperationId >= 0)
 		RequestTracker->AddRequestToOperation(OpHandle, OutRequestId);
+
+	// If cached...
+	if(FString CachedResponse; ResponseCache->TryHitResponseCache(RequestData, Request, CallingContext,  CachedResponse))
+	{{
+		UE_LOG(LogBeamBackend, Verbose, TEXT(""Found data in cache.REQUEST_TYPE=%s\\n%s""), *RequestData->GetRequestType().Name, *CachedResponse);
+		Backend->RunCodeRequestProcessor<U₢{nameof(GlobalNamespacedEndpointName)}₢Request, ₢{nameof(ResponseBodyNonPtrUnrealType)}₢>
+			(200, CachedResponse, EHttpRequestStatus::Succeeded, OutRequestId, RequestData, Handler);			
+	}}
+	// If not cached...
+	else
+	{{
+		// Binds the handler to the static response handler (pre-generated)	
+		auto ResponseProcessor = Backend->MakeCodeRequestProcessor<U₢{nameof(GlobalNamespacedEndpointName)}₢Request, ₢{nameof(ResponseBodyNonPtrUnrealType)}₢>
+			(OutRequestId, RequestData, Handler);
+		Request->OnProcessRequestComplete().BindLambda(ResponseProcessor);
+
+		// Logic that actually talks to the backend --- if you pass in some other delegate, that means you can avoid making the actual back-end call.	
+		Backend->ExecuteRequestDelegate.ExecuteIfBound(OutRequestId, ConnectivityStatus);	
+	}}	
 }}
 ";
 
@@ -536,26 +589,38 @@ void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::CPP_₢{nameof(Subsyste
 	 * @brief Overload version for binding lambdas when in C++ land. Prefer the BP version whenever possible, this is here mostly for quick experimentation purposes.	 
 	 */
 	void CPP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(const FBeamRealmHandle& TargetRealm, const FBeamRetryConfig& RetryConfig, const FBeamAuthToken& AuthToken, FBeamConnectivity& ConnectivityStatus, U₢{nameof(GlobalNamespacedEndpointName)}₢Request* RequestData,
-	                   const FOn₢{nameof(GlobalNamespacedEndpointName)}₢FullResponse& Handler, int64& OutRequestId, FBeamOperationHandle OpHandle = FBeamOperationHandle()) const;";
+	                   const FOn₢{nameof(GlobalNamespacedEndpointName)}₢FullResponse& Handler, int64& OutRequestId, FBeamOperationHandle OpHandle = FBeamOperationHandle(), const UObject* CallingContext = nullptr) const;";
 
 
 	public const string RAW_AUTH_CPP_DEFINITION = $@"
 void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::CPP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(const FBeamRealmHandle& TargetRealm, const FBeamRetryConfig& RetryConfig, const FBeamAuthToken& AuthToken, FBeamConnectivity& ConnectivityStatus,
-                              U₢{nameof(GlobalNamespacedEndpointName)}₢Request* RequestData, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢FullResponse& Handler, int64& OutRequestId, FBeamOperationHandle OpHandle) const
+                              U₢{nameof(GlobalNamespacedEndpointName)}₢Request* RequestData, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢FullResponse& Handler, int64& OutRequestId, FBeamOperationHandle OpHandle, const UObject* CallingContext) const
 {{
 	// AUTO-GENERATED...
 	const auto Request = Backend->CreateAuthenticatedRequest(OutRequestId, TargetRealm, RetryConfig, AuthToken, RequestData);
-
-	// Binds the handler to the static response handler (pre-generated)	
-	auto ResponseProcessor = Backend->MakeAuthenticatedCodeRequestProcessor<U₢{nameof(GlobalNamespacedEndpointName)}₢Request, ₢{nameof(ResponseBodyNonPtrUnrealType)}₢>(OutRequestId, TargetRealm, AuthToken, RequestData, Handler);
-	Request->OnProcessRequestComplete().BindLambda(ResponseProcessor);
-
-	// Logic that actually talks to the backend --- if you pass in some other delegate, that means you can avoid making the actual back-end call.	
-	Backend->ExecuteRequestDelegate.ExecuteIfBound(OutRequestId, ConnectivityStatus);
-
+	
 	// If we are making this request as part of an operation, we add it to it.
 	if(OpHandle.OperationId >= 0)
 		RequestTracker->AddRequestToOperation(OpHandle, OutRequestId);
+
+	// If cached...
+	if(FString CachedResponse; ResponseCache->TryHitResponseCache(RequestData, Request, CallingContext,  CachedResponse))
+	{{
+		UE_LOG(LogBeamBackend, Verbose, TEXT(""Found data in cache.REQUEST_TYPE=%s\\n%s""), *RequestData->GetRequestType().Name, *CachedResponse);
+		Backend->RunAuthenticatedCodeRequestProcessor<U₢{nameof(GlobalNamespacedEndpointName)}₢Request, ₢{nameof(ResponseBodyNonPtrUnrealType)}₢>
+			(200, CachedResponse, EHttpRequestStatus::Succeeded, OutRequestId, TargetRealm, AuthToken, RequestData, Handler);		
+	}}
+	// If not cached...
+	else
+	{{
+		// Binds the handler to the static response handler (pre-generated)	
+		auto ResponseProcessor = Backend->MakeAuthenticatedCodeRequestProcessor<U₢{nameof(GlobalNamespacedEndpointName)}₢Request, ₢{nameof(ResponseBodyNonPtrUnrealType)}₢>
+			(OutRequestId, TargetRealm, AuthToken, RequestData, Handler);
+		Request->OnProcessRequestComplete().BindLambda(ResponseProcessor);
+
+		// Logic that actually talks to the backend --- if you pass in some other delegate, that means you can avoid making the actual back-end call.	
+		Backend->ExecuteRequestDelegate.ExecuteIfBound(OutRequestId, ConnectivityStatus);	
+	}}
 }}
 ";
 
@@ -570,19 +635,20 @@ void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::CPP_₢{nameof(Subsyste
 	 * @param Request The Request UObject. All (de)serialized data the request data creates is tied to the lifecycle of this object.
 	 * @param Handler A callback that defines how to handle success, error and completion.
      * @param OutRequestContext The Request Context associated with this request -- used to query information about the request or to cancel it while it's in flight.
-	 * @param OpHandle When made as part of an Operation, you can pass this in and it'll register the request with the operation automatically. 
+	 * @param OpHandle When made as part of an Operation, you can pass this in and it'll register the request with the operation automatically.
+	 * @param CallingContext A UObject managed by the UWorld that's making the request. Used to support multiple PIEs (see UBeamUserSlot::GetNamespacedSlotId) and read-only RequestCaches. 
 	 */
-	void CPP_₢{nameof(SubsystemNamespacedEndpointName)}₢(U₢{nameof(GlobalNamespacedEndpointName)}₢Request* Request, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢FullResponse& Handler, FBeamRequestContext& OutRequestContext, FBeamOperationHandle OpHandle = FBeamOperationHandle()) const;
+	void CPP_₢{nameof(SubsystemNamespacedEndpointName)}₢(U₢{nameof(GlobalNamespacedEndpointName)}₢Request* Request, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢FullResponse& Handler, FBeamRequestContext& OutRequestContext, FBeamOperationHandle OpHandle = FBeamOperationHandle(), const UObject* CallingContext = nullptr) const;
 ";
 
 	public const string LAMBDA_BINDABLE_DEFINITION = $@"
-void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::CPP_₢{nameof(SubsystemNamespacedEndpointName)}₢(U₢{nameof(GlobalNamespacedEndpointName)}₢Request* Request, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢FullResponse& Handler, FBeamRequestContext& OutRequestContext, FBeamOperationHandle OpHandle) const
+void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::CPP_₢{nameof(SubsystemNamespacedEndpointName)}₢(U₢{nameof(GlobalNamespacedEndpointName)}₢Request* Request, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢FullResponse& Handler, FBeamRequestContext& OutRequestContext, FBeamOperationHandle OpHandle, const UObject* CallingContext) const
 {{
 	FBeamRetryConfig RetryConfig;
 	Backend->GetRetryConfigForRequestType(U₢{nameof(GlobalNamespacedEndpointName)}₢Request::StaticClass()->GetName(), RetryConfig);
 	
     int64 OutRequestId;
-	CPP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(GetDefault<UBeamCoreSettings>()->TargetRealm, RetryConfig, Backend->CurrentConnectivityStatus, Request, Handler, OutRequestId, OpHandle);
+	CPP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(GetDefault<UBeamCoreSettings>()->TargetRealm, RetryConfig, Backend->CurrentConnectivityStatus, Request, Handler, OutRequestId, OpHandle, CallingContext);
 	OutRequestContext = FBeamRequestContext{{OutRequestId, RetryConfig, GetDefault<UBeamCoreSettings>()->TargetRealm, -1, FUserSlot(), None}};
 }}
 ";
@@ -600,7 +666,7 @@ void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::CPP_₢{nameof(Subsyste
 	 * @param Handler A callback that defines how to handle success, error and completion.
      * @param OutRequestContext The Request Context associated with this request -- used to query information about the request or to cancel it while it's in flight.
 	 * @param OpHandle When made as part of an Operation, you can pass this in and it'll register the request with the operation automatically.
-     * @param CallingContext A UObject managed by the world that's making the request. Used to support multiple PIEs (see UBeamUserSlot::GetNamespacedSlotId). 
+	 * @param CallingContext A UObject managed by the UWorld that's making the request. Used to support multiple PIEs (see UBeamUserSlot::GetNamespacedSlotId) and read-only RequestCaches. 
 	 */
 	void CPP_₢{nameof(SubsystemNamespacedEndpointName)}₢(const FUserSlot& UserSlot, U₢{nameof(GlobalNamespacedEndpointName)}₢Request* Request, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢FullResponse& Handler, FBeamRequestContext& OutRequestContext, FBeamOperationHandle OpHandle = FBeamOperationHandle(), const UObject* CallingContext = nullptr) const;
 ";
@@ -616,7 +682,7 @@ void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::CPP_₢{nameof(Subsyste
 	Backend->GetRetryConfigForUserSlotAndRequestType(U₢{nameof(GlobalNamespacedEndpointName)}₢Request::StaticClass()->GetName(), UserSlot, RetryConfig);
 
     int64 OutRequestId;
-	CPP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(AuthenticatedUser.RealmHandle, RetryConfig, AuthenticatedUser.AuthToken, Backend->CurrentConnectivityStatus, Request, Handler, OutRequestId, OpHandle);
+	CPP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(AuthenticatedUser.RealmHandle, RetryConfig, AuthenticatedUser.AuthToken, Backend->CurrentConnectivityStatus, Request, Handler, OutRequestId, OpHandle, CallingContext);
 	OutRequestContext = FBeamRequestContext{{OutRequestId, RetryConfig, AuthenticatedUser.RealmHandle, -1, UserSlot, None}};
 }}
 ";
@@ -630,21 +696,22 @@ void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::CPP_₢{nameof(Subsyste
 	 * @param OnSuccess What to do if the requests receives a successful response.
 	 * @param OnError What to do if the request receives an error response.
 	 * @param OnComplete What to after either OnSuccess or OnError have finished executing.
-	 * @param OutRequestContext The Request Context associated with this request -- used to query information about the request or to cancel it while it's in flight. 
+	 * @param OutRequestContext The Request Context associated with this request -- used to query information about the request or to cancel it while it's in flight.
+	 * @param CallingContext A UObject managed by the UWorld that's making the request. Used to support multiple PIEs (see UBeamUserSlot::GetNamespacedSlotId) and read-only RequestCaches. 
 	 */
-	UFUNCTION(BlueprintCallable, BlueprintInternalUseOnly, Category=""Beam|Backend|₢{nameof(NamespacedOwnerServiceName)}₢"", meta=(AdvancedDisplay=""OpHandle"", AutoCreateRefTerm=""OnSuccess,OnError,OnComplete,OpHandle"", BeamFlowFunction))
-	void ₢{nameof(SubsystemNamespacedEndpointName)}₢(U₢{nameof(GlobalNamespacedEndpointName)}₢Request* Request, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success& OnSuccess, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error& OnError, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete& OnComplete, FBeamRequestContext& OutRequestContext, FBeamOperationHandle OpHandle = FBeamOperationHandle());
+	UFUNCTION(BlueprintCallable, BlueprintInternalUseOnly, Category=""Beam|Backend|₢{nameof(NamespacedOwnerServiceName)}₢"", meta=(DefaultToSelf=""CallingContext"", AdvancedDisplay=""OpHandle,CallingContext"", AutoCreateRefTerm=""OnSuccess,OnError,OnComplete,OpHandle"", BeamFlowFunction))
+	void ₢{nameof(SubsystemNamespacedEndpointName)}₢(U₢{nameof(GlobalNamespacedEndpointName)}₢Request* Request, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success& OnSuccess, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error& OnError, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete& OnComplete, FBeamRequestContext& OutRequestContext, FBeamOperationHandle OpHandle = FBeamOperationHandle(), const UObject* CallingContext = nullptr);
 ";
 
 	public const string U_FUNCTION_DEFINITION = $@"
-void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::₢{nameof(SubsystemNamespacedEndpointName)}₢(U₢{nameof(GlobalNamespacedEndpointName)}₢Request* Request, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success& OnSuccess, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error& OnError, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete& OnComplete, FBeamRequestContext& OutRequestContext, FBeamOperationHandle OpHandle)
+void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::₢{nameof(SubsystemNamespacedEndpointName)}₢(U₢{nameof(GlobalNamespacedEndpointName)}₢Request* Request, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success& OnSuccess, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error& OnError, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete& OnComplete, FBeamRequestContext& OutRequestContext, FBeamOperationHandle OpHandle, const UObject* CallingContext)
 {{
 	// AUTO-GENERATED...	
 	FBeamRetryConfig RetryConfig;
 	Backend->GetRetryConfigForRequestType(U₢{nameof(GlobalNamespacedEndpointName)}₢Request::StaticClass()->GetName(), RetryConfig);	
 	
 	int64 OutRequestId = 0;
-	BP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(GetDefault<UBeamCoreSettings>()->TargetRealm, RetryConfig, Backend->CurrentConnectivityStatus, Request, OnSuccess, OnError, OnComplete, OutRequestId, OpHandle);
+	BP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(GetDefault<UBeamCoreSettings>()->TargetRealm, RetryConfig, Backend->CurrentConnectivityStatus, Request, OnSuccess, OnError, OnComplete, OutRequestId, OpHandle, CallingContext);
 	OutRequestContext = FBeamRequestContext{{OutRequestId, RetryConfig, GetDefault<UBeamCoreSettings>()->TargetRealm, -1, FUserSlot(), None}};
 }}
 ";
@@ -660,7 +727,7 @@ void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::₢{nameof(SubsystemNam
 	 * @param OnError What to do if the request receives an error response.
 	 * @param OnComplete What to after either OnSuccess or OnError have finished executing.
 	 * @param OutRequestContext The Request Context associated with this request -- used to query information about the request or to cancel it while it's in flight.
-     * @param CallingContext A UObject managed by the world that's making the request. Used to support multiple PIEs (see UBeamUserSlot::GetNamespacedSlotId).
+	 * @param CallingContext A UObject managed by the UWorld that's making the request. Used to support multiple PIEs (see UBeamUserSlot::GetNamespacedSlotId) and read-only RequestCaches.
 	 */
 	UFUNCTION(BlueprintCallable, BlueprintInternalUseOnly, Category=""Beam|Backend|₢{nameof(NamespacedOwnerServiceName)}₢"", meta=(DefaultToSelf=""CallingContext"", AdvancedDisplay=""OpHandle,CallingContext"",AutoCreateRefTerm=""UserSlot,OnSuccess,OnError,OnComplete,OpHandle"", BeamFlowFunction))
 	void ₢{nameof(SubsystemNamespacedEndpointName)}₢(FUserSlot UserSlot, U₢{nameof(GlobalNamespacedEndpointName)}₢Request* Request, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success& OnSuccess, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error& OnError, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete& OnComplete, FBeamRequestContext& OutRequestContext, FBeamOperationHandle OpHandle = FBeamOperationHandle(), const UObject* CallingContext = nullptr);
@@ -677,63 +744,10 @@ void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::₢{nameof(SubsystemNam
 	Backend->GetRetryConfigForUserSlotAndRequestType(U₢{nameof(GlobalNamespacedEndpointName)}₢Request::StaticClass()->GetName(), UserSlot, RetryConfig);
 
 	int64 OutRequestId;
-	BP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(AuthenticatedUser.RealmHandle, RetryConfig, AuthenticatedUser.AuthToken, Backend->CurrentConnectivityStatus, Request, OnSuccess, OnError, OnComplete, OutRequestId, OpHandle);	
+	BP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(AuthenticatedUser.RealmHandle, RetryConfig, AuthenticatedUser.AuthToken, Backend->CurrentConnectivityStatus, Request, OnSuccess, OnError, OnComplete, OutRequestId, OpHandle, CallingContext);	
 	OutRequestContext = FBeamRequestContext{{OutRequestId, RetryConfig, AuthenticatedUser.RealmHandle, -1, UserSlot, None}};
 }}
 ";
-
-	public const string U_FUNCTION_WITH_RETRY_DECLARATION = $@"
-	/**
-	 * @brief Makes a request to the ₢{nameof(EndpointVerb)}₢ ₢{nameof(EndpointPath)}₢ endpoint of the ₢{nameof(NamespacedOwnerServiceName)}₢ Service.
-	 *	 
-	 * @param RetryConfig The retry config for this specific request. 
-	 * @param Request The Request UObject. All (de)serialized data the request data creates is tied to the lifecycle of this object.
-	 * @param OnSuccess What to do if the requests receives a successful response.
-	 * @param OnError What to do if the request receives an error response.
-	 * @param OnComplete What to after either OnSuccess or OnError have finished executing.
-	 * @param OutRequestContext The Request Context -- used to query information about the request or to cancel it while it's in flight.	  
-	 */
-	UFUNCTION(BlueprintCallable, BlueprintInternalUseOnly, Category=""Beam|Backend|₢{nameof(NamespacedOwnerServiceName)}₢"", meta=(AutoCreateRefTerm=""OnSuccess,OnError,OnComplete"", BeamFlowFunction))
-	void ₢{nameof(SubsystemNamespacedEndpointName)}₢WithRetry(const FBeamRetryConfig& RetryConfig, U₢{nameof(GlobalNamespacedEndpointName)}₢Request* Request, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success& OnSuccess, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error& OnError, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete& OnComplete, FBeamRequestContext& OutRequestContext);";
-
-	public const string U_FUNCTION_WITH_RETRY_DEFINITION = $@"
-void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::₢{nameof(SubsystemNamespacedEndpointName)}₢WithRetry(const FBeamRetryConfig& RetryConfig, U₢{nameof(GlobalNamespacedEndpointName)}₢Request* Request, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success& OnSuccess, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error& OnError, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete& OnComplete, FBeamRequestContext& OutRequestContext)
-{{
-	int64 OutRequestId = 0;
-	BP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(GetDefault<UBeamCoreSettings>()->TargetRealm, RetryConfig, Backend->CurrentConnectivityStatus, Request, OnSuccess, OnError, OnComplete, OutRequestId);
-	OutRequestContext = FBeamRequestContext{{OutRequestId, RetryConfig, GetDefault<UBeamCoreSettings>()->TargetRealm, -1, FUserSlot(), None}}; 
-}}
-";
-
-	public const string U_FUNCTION_WITH_RETRY_AUTH_DECLARATION = $@"
-	/**
-	 * @brief Makes an authenticated request to the ₢{nameof(EndpointVerb)}₢ ₢{nameof(EndpointPath)}₢ endpoint of the ₢{nameof(NamespacedOwnerServiceName)}₢ Service.
-	 *
-	 * @param UserSlot The authenticated UserSlot with the user making the request.
-	 * @param RetryConfig The retry config for this specific request. 
-	 * @param Request The Request UObject. All (de)serialized data the request data creates is tied to the lifecycle of this object.
-	 * @param OnSuccess What to do if the requests receives a successful response.
-	 * @param OnError What to do if the request receives an error response.
-	 * @param OnComplete What to after either OnSuccess or OnError have finished executing.
-	 * @param OutRequestContext The Request Context -- used to query information about the request or to cancel it while it's in flight.
-	 * @param CallingContext A UObject managed by the UWorld that's making the request. Used to support multiple PIEs (see UBeamUserSlot::GetNamespacedSlotId). 
-	 */
-	UFUNCTION(BlueprintCallable, BlueprintInternalUseOnly, Category=""Beam|Backend|₢{nameof(NamespacedOwnerServiceName)}₢"", meta=(DefaultToSelf=""CallingContext"", AdvancedDisplay=""CallingContext"", AutoCreateRefTerm=""UserSlot,OnSuccess,OnError,OnComplete"", BeamFlowFunction))
-	void ₢{nameof(SubsystemNamespacedEndpointName)}₢WithRetry(FUserSlot UserSlot, const FBeamRetryConfig& RetryConfig, U₢{nameof(GlobalNamespacedEndpointName)}₢Request* Request, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success& OnSuccess, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error& OnError, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete& OnComplete, FBeamRequestContext& OutRequestContext, const UObject* CallingContext = nullptr);";
-
-	public const string U_FUNCTION_WITH_RETRY_AUTH_DEFINITION = $@"
-void UBeam₢{nameof(NamespacedOwnerServiceName)}₢Api::₢{nameof(SubsystemNamespacedEndpointName)}₢WithRetry(FUserSlot UserSlot, const FBeamRetryConfig& RetryConfig, U₢{nameof(GlobalNamespacedEndpointName)}₢Request* Request, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Success& OnSuccess, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Error& OnError, const FOn₢{nameof(GlobalNamespacedEndpointName)}₢Complete& OnComplete, FBeamRequestContext& OutRequestContext, const UObject* CallingContext)
-{{
-	// AUTO-GENERATED...
-	FBeamRealmUser AuthenticatedUser;
-	Backend->BeamUserSlots->GetUserDataAtSlot(UserSlot, AuthenticatedUser, CallingContext);	
-
-	int64 OutRequestId;
-	BP_₢{nameof(SubsystemNamespacedEndpointName)}₢Impl(AuthenticatedUser.RealmHandle, RetryConfig, AuthenticatedUser.AuthToken, Backend->CurrentConnectivityStatus, Request, OnSuccess, OnError, OnComplete, OutRequestId);	
-	OutRequestContext = FBeamRequestContext{{OutRequestId, RetryConfig, AuthenticatedUser.RealmHandle, -1, UserSlot, None}}; 
-}}
-";
-
 	private const string BUILD_BODY_IMPLEMENTATION = @"ensureAlways(Body);
 
 	TUnrealJsonSerializer JsonSerializer = TJsonStringWriter<TCondensedJsonPrintPolicy<wchar_t>>::Create(&BodyString);
@@ -777,7 +791,7 @@ public:
 
 #undef LOCTEXT_NAMESPACE
 ";
-
+	
 	public const string BEAM_FLOW_BP_NODE_CPP = $@"
 
 #include ""BeamFlow/ApiRequest/AutoGen/₢{nameof(NamespacedOwnerServiceName)}₢/K2BeamNode_ApiRequest_₢{nameof(GlobalNamespacedEndpointName)}₢.h""
@@ -786,7 +800,7 @@ public:
 
 #include ""AutoGen/SubSystems/Beam₢{nameof(NamespacedOwnerServiceName)}₢Api.h""
 #include ""AutoGen/SubSystems/₢{nameof(NamespacedOwnerServiceName)}₢/₢{nameof(GlobalNamespacedEndpointName)}₢Request.h""
-#include ""AutoGen/₢{nameof(ResponseBodyNamespacedType)}₢.h""
+₢{nameof(_responseBodyIncludeStatement)}₢
 
 #define LOCTEXT_NAMESPACE ""K2BeamNode_ApiRequest_₢{nameof(GlobalNamespacedEndpointName)}₢""
 
@@ -849,6 +863,6 @@ FString UK2BeamNode_ApiRequest_₢{nameof(GlobalNamespacedEndpointName)}₢::Get
 
 #undef LOCTEXT_NAMESPACE
 ";
-
-
+	
+	
 }


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3347

# Brief Description

- Added function to first build a map tying specific semantic type declarations to the type we should be serializing that declaration when sending it over the wire.
- Added cases to serialization/deserialization functions to output the correct semantic type versions of serialize/deserialize.
- Fixed an issue that caused code-gen to fail to spot optional/wrappers/semantic types for types whose name we override during the code-gen type transformation.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
