### PR TITLE
[BEAM-3451] bugfix for keyboard focus on Tournament Interval field

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Validation/TimeSpanDisplayPropertyAttribute.cs
+++ b/client/Packages/com.beamable/Editor/UI/Validation/TimeSpanDisplayPropertyAttribute.cs
@@ -29,24 +29,35 @@ namespace Beamable.Editor.UI.Validation
 
 			var labelRect = new Rect(position.x, position.y + 5, position.width,
 									 EditorGUIUtility.singleLineHeight);
+
+			GUIContent content = new GUIContent();
+			var style = EditorStyles.miniLabel;
+			var indentedRect = EditorGUI.IndentedRect(labelRect);
+			
 			if (MustBeTimeSpanDuration.TryParseTimeSpan(prop.stringValue, out var span, out var readable))
 			{
-				var style = EditorStyles.miniLabel;
-				var content = new GUIContent("~" + readable);
+				content.text = "~" + readable;
 				content.tooltip = $"This will cycle about every {readable}, or {span.ToString("c")}";
-				EditorGUI.LabelField(labelRect, new GUIContent(" "), content, style);
+
+				indentedRect.width = 0;
+				indentedRect.height = 0;
 			}
 			else
 			{
-				var indentedRect = EditorGUI.IndentedRect(labelRect);
+				style.fixedHeight = 0;
+
+			
 				indentedRect.width = indentedRect.width - EditorGUIUtility.labelWidth;
 				indentedRect.x += EditorGUIUtility.labelWidth + 1;
-				if (GUI.Button(indentedRect, "Enter a valid ISO 8601 Period Code"))
-				{
-					Application.OpenURL("https://en.wikipedia.org/wiki/ISO_8601#Durations");
-				}
+				
 			}
-
+			
+			EditorGUI.LabelField(labelRect, new GUIContent(" "), content, style);
+			
+			if (GUI.Button(indentedRect, "Enter a valid ISO 8601 Period Code"))
+			{
+				Application.OpenURL("https://en.wikipedia.org/wiki/ISO_8601#Durations");
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Brief Description

Adding new gui element changes focus, so right now element is awlays exist but is disabled by width/height.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
