### PR TITLE
[BEAM-3369] Infinite loop fix for GetCredentialState in SignWithApple.cs

### DIFF
--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Auth/SignInWithApple.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Auth/SignInWithApple.cs
@@ -145,7 +145,7 @@ namespace Beamable.Platform.SDK.Auth
             }
             s_CredentialStateCallback = callback;
 
-            GetCredentialState(userID);
+            GetCredentialStateInternal(userID);
         }
 
         private void GetCredentialStateInternal(string userID)


### PR DESCRIPTION
# Ticket

Our implementation (which is based on old official Unity solution) had a bug with infinite loop in GetCredentialState method. (More info and solution based on here: https://forum.unity.com/threads/does-unity-plan-to-support-sign-in-with-apple-as-a-part-of-the-social-api.746615/)



# Brief Description

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
