### PR TITLE
[BEAM-3361] Disabled sweep for test microservice and microstorage in BEAMABLE_DEVELOPER mode. 

### DIFF
--- a/client/Packages/com.beamable/Runtime/Modules/CoreConfiguration.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/CoreConfiguration.cs
@@ -183,7 +183,9 @@ namespace Beamable
 
 			for (int i = 0; i < AssembliesToSweep.Count; i++)
 			{
-				if (AssembliesToSweep[i].Contains("Test"))
+				if (AssembliesToSweep[i].Contains("Test") &&
+				    !AssembliesToSweep[i].Contains("Beamable.Microservice") &&
+				    !AssembliesToSweep[i].Contains("Beamable.Storage"))
 				{
 					AssembliesToSweep.RemoveAt(i);
 					i--;


### PR DESCRIPTION
# Ticket

Small tweak based on dev tests when BEAMABLE_DEVELOPERS can't create microservices and storages with any name etc.

# Brief Description

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
