### PR TITLE
beam 3473 - fix trial data from microservice

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Standalone Microservices don't use structured JSON logs
 
+### Fixed
+- Microservice calls to `GetCloudDataContent` no longer throw 500 errors.
+
 ## [1.12.1]
 ### Added
 - `IMicroserviceBuildContext.AddDirectory` method allows to copy an entire directory of files into a build context.

--- a/client/Packages/com.beamable/Common/Runtime/Api/CloudData/CloudDataApi.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/CloudData/CloudDataApi.cs
@@ -87,11 +87,17 @@ namespace Beamable.Common.Api.CloudData
 	{
 		public IUserContext Ctx { get; }
 		public IBeamableRequester Requester { get; }
+		public IHttpRequester HttpRequester { get; }
 
-		public CloudDataApi(IUserContext ctx, IBeamableRequester requester)
+		public CloudDataApi(IUserContext ctx, IBeamableRequester requester, IHttpRequester httpRequester=null)
 		{
 			Ctx = ctx;
 			Requester = requester;
+			HttpRequester = httpRequester;
+			if (httpRequester == null)
+			{
+				BeamableLogger.LogWarning($"{nameof(CloudDataApi)} was initialized without a {nameof(httpRequester)}, which means that certain functions will not work. {nameof(GetCloudDataContent)} will break.");
+			}
 		}
 
 		public Promise<GetCloudDataManifestResponse> GetGameManifest()
@@ -112,8 +118,7 @@ namespace Beamable.Common.Api.CloudData
 
 		public Promise<string> GetCloudDataContent(CloudMetaData metaData)
 		{
-			return Requester.Request(Method.GET,
-									 $"https://{metaData.uri}", parser: s => s);
+			return HttpRequester.ManualRequest(Method.GET, $"https://{metaData.uri}", parser: s => s);
 		}
 	}
 }

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/CloudData/CloudDataService.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/CloudData/CloudDataService.cs
@@ -17,7 +17,7 @@ namespace Beamable.Api.CloudData
 	/// </summary>
 	public class CloudDataService : CloudDataApi
 	{
-		public CloudDataService(IUserContext ctx, IBeamableRequester requester) : base(ctx, requester)
+		public CloudDataService(IUserContext ctx, IBeamableRequester requester, IHttpRequester httpRequester) : base(ctx, requester, httpRequester)
 		{
 		}
 	}

--- a/microservice/microservice/Api/CloudData/MicroserviceCloudDataApi.cs
+++ b/microservice/microservice/Api/CloudData/MicroserviceCloudDataApi.cs
@@ -5,7 +5,7 @@ namespace Beamable.Server.Api.CloudData
 {
    public class MicroserviceCloudDataApi : CloudDataApi, IMicroserviceCloudDataApi
    {
-      public MicroserviceCloudDataApi(IBeamableRequester requester, IUserContext ctx) : base(ctx, requester)
+      public MicroserviceCloudDataApi(IBeamableRequester requester, IUserContext ctx, IHttpRequester httpRequester) : base(ctx, requester, httpRequester)
       {
       }
    }

--- a/microservice/microservice/dbmicroservice/MicroserviceBootstrapper.cs
+++ b/microservice/microservice/dbmicroservice/MicroserviceBootstrapper.cs
@@ -42,6 +42,8 @@ using Serilog.Events;
 using Serilog.Formatting.Display;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using UnityEngine;
 using Constants = Beamable.Common.Constants;
@@ -196,6 +198,14 @@ namespace Beamable.Server
 			        .AddScoped<IDependencyProvider>(provider => new MicrosoftServiceProviderWrapper(provider))
 			        .AddScoped<IRealmInfo>(provider => provider.GetService<IMicroserviceArgs>())
 			        .AddScoped<IBeamableRequester>(p => p.GetService<MicroserviceRequester>())
+			        .AddScoped<IHttpRequester, MicroserviceHttpRequester>(() =>
+			        {
+				        HttpClientHandler handler = new HttpClientHandler()
+				        {
+					        AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+				        };
+				        return new MicroserviceHttpRequester(new HttpClient(handler));
+			        })
 			        .AddSingleton<IMicroserviceArgs>(envArgs)
 			        .AddSingleton<SocketRequesterContext>(_ =>
 			        {

--- a/microservice/microservice/dbmicroservice/MicroserviceHttpRequester.cs
+++ b/microservice/microservice/dbmicroservice/MicroserviceHttpRequester.cs
@@ -1,0 +1,88 @@
+using Beamable.Common;
+using Beamable.Common.Api;
+using Beamable.Server.Common;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+
+namespace Beamable.Server;
+
+public class MicroserviceHttpRequester : IHttpRequester
+{
+	private readonly HttpClient _client;
+
+	public MicroserviceHttpRequester(HttpClient client)
+	{
+		_client = client;
+	}
+	
+	public async Promise<T> ManualRequest<T>(Method method, string url, object body = null, Dictionary<string, string> headers = null,
+		string contentType = "application/json", Func<string, T> parser = null)
+	{
+		var req = new HttpRequestMessage();
+		req.Method = method switch
+		{
+			Method.GET => HttpMethod.Get,
+			Method.PUT => HttpMethod.Put,
+			Method.POST => HttpMethod.Post,
+			Method.DELETE => HttpMethod.Delete,
+			_ => throw new ArgumentOutOfRangeException(nameof(method), method, null)
+		};
+		req.RequestUri = new Uri(url);
+
+		if (headers != null)
+		{
+			foreach (var header in headers)
+			{
+				req.Headers.Add(header.Key, header.Value);
+			}
+		}
+
+		if (body is string bodyStr)
+		{
+			req.Content = new StringContent(bodyStr, Encoding.UTF8, contentType);
+		}
+		else if (body != null)
+		{
+			var json = JsonConvert.SerializeObject(body, UnitySerializationSettings.Instance);
+			req.Content = new StringContent(json, Encoding.UTF8, contentType);
+		}
+
+		
+		var res = await _client.SendAsync(req);
+
+		var resBody = await res.Content.ReadAsStringAsync();
+		
+		if (!res.IsSuccessStatusCode)
+		{
+			throw new RequesterException("microservice-http", method.ToString(), url, (long)res.StatusCode,
+				new BeamableRequestError
+				{
+					service = "",
+					status = (long)res.StatusCode,
+					error = res.ReasonPhrase,
+					message = resBody
+				}
+				);
+		}
+
+		T result;
+		if (parser == null)
+		{
+			result = JsonConvert.DeserializeObject<T>(resBody, UnitySerializationSettings.Instance);
+		}
+		else
+		{
+			result = parser(resBody);
+		}
+
+		return result;
+	}
+
+	public string EscapeURL(string url)
+	{
+		return System.Web.HttpUtility.UrlEncode(url);
+	}
+}


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3473

# Brief Description
Fetching trial data needs to go through HTTP, because it needs to hit our ALB and get directed to a custom endpoint. In Unity, all requests are HTTP anyway, so it just works. But in C#MS, we send traffic through the websocket, and by doing so, dodge the ALB. 

To fix the problem, I had to
1. add an implementation of `IhttpRequester` to the C#MS, 
2. in the trial server, use the http requester specifically instead of the websocket one. 


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
