### PR TITLE
beam 3489 - sign out on env switch

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -13,12 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AdminConsole works on webGL builds.
 - CurrencyHud no longer throws exceptions.
 - TournamentContent period field no longer loses focus. 
+- Switching environments will correctly sign out the current editor user.
 
 ### Changed
 - CID/PID warning at build time is more descriptive.
-
-### Changed
-- changed functions names in third party Websocket library so now they should not conflict when user is using other libraries that depends on that library
+- Functions names in third party Websocket library so now they should not conflict when user is using other libraries that depends on that library
 
 
 ## [1.12.0]

--- a/client/Packages/com.beamable/Editor/Environment/EnvironmentService.cs
+++ b/client/Packages/com.beamable/Editor/Environment/EnvironmentService.cs
@@ -8,10 +8,16 @@ namespace Beamable.Editor.Environment
 {
 	public class EnvironmentService
 	{
+		private readonly BeamEditorContext _context;
 		public EnvironmentData GetDev() => EnvironmentData.BeamableDev;
 		public EnvironmentData GetStaging() => EnvironmentData.BeamableStaging;
 		public EnvironmentData GetProd() => EnvironmentData.BeamableProduction;
 
+		public EnvironmentService(BeamEditorContext context)
+		{
+			_context = context;
+		}
+		
 		/// <summary>
 		/// Erase the overrides file, and reload the editor.
 		/// After this method is called, whatever is in env-defaults will be used.
@@ -22,6 +28,7 @@ namespace Beamable.Editor.Environment
 			{
 				FileUtil.DeleteFileOrDirectory(OVERRIDE_PATH);
 				FileUtil.DeleteFileOrDirectory(OVERRIDE_PATH + ".meta");
+				_context.Logout(false);
 				ConfigDatabase.DeleteConfigDatabase();
 				EditorUtility.RequestScriptReload();
 				AssetDatabase.Refresh();
@@ -38,6 +45,7 @@ namespace Beamable.Editor.Environment
 			var json = JsonSerializable.ToJson(data);
 			File.WriteAllText(OVERRIDE_PATH, json);
 			ConfigDatabase.DeleteConfigDatabase();
+			_context.Logout(false);
 			EditorUtility.RequestScriptReload();
 			AssetDatabase.Refresh();
 


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3489

# Brief Description
Dwayne found a bug in 1.12.1 RC1 where the env switcher wouldn't sign you out anymore. This is probably a bug from 1.12.0 actually, because we don't read from config-defaults, and the env switcher was just wiping the file.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
