### PR TITLE
beam 3430 - errors for external auth

### DIFF
--- a/client/Packages/com.beamable/Runtime/Player/PlayerAccounts.cs
+++ b/client/Packages/com.beamable/Runtime/Player/PlayerAccounts.cs
@@ -753,6 +753,8 @@ namespace Beamable.Player
 	[Serializable]
 	public class PlayerRecoveryOperation
 	{
+		private Exception _innerException;
+
 		/// <summary>
 		/// If an error occured while attempting to recovery a <see cref="PlayerAccount"/>,
 		/// then this value will be anything other than <see cref="PlayerRecoveryError.NONE"/>.
@@ -790,7 +792,7 @@ namespace Beamable.Player
 					return _account;
 				}
 
-				throw new PlayerRecoveryException(error);
+				throw GetException();
 			}
 			set => _account = value;
 		}
@@ -804,6 +806,27 @@ namespace Beamable.Player
 		{
 			await account.SwitchToAccount();
 		}
+
+		public PlayerRecoveryOperation()
+		{
+			
+		}
+
+		public PlayerRecoveryOperation(Exception ex, PlayerRecoveryError error)
+		{
+			this.error = error;
+			_innerException = ex;
+		}
+
+		/// <summary>
+		/// This function will create an <see cref="PlayerRecoveryException"/> instance that contains the error code
+		/// and any inner exception.
+		/// </summary>
+		/// <returns></returns>
+		public PlayerRecoveryException GetException()
+		{
+			return new PlayerRecoveryException(error, _innerException);
+		}
 	}
 
 
@@ -815,14 +838,14 @@ namespace Beamable.Player
 
 		public PlayerRecoveryError Error { get; }
 
-		public PlayerRecoveryException(PlayerRecoveryError error)
-			: base($"The recovery failed. error=[{error}]")
+		public PlayerRecoveryException(PlayerRecoveryError error, Exception innerException=null)
+			: base($"The recovery failed. error=[{error}]", innerException)
 		{
 			Error = error;
 		}
 
-		public PlayerRecoveryException(PlayerRecoveryError error, string message)
-			: base($"The recovery failed. error=[{error}] message=[{message}]")
+		public PlayerRecoveryException(PlayerRecoveryError error, string message, Exception innerException=null)
+			: base($"The recovery failed. error=[{error}] message=[{message}]", innerException)
 		{
 			
 		}
@@ -891,7 +914,12 @@ namespace Beamable.Player
 		/// <summary>
 		/// Represents that the given recovery did not specify enough information to login 
 		/// </summary>
-		INSUFFICIENT_DATA
+		INSUFFICIENT_DATA,
+		
+		/// <summary>
+		/// Represents that the given recovery did not work, but the error isn't classified. 
+		/// </summary>
+		UNKNOWN_ERROR
 	}
 
 	/// <summary>
@@ -1141,13 +1169,13 @@ namespace Beamable.Player
 					res = await loginFunction(_authService, false);
 				}
 			}
-			catch (PlayerRecoveryException)
+			catch (PlayerRecoveryException ex)
 			{
-				return new PlayerRecoveryOperation { error = PlayerRecoveryError.INSUFFICIENT_DATA };
+				return new PlayerRecoveryOperation(ex, PlayerRecoveryError.INSUFFICIENT_DATA);
 			}
-			catch (PlatformRequesterException)
+			catch (Exception ex)
 			{
-				return new PlayerRecoveryOperation { error = PlayerRecoveryError.UNKNOWN_CREDENTIALS };
+				return new PlayerRecoveryOperation(ex, PlayerRecoveryError.UNKNOWN_ERROR);
 			}
 
 			var user = await _authService.GetUser(res);


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3430

# Brief Description
Now, there is an `innerException` set that can be used to see what the actual error was. 
![image](https://user-images.githubusercontent.com/3848374/217593258-8212d7c4-54da-43ab-ae26-24394129e539.png)
```csharp
	public PlayerRecoveryOperation exampleOp;
		[ContextMenu("error example")]
		public async void ErrorExample()
		{
			var ctx = await BeamContext.Default.Instance;
			exampleOp = await ctx.Accounts.RecoverAccountWithExternalIdentity<ExampleCloudIdentity, HotTunaClient>(
				"doesntExist", challenge => "x");

			var ex = exampleOp.GetException();
			
			
		}
		```


# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
