### PR TITLE
[BEAM-3391] Fix for not initialized BeamableEditor error in Postprocessor class after beamable installation.

### DIFF
--- a/client/Packages/com.beamable.server/Editor/BeamServiceAssemblyPostprocessor.cs
+++ b/client/Packages/com.beamable.server/Editor/BeamServiceAssemblyPostprocessor.cs
@@ -31,6 +31,11 @@ namespace Beamable.Server.Editor
 		
 		static void Process(string[] importedAssets) 
 		{
+			if (!BeamEditor.IsInitialized)
+			{
+				return;
+			}
+			
 			var serviceRegistry = BeamEditor.GetReflectionSystem<MicroserviceReflectionCache.Registry>();
 			foreach (string importedAsset in importedAssets)
 			{


### PR DESCRIPTION
# Ticket

Fix for case when we've just install Beamable SDK and we are not logged to BEAMABLE -> error with not initialized BeamableEditor and EditorReflectionCache.

# Brief Description

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
