### PR TITLE
beam 3398 - fix asset post processor

### DIFF
--- a/client/Packages/com.beamable.server/Editor/BeamServiceAssemblyPostprocessor.cs
+++ b/client/Packages/com.beamable.server/Editor/BeamServiceAssemblyPostprocessor.cs
@@ -1,5 +1,4 @@
-﻿using JetBrains.Annotations;
-using System.IO;
+﻿using System.IO;
 using UnityEditor;
 using UnityEngine;
 
@@ -9,12 +8,28 @@ namespace Beamable.Server.Editor
 	{
 		const string EXTENSION = "asmdef";
 
-		[UsedImplicitly]
+#if UNITY_2021_1_OR_NEWER
 		static void OnPostprocessAllAssets(string[] importedAssets,
-										   string[] deletedAssets,
-										   string[] movedAssets,
-										   string[] movedFromAssetPaths,
-										   bool didDomainReload)
+		                                   string[] deletedAssets,
+		                                   string[] movedAssets,
+		                                   string[] movedFromAssetPaths,
+		                                   bool _
+
+		)
+		{
+			Process(importedAssets);
+		}
+#else
+		static void OnPostprocessAllAssets(string[] importedAssets,
+		                                   string[] deletedAssets,
+		                                   string[] movedAssets,
+		                                   string[] movedFromAssetPaths)
+		{
+			Process(importedAssets);
+		}
+#endif
+		
+		static void Process(string[] importedAssets) 
 		{
 			var serviceRegistry = BeamEditor.GetReflectionSystem<MicroserviceReflectionCache.Registry>();
 			foreach (string importedAsset in importedAssets)


### PR DESCRIPTION
# Ticket

# Brief Description

My hunch is that this PR from 
[@piotr](https://disruptorbeam.slack.com/team/U026RJSED0U)
,
https://github.com/beamable/BeamableProduct/pull/2062
 introduces this issue-
The docs for that function in 2019.4 (and 2020) only include 4 method parameters...
https://docs.unity3d.com/2019.4/Documentation/ScriptReference/AssetPostprocessor.OnPostprocessAllAssets.html
But in 2021, it has has 5.
https://docs.unity3d.com/2021.3/Documentation/ScriptReference/AssetPostprocessor.OnPostprocessAllAssets.html
hence, the "TargetParameterCountException: Number of parameters specified does not match the expected number." bug error.

---
This PR just adds a pound-def for the unity version...

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
