### PR TITLE
beam 3373 - federation validation

### DIFF
--- a/client/Packages/com.beamable/Common/Runtime/Content/Validation/FederationMustBeValid.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Content/Validation/FederationMustBeValid.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Linq;
+using static Beamable.Common.Constants.Features.Content;
+
+namespace Beamable.Common.Content.Validation
+{
+	public class FederationMustBeValid : ValidationAttribute
+	{
+		public override void Validate(ContentValidationArgs args)
+		{
+			var field = args.ValidationField;
+			var obj = args.Content;
+
+
+			if (typeof(OptionalFederation) == field.FieldType)
+			{
+				var fieldValue = field.GetValue() as OptionalFederation;
+				if (!fieldValue.HasValue) return;
+				Validate(args, fieldValue.Value);
+				return;
+			}
+
+			if (typeof(Federation) == field.FieldType)
+			{
+				var fieldValue = field.GetValue() as Federation;
+				Validate(args, fieldValue);
+				return;
+			}
+			
+			throw new ContentValidationException(obj, field, $"{nameof(FederationMustBeValid)} is only valid on {nameof(Federation)}");
+		}
+
+		void Validate(ContentValidationArgs args, Federation federation)
+		{
+			if (string.IsNullOrEmpty(federation.Service))
+			{
+				throw new ContentValidationException(args.Content, args.ValidationField, $"Microservice cannot be empty");
+			}
+
+			if (string.IsNullOrEmpty(federation.Namespace))
+			{
+				throw new ContentValidationException(args.Content, args.ValidationField, $"Namespace cannot be empty");
+			}
+			
+			
+			if (federation.Service.EndsWith(MISSING_SUFFIX))
+			{
+				throw new ContentValidationException(args.Content, args.ValidationField, $"Microservice must exist");
+			}
+			if (federation.Namespace.EndsWith(MISSING_SUFFIX))
+			{
+				throw new ContentValidationException(args.Content, args.ValidationField, $"Namespace must exist");
+
+			}
+		}
+	}
+}

--- a/client/Packages/com.beamable/Common/Runtime/Content/Validation/FederationMustBeValid.cs.meta
+++ b/client/Packages/com.beamable/Common/Runtime/Content/Validation/FederationMustBeValid.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 715e373fc40f4942814bdea5f94d9cb7
+timeCreated: 1674674293

--- a/client/Packages/com.beamable/Common/Runtime/Modules/Inventory/CurrencyContent.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Modules/Inventory/CurrencyContent.cs
@@ -44,6 +44,7 @@ namespace Beamable.Common.Inventory
 
 		[ContentField("external")]
 		[Tooltip(TooltipFederation)]
+		[FederationMustBeValid]
 		public OptionalFederation federation;
 	}
 

--- a/client/Packages/com.beamable/Common/Runtime/Modules/Inventory/ItemContent.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Modules/Inventory/ItemContent.cs
@@ -38,6 +38,7 @@ namespace Beamable.Common.Inventory
 
 		[ContentField("external")]
 		[Tooltip(TooltipFederation)]
+		[FederationMustBeValid]
 		public OptionalFederation federation;
 	}
 


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3373

# Brief Description
Drazen saw this bug
![image](https://user-images.githubusercontent.com/3848374/214669078-51a6dc9d-edb8-4acb-8d7b-aa2089282e95.png)

I wasn't able to reproduce it, but this PR does add validation for the the federation field, so that you must have a microservice and a namespace. 

He also brought up a good workflow point that you can specify a servce/namespace field that don't match. Really, we should only allow namespace selection from Microservices that implement the given namespace

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
