### PR TITLE
[BEAM-3431] Added inner exception field to RegistrationResult

### DIFF
--- a/client/Packages/com.beamable/Runtime/Player/PlayerAccounts.cs
+++ b/client/Packages/com.beamable/Runtime/Player/PlayerAccounts.cs
@@ -597,6 +597,11 @@ namespace Beamable.Player
 	public class RegistrationResult
 	{
 		/// <summary>
+		/// Exception thrown by a server will be cached here
+		/// </summary>
+		public Exception innerException;
+		
+		/// <summary>
 		/// The type of error that occured, if <see cref="isSuccess"/> is false.
 		/// </summary>
 		public PlayerRegistrationError error;
@@ -626,7 +631,7 @@ namespace Beamable.Player
 					return _account;
 				}
 
-				throw new PlayerRegistrationException(error);
+				throw new PlayerRegistrationException(error, innerException);
 			}
 			set => _account = value;
 		}
@@ -859,8 +864,8 @@ namespace Beamable.Player
 
 		public PlayerRegistrationError Error { get; }
 
-		public PlayerRegistrationException(PlayerRegistrationError error)
-			: base($"The registration failed. error=[{error}]")
+		public PlayerRegistrationException(PlayerRegistrationError error, Exception innerException=null)
+			: base($"The registration failed. error=[{error}]", innerException)
 		{
 			Error = error;
 		}
@@ -1500,8 +1505,9 @@ namespace Beamable.Player
 				account.Update(user);
 				account.TryTriggerUpdate();
 			}
-			catch (PlatformRequesterException)
+			catch (PlatformRequesterException ex)
 			{
+				res.innerException = ex;
 				res.error = PlayerRegistrationError.CREDENTIAL_IS_ALREADY_TAKEN;
 				return res;
 			} 


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3431

# Brief Description
RegistrationResult class now can store a data about exception thrown by a platform. Usage has been implemented in try/catch
block while adding external identity.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
