### PR TITLE
beam 3488 - add directory copy

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.12.1]
-no changes
+### Added
+- `IMicroserviceBuildContext.AddDirectory` method allows to copy an entire directory of files into a build context.
 
 ## [1.12.0]
 ### Fixed

--- a/client/Packages/com.beamable.server/Editor/IMicroserviceBuildHook.cs
+++ b/client/Packages/com.beamable.server/Editor/IMicroserviceBuildHook.cs
@@ -43,6 +43,13 @@ namespace Beamable.Server.Editor
 		void AddFile(string srcPath, string containerPath);
 
 		/// <summary>
+		/// Adding a directory will add a directory from your local Unity project into the final Microservice docker image.
+		/// </summary>
+		/// <param name="srcPath">The source path should be relative to your Unity project. For example, a valid path may be "Assets/myContent </param>
+		/// <param name="containerPath">The container path is where the directory will be placed in the Docker image. It should also include the copied name. For example, a valid path may be "myContent"</param>
+		void AddDirectory(string srcPath, string containerPath);
+
+		/// <summary>
 		/// Commiting a file assumes that a file is already present in the docker build context.
 		/// </summary>
 		/// <param name="containerPath">The container path is where the file will be placed in the Docker image. It should also include the copied filename. For example, a valid path may be "mydata/test.txt" </param>
@@ -59,6 +66,12 @@ namespace Beamable.Server.Editor
 		public void AddFile(string srcPath, string containerPath)
 		{
 			FileUtils.CopyFile(Descriptor, srcPath, containerPath);
+			CommitFile(containerPath);
+		}
+
+		public void AddDirectory(string srcPath, string containerPath)
+		{
+			FileUtils.CopyFolderToBuildDirectory(srcPath, containerPath, Descriptor);
 			CommitFile(containerPath);
 		}
 


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3488
https://disruptorbeam.slack.com/archives/C04714FNJ7Q/p1678888935829109?thread_ts=1678881084.721689&cid=C04714FNJ7Q

# Brief Description
Copying too many files breaks docker, so we need directory copy support. Luckily, we already had the logic to do a directory copy, so we just needed to apply it. 

here is my sample build hook,
```csharp
using Beamable.Common.Dependencies;
using Beamable.Microservices;
using Beamable.Server.Editor;
using UnityEngine;

namespace DefaultNamespace
{
	public class MyBuildHook : IMicroserviceBuildHook<MMV3Publish2>
	{
		public void Execute(IMicroserviceBuildContext ctx)
		{
			Debug.Log("------- RUNNING CUSTOM BUILD HOOK STUFF------");
			ctx.AddDirectory("Assets/MyStuff", "MyOwnStuff");
		}
	}

	[BeamContextSystem]
	public class Registration
	{
		[RegisterBeamableDependencies(-1, RegistrationOrigin.EDITOR)]
		public static void Doop(IDependencyBuilder b)
		{
			b.AddSingleton<IMicroserviceBuildHook<MMV3Publish2>, MyBuildHook>();
		}
	}
}
```

and the resulting docker file
```dockerfile

FROM beamservice:latest AS build-env
RUN dotnet --version
WORKDIR /subapp


COPY MyOwnStuff MyOwnStuff

COPY mmv3publish2.csproj .
RUN cp /src/baseImageDocs.xml .

RUN echo $BEAMABLE_SDK_VERSION > /subapp/.beamablesdkversion



EXPOSE 6565
ENV BEAMABLE_SDK_VERSION_EXECUTION=0.0.0
ENV DOTNET_WATCH_RESTART_ON_RUDE_EDIT=1
RUN dotnet restore .
ENTRYPOINT ["dotnet", "watch"]
```

and when I do a `ls` in the container, 
<img width="1042" alt="image" src="https://user-images.githubusercontent.com/3848374/225339243-f38b9399-285a-4b6b-a165-80ee7c6ae766.png">


# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
