### PR TITLE
dont hover on sub labels

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StylePropertyVisualElement/StylePropertyVisualElement.dark.uss
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StylePropertyVisualElement/StylePropertyVisualElement.dark.uss
@@ -1,3 +1,4 @@
+ComputedBussPropertyVisualElement #propertyLabel:hover,
 #propertyLabel {
     color: rgb(255, 255, 255);
 }

--- a/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StylePropertyVisualElement/StylePropertyVisualElement.light.uss
+++ b/client/Packages/com.beamable/Editor/UI/Buss/ThemeManager/StylePropertyVisualElement/StylePropertyVisualElement.light.uss
@@ -1,3 +1,4 @@
+ComputedBussPropertyVisualElement #propertyLabel:hover,
 #propertyLabel {
     color:rgba(0,0,0,1);
 }


### PR DESCRIPTION
# Ticket

# Brief Description
PR feedback, when you hover over these sub labels, they shouldn't have a darker hover interaction.
<img width="244" alt="image" src="https://user-images.githubusercontent.com/3848374/217941961-f70e0673-a618-4872-a552-ab1b16802bb5.png">


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
