### PR TITLE
Marco's debug stack trace

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `PlayerInventory` no longer duplicates items if retrieved with multiple `GetItems()` calls.
-- `PlayerInventory` makes less read calls to Beamable Cloud by coupling read operations into batches every .3 seconds.
 - Multiple calls to `PlayerInventory.Update()` will operate serially instead of compete for priority. 
 - Update banner in Toolbox will link to changelog instead of blog post.
 - Refactored `BeamContext` initialization logic.
@@ -30,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Duplicate content is now displayed immediately in `Content Manager`
 - Update banner in Toolbox will update both `com.beamable` and `com.beamable.server` package. 
 - Fixed issues with wrong content status and checksum on domain reload.
+- `FilePathSelectorAttribute` no longer accesses `Application` in constructor.
 
 ## [1.10.3]
 ### Changed

--- a/client/Packages/com.beamable/Common/Runtime/Content/PropertyAttributes/FilePathSelectorAttribute.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Content/PropertyAttributes/FilePathSelectorAttribute.cs
@@ -7,13 +7,12 @@ namespace Beamable.Common.Content
 		public string DialogTitle;
 		public bool OnlyFiles;
 		public string FileExtension;
-		public string RootFolder;
+		public string RootFolder => Application.dataPath;
 		public string PathRelativeTo;
 
 		public FilePathSelectorAttribute(bool absolutePath = false)
 		{
 #if UNITY_EDITOR
-			RootFolder = Application.dataPath;
 			PathRelativeTo = absolutePath ? null : RootFolder;
 #endif
 		}


### PR DESCRIPTION
Marco had this stack trace that pointed back to a bad thread access to `Application`. It happened in this constructor. This constructor only gets referenced when the `CoreConfiguration` is opened; so
1. something must be touching `CoreConfiguration` outside of the main thread. We don't do that (to my knowledge), but maybe they are. 
2. Anyway, we can just move this to be a computed property anyway. 

Maybe this will solve their problem, or maybe their issue is much much much bigger than this. If so, we'll need more stacks and project details to pin it down.