### PR TITLE
beam 3372 - add support for federated inventory in sdk

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Microservices with `IFederatedLogin<T>` will generate client callable methods.
+- Microservices with `IFederatedInventory<T>` will generate client callable methods.
+
+### Fixed
+- Empty dictionary of supported subtypes no longer break request serialization.
 
 ## [1.10.3]
 ### Fixed

--- a/client/Packages/com.beamable.server/SharedRuntime/ClientCodeGenerator.cs
+++ b/client/Packages/com.beamable.server/SharedRuntime/ClientCodeGenerator.cs
@@ -108,6 +108,7 @@ namespace Beamable.Server.Generator
 
 			AddServiceNameInterface();
 			AddFederatedLoginInterfaces();
+			AddFederatedInventoryInterfaces();
 
 			var registrationMethod = new CodeMemberMethod
 			{
@@ -190,6 +191,21 @@ namespace Beamable.Server.Generator
 				{
 					var genericType = type.GetGenericArguments()[0];
 					var baseReference = new CodeTypeReference(typeof(ISupportsFederatedLogin<>));
+					baseReference.TypeArguments.Add(new CodeTypeReference(genericType));
+					targetClass.BaseTypes.Add(baseReference);
+				}
+			}
+		}
+		
+		void AddFederatedInventoryInterfaces()
+		{
+			var interfaces = Descriptor.Type.GetInterfaces();
+			foreach (var type in interfaces)
+			{
+				if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IFederatedInventory<>))
+				{
+					var genericType = type.GetGenericArguments()[0];
+					var baseReference = new CodeTypeReference(typeof(ISupportsFederatedInventory<>));
 					baseReference.TypeArguments.Add(new CodeTypeReference(genericType));
 					targetClass.BaseTypes.Add(baseReference);
 				}

--- a/client/Packages/com.beamable/Common/Runtime/ThirdPartyCloudIdentity.cs
+++ b/client/Packages/com.beamable/Common/Runtime/ThirdPartyCloudIdentity.cs
@@ -1,6 +1,10 @@
 using Beamable.Common.Api.Auth;
+using Beamable.Common.Api.Inventory;
 using Beamable.Common.Dependencies;
+using Beamable.Common.Content;
 using BeamableReflection;
+using System;
+using System.Collections.Generic;
 
 namespace Beamable.Common
 {
@@ -23,11 +27,44 @@ namespace Beamable.Common
 		Promise<FederatedAuthenticationResponse> Authenticate(string token, string challenge, string solution);
 	}
 
+	public interface IFederatedInventory<in T> : IFederatedLogin<T> where T : IThirdPartyCloudIdentity, new()
+	{
+		Promise<FederatedInventoryProxyState> GetInventoryState(string id);
+
+		Promise<FederatedInventoryProxyState> StartInventoryTransaction(
+			string id,
+			string transaction,
+			Dictionary<string, long> currencies,
+			List<ItemCreateRequest> newItems);
+	}
+
+	[Serializable]
 	public class FederatedAuthenticationResponse : ExternalAuthenticationResponse
 	{
 		// exists for typing purposes.
 	}
 
+	[Serializable]
+	public class FederatedInventoryCurrency
+	{
+		public string name;
+		public long value;
+	}
+	
+	[Serializable]
+	public class FederatedInventoryProxyState
+	{
+		public Dictionary<string, long> currencies;
+		public Dictionary<string, List<FederatedItemProxy>> items;
+	}
+
+	[Serializable]
+	public class FederatedItemProxy
+	{
+		public string proxyId;
+		public List<ItemProperty> properties;
+	}
+	
 	public interface IHaveServiceName
 	{
 		string ServiceName { get; }
@@ -36,5 +73,11 @@ namespace Beamable.Common
 	public interface ISupportsFederatedLogin<T> : IHaveServiceName where T : IThirdPartyCloudIdentity, new()
 	{
 		IDependencyProvider Provider { get; }
+	}
+
+	public interface ISupportsFederatedInventory<T> : ISupportsFederatedLogin<T>
+		where T : IThirdPartyCloudIdentity, new()
+	{
+		
 	}
 }

