### PR TITLE
beam 3426 - federated endpoints require admin scopes

### DIFF
--- a/microservice/microservice/dbmicroservice/CallableAdapter.cs
+++ b/microservice/microservice/dbmicroservice/CallableAdapter.cs
@@ -58,7 +58,7 @@ public class FederatedInventoryCallbackGenerator : ICallableGenerator
 					path,
 					tag,
 					false,
-					new HashSet<string>(),
+					new HashSet<string>(new []{"*"}),
 					method);
 
 				output.Add(serviceMethod);
@@ -111,7 +111,7 @@ public class FederatedLoginCallableGenerator : ICallableGenerator
 				path,
 				tag,
 				false,
-				new HashSet<string>(),
+				new HashSet<string>(new []{"*"}),
 				method);
 
 			output.Add(serviceMethod);


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3426

# Brief Description
The client-callables for federated endpoints need to require admin scopes, but not require a user.
The methods already _didn't_ require a user, but this PR updates the required scopes.


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
