### PR TITLE
check for dir and templates before new solution

### DIFF
--- a/cli/cli/Services/ProjectService.cs
+++ b/cli/cli/Services/ProjectService.cs
@@ -45,9 +45,21 @@ public class ProjectService
 		var projectPath = Path.Combine(rootServicesPath, projectName);
 		var commonProjectPath = Path.Combine(rootServicesPath, commonProjectName);
 	
-		// TODO: automatically install Beam.Templates if not installed... 
+		if (Directory.Exists(solutionPath))
+		{
+			throw new CliException("Cannot create a solution because the directory already exists");
+		}
 		
-		// TODO: if the folder already exists, fail the command. 
+		// check that we have the templates available
+		var canUseTemplates = await Cli.Wrap("dotnet")
+			.WithArguments($"new list --tag beamable")
+			.WithValidation(CommandResultValidation.None)
+			.ExecuteAsync().Select(res => res.ExitCode == 0).Task;
+
+		if (!canUseTemplates)
+		{
+			throw new CliException("Cannot access Beamable.Templates dotnet templates. Please install the Beamable templates and try again.");
+		}
 		
 		// create the solution
 		await Cli.Wrap($"dotnet")


### PR DESCRIPTION
Before allowing the user to make a new .sln, check that
1. the folder is valid, 
2. the user has the beamable templates installed. 

When the template is hosted on nuget, we can update the CLI to offer an automatic install