### PR TITLE
[BEAM-3437] C#MS Publish Flow - Tooltip if SO is forced enabled 

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Components/PublishManifestEntryVisualElement/PublishManifestEntryVisualElement.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/PublishManifestEntryVisualElement/PublishManifestEntryVisualElement.cs
@@ -52,7 +52,8 @@ namespace Beamable.Editor.Microservice.UI.Components
 		private Label _stateLabel;
 		private Label _serviceName;
 		private VisualElement _knowLocationEntry;
-		
+		private VisualElement _enableColumn;
+
 		private string _currentPublishState;
 
 		private readonly int _index;
@@ -76,7 +77,6 @@ namespace Beamable.Editor.Microservice.UI.Components
 			{ "mongov1", "StorageObject" }
 		};
 
-
 		public PublishManifestEntryVisualElement(IEntryModel model,
 		                                         int elementIndex,
 		                                         bool isLocal,
@@ -97,6 +97,9 @@ namespace Beamable.Editor.Microservice.UI.Components
 			_loadingBar.Hidden = true;
 			_loadingBar.Refresh();
 
+			_enableColumn = Root.Q("enableC");
+			_enableColumn.tooltip = CHECKBOX_TOOLTIP;
+			
 			EnableState = Root.Q<BeamableCheckboxVisualElement>("enableState");
 			EnableState.Refresh();
 			UpdateEnableState(Model.Enabled);
@@ -152,12 +155,17 @@ namespace Beamable.Editor.Microservice.UI.Components
 			UpdateStatus(ServicePublishState.Unpublished);
 		}
 
-		public void UpdateEnableState(bool isEnabled, bool isSilentUpdate = false)
+		public void UpdateEnableState(bool isEnabled, bool isSilentUpdate = false, string additionalTooltip = "")
 		{
 			Model.Enabled = isEnabled;
 			EnableState.SetWithoutNotify(isEnabled); 
 			EnableState.EnableInClassList("enabled", isEnabled);
 			EnableState.EnableInClassList("disabled", !isEnabled);
+
+			var tooltip = CHECKBOX_TOOLTIP;
+			if (!string.IsNullOrWhiteSpace(additionalTooltip))
+				tooltip += $"\n\nOn/Off state is in fixed state due to:\n{additionalTooltip}";
+			_enableColumn.tooltip = tooltip;
 			
 			if (Model is ManifestEntryModel && !isSilentUpdate)
 				OnEnableStateChanged?.Invoke(Model);

--- a/client/Packages/com.beamable.server/Editor/UI/Components/PublishPopup/PublishPopup.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/PublishPopup/PublishPopup.cs
@@ -226,7 +226,7 @@ namespace Beamable.Editor.Microservice.UI.Components
 					if (service.Dependencies.Count != dependencies.Count)
 					{
 						x.EnableState.SetEnabled(false);
-						x.UpdateEnableState(false, true);
+						x.UpdateEnableState(false, true, CHECKBOX_TOOLTIP_ARCHIVED_STORAGE);
 						return;
 					}
 				}
@@ -300,7 +300,7 @@ namespace Beamable.Editor.Microservice.UI.Components
 				var isAnyDependentServiceEnabled = _storageDependsOnServiceRepresentation[storageEntryModel].Any(y => y.Enabled);
 				x.EnableState.SetEnabled(!isAnyDependentServiceEnabled);
 				if (isAnyDependentServiceEnabled)
-					x.UpdateEnableState(true);
+					x.UpdateEnableState(true, additionalTooltip: CHECKBOX_TOOLTIP_DEPENDENCY_ON_SERVICE);
 			});
 		}
 


### PR DESCRIPTION
# [Ticket](https://disruptorbeam.atlassian.net/browse/BEAM-3437)

# Brief Description

## Archived storage tooltip
![image](https://user-images.githubusercontent.com/18366601/218507576-bed7683f-ab6e-4fab-a5a1-bd635b42a68b.png)

## Depends on service state tooltip
![image](https://user-images.githubusercontent.com/18366601/218507996-87fb156f-1cb9-4ff4-a0ae-b92c3e24d527.png)


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
