### PR TITLE
beam 3524 - login issues from upgrading from pre 12

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Realms are reloaded if absent on domain reload.
+- Realm secret is reloaded on login.
+
 ## [1.13.0]
 ### Added
 - `ItemView` has new `contentId` field.

--- a/client/Packages/com.beamable/Editor/AccountService.cs
+++ b/client/Packages/com.beamable/Editor/AccountService.cs
@@ -291,6 +291,10 @@ namespace Beamable.Editor
 		public OptionalString realmPid = new OptionalString();
 		public EditorUser user;
 
+		public bool HasEmptyCustomerView =>
+			customerViewResponse == null || customerViewResponse.customer == null ||
+			customerViewResponse.customer.projects.Length == 0;
+		
 		[SerializeField]
 		private CustomerViewResponse customerViewResponse;
 
@@ -362,11 +366,10 @@ namespace Beamable.Editor
 				Projects = CustomerRealms
 			};
 
-			CurrentRealm.DoIfExists(realm =>
+			if (CurrentRealm.HasValue)
 			{
-				// override the gamePid value based on the realmPid's actual game parent.
-				gamePid.Set(realm.GamePid);
-			});
+				gamePid.Set(CurrentRealm.Value.GamePid);
+			}
 		}
 
 		public string GetRealmPidForGame(RealmView game)

--- a/client/Packages/com.beamable/Editor/BeamEditor.cs
+++ b/client/Packages/com.beamable/Editor/BeamEditor.cs
@@ -514,7 +514,7 @@ namespace Beamable
 
 			// TODO: Handle faulty API
 			// TODO: Handle offline?
-
+			
 			async Promise Initialize()
 			{
 				var configService = ServiceScope.GetService<ConfigDefaultsService>();
@@ -540,12 +540,20 @@ namespace Beamable
 				}
 
 				requester.Host = BeamableEnvironment.ApiUrl;
+				
 				ServiceScope.GetService<BeamableVsp>().TryToEmitAttribution("login"); // this will no-op if the package isn't a VSP package.
 
 				var accessTokenStorage = ServiceScope.GetService<AccessTokenStorage>();
 				var accessToken = await accessTokenStorage.LoadTokenForCustomer(cid);
 				requester.Token = accessToken;
 
+				// it is possible that the requester cid/pid have been set, but the editor account service hasn't.
+				if (accessToken != null &&  account.HasEmptyCustomerView)
+				{
+					await account.UpdateRealms(requester);
+					account.Refresh();
+				}
+				
 				await RefreshRealmSecret();
 
 			}
@@ -575,7 +583,7 @@ namespace Beamable
 			var token = new AccessToken(accessTokenStorage, cid, null, tokenRes.access_token, tokenRes.refresh_token, tokenRes.expires_in);
 
 			await ApplyToken(cid, token);
-
+			await RefreshRealmSecret();
 			return PromiseBase.Unit;
 		}
 

--- a/client/Packages/com.beamable/Editor/ResetPlayerAccessTokenEditor.cs
+++ b/client/Packages/com.beamable/Editor/ResetPlayerAccessTokenEditor.cs
@@ -23,9 +23,13 @@ namespace Beamable.Editor
 				EditorGUILayout.LabelField("Editor (the token used in edit mode)");
 				if (GUILayout.Button("Clear Tokens"))
 				{
+					var token = BeamEditorContext.Default.Requester.Token;
 					BeamEditorContext.Default.EditorAccountService.Clear();
+					var storage = BeamEditorContext.Default.ServiceScope.GetService<AccessTokenStorage>();
+					storage.DeleteTokenForCustomer(token.Cid);
+					storage.DeleteTokenForRealm(token.Cid, token.Pid);
 					BeamEditorContext.Default.Requester.DeleteToken();
-					BeamEditorContext.Default.Requester.Token.SaveAsCustomerScoped();
+
 				}
 
 				if (GUILayout.Button("Corrupt Tokens"))


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3524

# Brief Description
To test this, I had to
1. Clear my access token via Window/Beamable/Utility/Clear Access Token
2. Close Unity
3. Delete my Library/BeamableEditor folder
4. re-open Unity

And then I would experience the bug described. It makes sense that this would happen, in that folks who are updating from pre 1.12 don't have that Library/BeamableEditor folder at all. 

To fix the issue, I added a check during Beamable editor init to see if the customer realm data is empty, and if so, fetch it! I also added the realm secret call on login.

The clear-access-token was a bit broken, so I fixed that too.

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
