### PR TITLE
Fix IThirdPartyCloudIdentity resolving service namespace/uniqueName

### DIFF
--- a/client/Packages/com.beamable.server/Runtime/ThirdPartyFederatedLoginExtensions.cs
+++ b/client/Packages/com.beamable.server/Runtime/ThirdPartyFederatedLoginExtensions.cs
@@ -1,35 +1,51 @@
 using Beamable.Common;
 using Beamable.Common.Api.Auth;
+using Beamable.Common.Runtime.Collections;
+using System;
 
 namespace Beamable.Server
 {
 	public static class ThirdPartyFederatedLoginExtensions
 	{
+		private static readonly ConcurrentDictionary<Type, string> ServiceNamespaceCache = new ConcurrentDictionary<Type, string>();
 
-		public static Promise<AttachExternalIdentityResponse> AttachIdentity<T>(this ISupportsFederatedLogin<T> client, string token, ChallengeSolution solution = null)
-			where T : IThirdPartyCloudIdentity, new()
+		private static string GetServiceNamespace<T>() where T : IThirdPartyCloudIdentity, new()
 		{
-			var identity = client.Provider.GetService<T>();
-			var api = client.Provider.GetService<IAuthApi>();
-			return api.AttachIdentity(token, client.ServiceName, identity.UniqueName, solution);
+			return ServiceNamespaceCache.GetOrAdd(typeof(T), _ => new T().UniqueName);
 		}
 
-		public static Promise<DetachExternalIdentityResponse> DetachIdentity<T>(this ISupportsFederatedLogin<T> client, string userId)
+		public static Promise<AttachExternalIdentityResponse> AttachIdentity<T>(
+			this ISupportsFederatedLogin<T> client,
+			string token,
+			ChallengeSolution solution = null)
 			where T : IThirdPartyCloudIdentity, new()
 		{
-			var identity = client.Provider.GetService<T>();
+			var serviceNamespace = GetServiceNamespace<T>();
 			var api = client.Provider.GetService<IAuthApi>();
-			return api.DetachIdentity(client.ServiceName, userId, identity.UniqueName);
+			return api.AttachIdentity(token, client.ServiceName, serviceNamespace, solution);
 		}
 
-		public static Promise<ExternalAuthenticationResponse> AuthorizeExternalIdentity<T>(this ISupportsFederatedLogin<T> client, string token, ChallengeSolution solution = null)
+		public static Promise<DetachExternalIdentityResponse> DetachIdentity<T>(
+			this ISupportsFederatedLogin<T> client,
+			string userId)
 			where T : IThirdPartyCloudIdentity, new()
 		{
-			var identity = client.Provider.GetService<T>();
+			var serviceNamespace = GetServiceNamespace<T>();
+			var api = client.Provider.GetService<IAuthApi>();
+			return api.DetachIdentity(client.ServiceName, userId, serviceNamespace);
+		}
+
+		public static Promise<ExternalAuthenticationResponse> AuthorizeExternalIdentity<T>(
+			this ISupportsFederatedLogin<T> client,
+			string token,
+			ChallengeSolution solution = null)
+			where T : IThirdPartyCloudIdentity, new()
+		{
+			var serviceNamespace = GetServiceNamespace<T>();
 			var api = client.Provider.GetService<IAuthApi>();
 			return api.AuthorizeExternalIdentity(token, client.ServiceName,
-												 identity.UniqueName,
-																 solution);
+			                                     serviceNamespace,
+			                                     solution);
 		}
 	}
 }

--- a/client/Packages/com.beamable/Common/Runtime/Collections/ConcurrentDictionary.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Collections/ConcurrentDictionary.cs
@@ -2,6 +2,7 @@
 #define DISABLE_THREADING
 #endif
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -37,6 +38,7 @@ namespace Beamable.Common.Runtime.Collections
 		public IEnumerable<TValue> Values => _internal.Values;
 		public void Clear() => _internal.Clear();
 		public bool TryGetValue(TKey key, out TValue value) => _internal.TryGetValue(key, out value);
+		public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory) => _internal.GetOrAdd(key, valueFactory);
 
 		public TValue this[TKey key]
 		{
@@ -50,7 +52,6 @@ namespace Beamable.Common.Runtime.Collections
 		IEnumerator IEnumerable.GetEnumerator() => _internal.GetEnumerator();
 
 		public bool Remove(TKey key) => _internal.TryRemove(key, out _);
-
 #else
       private Dictionary<TKey, TValue> _internal = new Dictionary<TKey, TValue>();
       public bool ContainsKey(TKey key) => _internal.ContainsKey(key);
@@ -70,6 +71,15 @@ namespace Beamable.Common.Runtime.Collections
       public void Clear() => _internal.Clear();
 
       public bool TryGetValue(TKey key, out TValue value) => _internal.TryGetValue(key, out value);
+      public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory) {
+        TValue value;
+        if (!_internal.TryGetValue(key, out value))
+        {
+          value = valueFactory(key);
+          _internal.Add(key, value);
+        }
+        return value;
+      }
 
       public int Count => _internal.Count;
       public IEnumerable<TValue> Values => _internal.Values;


### PR DESCRIPTION
# Brief Description
IThirdPartyCloudIdentity implementations are not available as a registered dependency. We need to create a new instance manually and cache it to avoid a lot of allocations.
 
