### PR TITLE
beam 3452 - inventory event fix

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Expose Google Play Game Services `ForceRefreshToken` option and set it to `true` by default
 
+### Fixed
+- `PlayerInventory` triggers `OnDataUpdated` events.
+- `PlayerInventory` item properties can be `null` without throwing a `NullReferenceException`.
+
 ## [1.11.0]
 ### Added
 - `PlayerInventory` supports storing player's inventory in offline mode

--- a/client/Packages/com.beamable/Common/Runtime/Player/Observables.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Player/Observables.cs
@@ -343,6 +343,7 @@ namespace Beamable.Common.Player
 			{
 				OnElementsAdded?.Invoke(added);
 			}
+			TriggerUpdate();
 		}
 
 		// public override object GetData() => _data;

--- a/client/Packages/com.beamable/Runtime/Player/PlayerItemGroup.cs
+++ b/client/Packages/com.beamable/Runtime/Player/PlayerItemGroup.cs
@@ -110,8 +110,8 @@ namespace Beamable.Player
 			var hash = 0;
 			foreach (var kvp in Properties)
 			{
-				hash = CombineHashCodes(hash, kvp.Key.GetHashCode());
-				hash = CombineHashCodes(hash, kvp.Value.GetHashCode());
+				hash = CombineHashCodes(hash, kvp.Key?.GetHashCode() ?? 1);
+				hash = CombineHashCodes(hash, kvp.Value?.GetHashCode() ?? 1 );
 			}
 
 			hash = CombineHashCodes(hash, UpdatedAt.GetHashCode());


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3452

# Brief Description

1. When I refactored the PSDK, I removed the old code where it called `TriggerUpdate` by hand. To fix this, I put the `TriggerUpdate` function inside the `SetData` function, because we should always be checking for updates when we change the data... 
2. The broadcast checksum for the player item group didn't allow for nulls, now it does.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