--- a/microservice/beamable.tooling.common/UnityJsonContractResolver.cs
+++ b/microservice/beamable.tooling.common/UnityJsonContractResolver.cs
@@ -20,6 +20,7 @@ namespace Beamable.Server.Common
 				new StringToSomethingDictionaryConverter<int>(),
 				new StringToSomethingDictionaryConverter<long>(),
 				new StringToSomethingDictionaryConverter<CurrencyPropertyList>(),
+				new StringToSomethingDictionaryConverter<List<FederatedItemProxy>>(),
 
 				// THIS MUST BE LAST, because it is hacky, and falls back onto other converts as its _normal_ behaviour. If its not last, then other converts can run twice, which causes newtonsoft to explode.
 				new UnitySerializationCallbackInvoker(),
@@ -82,17 +83,27 @@ namespace Beamable.Server.Common
 
 		    SerializableDictionaryStringToSomething<T> HandleObjectVariant()
 		    {
-			    var keysAndValues = serializer.Deserialize<KeysAndValues>(reader);
-			    if (keysAndValues.keys.Length != keysAndValues.values.Length)
+			    try
 			    {
-				    BeamableLogger.LogWarning($"Deserializing dictionary but keys and values were different values. keyCount=[{keysAndValues.keys.Length}] valueCount=[{keysAndValues.values.Length}]");
-			    }
-			    for (var i = 0; i < keysAndValues.keys.Length && i < keysAndValues.values.Length; i++)
-			    {
-				    instance[keysAndValues.keys[i]] = keysAndValues.values[i];
-			    }
+				    var keysAndValues = serializer.Deserialize<KeysAndValues>(reader);
+				    if (keysAndValues.keys.Length != keysAndValues.values.Length)
+				    {
+					    BeamableLogger.LogWarning(
+						    $"Deserializing dictionary but keys and values were different values. keyCount=[{keysAndValues.keys.Length}] valueCount=[{keysAndValues.values.Length}]");
+				    }
 
-			    return instance;
+				    for (var i = 0; i < keysAndValues.keys.Length && i < keysAndValues.values.Length; i++)
+				    {
+					    instance[keysAndValues.keys[i]] = keysAndValues.values[i];
+				    }
+
+				    return instance;
+			    }
+			    catch (Exception ex)
+			    {
+				    BeamableLogger.LogError($"Failed to deserialize map type type=[{ex.GetType().Name}] message=[{ex.Message}] stack=[{ex.StackTrace}]");
+				    throw;
+			    }
 		    }
 
 		    return reader.TokenType == JsonToken.StartArray
@@ -108,8 +119,8 @@ namespace Beamable.Server.Common
 
 	    public class KeysAndValues
 	    {
-		    public string[] keys;
-		    public T[] values;
+		    public string[] keys = Array.Empty<string>();
+		    public T[] values = Array.Empty<T>();
 	    }
     }
 

--- a/microservice/microservice/dbmicroservice/BeamableMicroService.cs
+++ b/microservice/microservice/dbmicroservice/BeamableMicroService.cs
@@ -309,7 +309,8 @@ namespace Beamable.Server
 	      ServiceMethods = ServiceMethodHelper.Scan(_serviceAttribute,
 		      new ICallableGenerator[]
 		      {
-			      new FederatedLoginCallableGenerator()
+			      new FederatedLoginCallableGenerator(),
+			      new FederatedInventoryCallbackGenerator()
 		      },
 		      new ServiceMethodProvider
 		      {


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3372

# Brief Description
Like `IFederatedLogin<T>`, we need a `IFederatedInventory<T>`, and now we do!
1. this pretty much just piggy backs off the `IFederatedLogin<T>` work. I didn't try to overgeneralize a few places in the PR because I'm following the 1-2-3 rule of thumb for generalization, which is, "don't generalize until you have 3 instances of a thing". 
2. I fixed a bug with empty dictionary serialization.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
