### PR TITLE
remove extra generic stuff for color props

### DIFF
--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/Styles/BussStyle_Operators.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/Styles/BussStyle_Operators.cs
@@ -15,16 +15,6 @@ namespace Beamable.UI.Buss
 			  .AddOperator<FloatMinOperation>()
 			  .AddOperator<FloatAddOperation>();
 		
-		public static BussOperatorBinding<IVertexColorBussProperty> IColorBussOperators
-			= new BussOperatorBinding<IVertexColorBussProperty>()
-			  .AddOperator<ColorFadeOperation>()
-			  .AddOperator<ColorDesaturateOperation>()
-			  .AddOperator<ColorSaturateOperation>()
-			  .AddOperator<ColorLightenOperation>()
-			  .AddOperator<ColorDarkenOperation>()
-			  .AddOperator<ColorSpinOperation>()
-			  .AddOperator<SingleColorToMultiColorOperation>();
-
 		public static BussOperatorBinding<VertexColorBussProperty> VertexColorBussOperators
 			= new BussOperatorBinding<VertexColorBussProperty>()
 			  .AddOperator<ColorFadeOperation>()

--- a/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/Styles/Properties/ComputedColorOperations.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/Buss/Styles/Properties/ComputedColorOperations.cs
@@ -74,7 +74,6 @@ namespace Beamable.UI.Buss
 	[Serializable]
 	public class SingleColorToMultiColorOperation : 
 		IVertexColorBussProperty,
-		IComputedProperty<IVertexColorBussProperty>,
 		IComputedProperty<VertexColorBussProperty>
 	{
 		
@@ -154,8 +153,6 @@ namespace Beamable.UI.Buss
 	public abstract class SingleColorAndFloatOperation : 
 		IColorBussProperty, 
 		IVertexColorBussProperty,
-		IComputedProperty<IColorBussProperty>,
-		IComputedProperty<IVertexColorBussProperty>,
 		IComputedProperty<SingleColorBussProperty>,
 		IComputedProperty<VertexColorBussProperty>
 	{
@@ -203,11 +200,6 @@ namespace Beamable.UI.Buss
 			return new SingleColorBussProperty(val); 
 		}
 		
-		
-		IColorBussProperty IComputedProperty<IColorBussProperty>.GetComputedValue(BussStyle style)
-		{
-			return ComputeSingle(style);
-		}
 
 		public IVertexColorBussProperty GetComputedValue(BussStyle style)
 		{


### PR DESCRIPTION
# Ticket

# Brief Description

In a CR with Tomasz, we found that we didn't need as mush generic nonsense as I thought. We'd removed it for Float operators; this removes it for Color operators

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
