### PR TITLE
[BEAM-3472] 1.12 blocker - temporary disable Load Config-Defaults button

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Login/UI/Components/AccountSummaryVisualElement/AccountSummaryVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Login/UI/Components/AccountSummaryVisualElement/AccountSummaryVisualElement.cs
@@ -65,7 +65,7 @@ namespace Beamable.Editor.Login.UI.Components
 					}, .3f);
 				}, .1f);
 			};
-
+/*
 			var loadConfigDefaults = Root.Q<GenericButtonVisualElement>("revertConfigToDefaults");
 			loadConfigDefaults.OnClick += () =>
 			{
@@ -82,7 +82,7 @@ namespace Beamable.Editor.Login.UI.Components
 					});
 				}, .1f);
 			};
-
+*/
 			var resetPasswordButton = Root.Q<GenericButtonVisualElement>("resetPassword");
 			resetPasswordButton.OnClick += Manager.GotoForgotPassword;
 

--- a/client/Packages/com.beamable/Editor/UI/Login/UI/Components/AccountSummaryVisualElement/AccountSummaryVisualElement.uxml
+++ b/client/Packages/com.beamable/Editor/UI/Login/UI/Components/AccountSummaryVisualElement/AccountSummaryVisualElement.uxml
@@ -72,15 +72,15 @@
                                                  tooltip="Set the values in 'Assets/Beamable/Resources/config-default.txt' to your current state."
             />
 
-            <beamable:GenericButtonVisualElement name="revertConfigToDefaults"
-                                                 text="Load Config-Defaults"
-                                                 type="Link"
-                                                 tooltip="Set your current CID/PID to the values stored in 'Assets/Beamable/Resources/config-defaults.txt'"
-            />
-
-            <engine:VisualElement name="actionBtn">
-              <beamable:GenericButtonVisualElement name="logout" text="Log out" type ="Cancel"/>
-<!--                <beamable:PrimaryButtonVisualElement name="signIn" text="Sign In"/>-->
+            <!--            <beamable:GenericButtonVisualElement name="revertConfigToDefaults"
+                                                             text="Load Config-Defaults"
+                                                             type="Link"
+                                                             tooltip="Set your current CID/PID to the values stored in 'Assets/Beamable/Resources/config-defaults.txt'"
+                        />-->
+            
+                        <engine:VisualElement name="actionBtn">
+                          <beamable:GenericButtonVisualElement name="logout" text="Log out" type ="Cancel"/>
+            <!--                <beamable:PrimaryButtonVisualElement name="signIn" text="Sign In"/>-->
             </engine:VisualElement>
 
         </engine:VisualElement>


### PR DESCRIPTION
# Brief Description

Based on recommendation from @cdhanna we decided to temporary disable Load Config-Defaults button because it's buggy and He needs more dev time to fix that.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
