### PR TITLE
beam 3484 - option to disble build warnings for cid/pid

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- `DisableBeamableCidPidWarningsOnBuild` option in _Project Settings/Beamable/Editor_ that will disable the CID/PID warning dialog on build.
+
 ## [1.12.1]
 ### Added
 - `ItemView` has new `contentId` field.

--- a/client/Packages/com.beamable/Editor/BuildPreProcessor.cs
+++ b/client/Packages/com.beamable/Editor/BuildPreProcessor.cs
@@ -17,10 +17,12 @@ namespace Beamable.Editor
 		public async void OnPreprocessBuild(BuildReport report)
 		{
 			var messages = new List<string>();
+			#if !BEAMABLE_NO_CID_PID_WARNINGS_ON_BUILD
 			if (!CheckForConfigDefaultsAlignment(out var message))
 			{
 				messages.Add(message);
 			}
+			#endif
 
 			var hasLocalContentChanges = await ContentIO.HasLocalChanges();
 			if (hasLocalContentChanges)

--- a/client/Packages/com.beamable/Editor/Modules/EditorConfig/EditorConfiguration.cs
+++ b/client/Packages/com.beamable/Editor/Modules/EditorConfig/EditorConfiguration.cs
@@ -16,6 +16,7 @@ namespace Beamable.Editor.Modules.EditorConfig
 		public const string BEAMABLE_DISABLE_DICT_PROPERTYDRAWERS = "BEAMABLE_NO_DICT_DRAWERS";
 		public const string BEAMABLE_DISABLE_LIST_PROPERTYDRAWERS = "BEAMABLE_NO_LIST_DRAWERS";
 		public const string BEAMABLE_DISABLE_DATE_STRING_PROPERTYDRAWERS = "BEAMABLE_NO_DATE_STRING_DRAWERS";
+		public const string BEAMABLE_DISABLE_CID_PID_WARNINGS_ON_BUILD = "BEAMABLE_NO_CID_PID_WARNINGS_ON_BUILD";
 
 		public const string BEAMABLE_DEVELOPER = "BEAMABLE_DEVELOPER";
 
@@ -33,6 +34,8 @@ namespace Beamable.Editor.Modules.EditorConfig
 			Advanced.DisableBeamableListPropertyDrawers = existing.Contains(BEAMABLE_DISABLE_LIST_PROPERTYDRAWERS);
 			Advanced.DisableContentRefPropertyDrawers = existing.Contains(BEAMABLE_DISABLE_CONTENT_REF_PROPERTYDRAWERS);
 			Advanced.DisableBeamableDateStringPropertyDrawers = existing.Contains(BEAMABLE_DISABLE_DATE_STRING_PROPERTYDRAWERS);
+			Advanced.DisableBeamableCidPidWarningsOnBuild =
+				existing.Contains(BEAMABLE_DISABLE_CID_PID_WARNINGS_ON_BUILD);
 		}
 
 
@@ -92,6 +95,7 @@ namespace Beamable.Editor.Modules.EditorConfig
 			{BEAMABLE_DISABLE_LIST_PROPERTYDRAWERS, Advanced.DisableBeamableListPropertyDrawers},
 			{BEAMABLE_DEVELOPER, Advanced.RunAsBeamableDeveloper},
 			{BEAMABLE_DISABLE_DATE_STRING_PROPERTYDRAWERS, Advanced.DisableBeamableDateStringPropertyDrawers},
+			{BEAMABLE_DISABLE_CID_PID_WARNINGS_ON_BUILD, Advanced.DisableBeamableCidPidWarningsOnBuild},
 		 };
 
 			foreach (var kvp in settings)
@@ -153,6 +157,9 @@ namespace Beamable.Editor.Modules.EditorConfig
 
 			[Tooltip("[Danger] Beamable provides a date-string custom property drawer. if you wish to disable the property drawer, use this property.")]
 			public bool DisableBeamableDateStringPropertyDrawers;
+
+			[Tooltip("[Danger] When you build the game but the config-default.txt CID/PID is different than the currently selected CID/PID in the Toolbox, then a warning will be displayed. This option disables that warning.")]
+			public bool DisableBeamableCidPidWarningsOnBuild;
 
 		}
 	}


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3484

# Brief Description
For some developers, the warning popup may be more annoying than useful, so there is a danger-flag option to disable it.


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
