### PR TITLE
[BEAM-3409] C#MS Publish Flow - When service is Local&Remote should only care about enable state instead of rebuilding

### DIFF
--- a/client/Packages/com.beamable.server/Editor/ReflectionCache/UserSystems/MicroserviceReflectionCache.cs
+++ b/client/Packages/com.beamable.server/Editor/ReflectionCache/UserSystems/MicroserviceReflectionCache.cs
@@ -443,6 +443,10 @@ namespace Beamable.Server.Editor
 				var availableArchitectures = await new GetBuildOutputArchitectureCommand().StartAsync();
 				foreach (var descriptor in Descriptors)
 				{
+					var entryModel = model.Services[descriptor.Name];
+					if (entryModel.Archived || !entryModel.Enabled)
+						continue;
+					
 					var forceStop = new StopImageReturnableCommand(descriptor);
 					await forceStop.StartAsync(); // force the image to stop.
 					await BeamServicesCodeWatcher.StopClientSourceCodeGenerator(descriptor); // force the generator to stop.
@@ -475,6 +479,10 @@ namespace Beamable.Server.Editor
 
 				foreach (var descriptor in Descriptors)
 				{
+					var entryModel = model.Services[descriptor.Name];
+					if (entryModel.Archived || !entryModel.Enabled)
+						continue;
+					
 					OnProgressInfoUpdated?.Invoke($"[{descriptor.Name}] Verifying healthcheck", ServicePublishState.Verifying);
 					UpdateServiceDeployStatus(descriptor, ServicePublishState.Verifying);
 					try
@@ -583,7 +591,6 @@ namespace Beamable.Server.Editor
 				foreach (var descriptor in Descriptors)
 				{
 					var entryModel = model.Services[descriptor.Name];
-					
 					if (entryModel.Archived || !entryModel.Enabled)
 						continue;
 

--- a/client/Packages/com.beamable.server/Editor/UI/Components/PublishManifestEntryVisualElement/PublishManifestEntryVisualElement.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/PublishManifestEntryVisualElement/PublishManifestEntryVisualElement.cs
@@ -182,7 +182,7 @@ namespace Beamable.Editor.Microservice.UI.Components
 			switch (state)
 			{
 				case ServicePublishState.Failed:
-					_loadingBar.UpdateProgress(0, failed: true);
+					_loadingBar.UpdateProgress(1, failed: true);
 					_stateLabel.AddToClassList("error");
 					_stateLabel.text = "FAILED";
 					return;

--- a/client/Packages/com.beamable.server/Editor/UI/Components/PublishPopup/PublishPopup.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/PublishPopup/PublishPopup.cs
@@ -261,7 +261,7 @@ namespace Beamable.Editor.Microservice.UI.Components
 				if (serviceModel.IsArchived)
 					continue;
 
-				if (serviceModel is MongoStorageModel || (kvp.Value.IsRemote && !kvp.Value.IsLocal))
+				if (serviceModel is MongoStorageModel || !kvp.Value.Model.Enabled || (kvp.Value.IsRemote && !kvp.Value.IsLocal))
 				{
 					kvp.Value.UpdateStatus(ServicePublishState.Published);
 					continue;


### PR DESCRIPTION
# [Ticket](https://disruptorbeam.atlassian.net/browse/BEAM-3409)

# Brief Description

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
