### PR TITLE
beam 3551 - start microservice with alias

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Importing assets during microservice publish process on Unity2021.
 - Unity clients will direct Microservice traffic to local standalone Microservices.
+- Microservices can be started with an alias in the CID environment variable.
 
 ### Added
 - Runtime log level switching. In RealmConfig, use a key for service_logs|serviceName=logLevel.

--- a/microservice/microservice/dbmicroservice/MicroserviceBootstrapper.cs
+++ b/microservice/microservice/dbmicroservice/MicroserviceBootstrapper.cs
@@ -6,6 +6,7 @@ using Beamable.Common;
 using Beamable.Common.Api;
 using Beamable.Common.Api.Content;
 using Beamable.Common.Api.Leaderboards;
+using Beamable.Common.Api.Realms;
 using Beamable.Common.Api.Stats;
 using Beamable.Common.Assistant;
 using Beamable.Common.Content;
@@ -254,7 +255,7 @@ namespace Beamable.Server
 				        {
 					        AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
 				        };
-				        return new MicroserviceHttpRequester(new HttpClient(handler));
+				        return new MicroserviceHttpRequester(envArgs, new HttpClient(handler));
 			        })
 			        .AddSingleton<IMicroserviceArgs>(envArgs)
 			        .AddSingleton<SocketRequesterContext>(_ =>
@@ -278,6 +279,7 @@ namespace Beamable.Server
 			        .AddSingleton<IContentApi>(p => p.GetService<ContentService>())
 			        .AddSingleton<IContentResolver, DefaultContentResolver>()
 			        .AddSingleton<IConnectionProvider, EasyWebSocketProvider>()
+			        .AddSingleton<IAliasService, AliasService>()
 			        .AddScoped<IMicroserviceInventoryApi, MicroserviceInventoryApi>()
 			        .AddScoped<IMicroserviceGroupsApi, MicroserviceGroupsApi>()
 			        .AddScoped<IMicroserviceTournamentApi, MicroserviceTournamentApi>()
@@ -435,6 +437,17 @@ namespace Beamable.Server
 	        beacon.Publish(msgJson, TimeSpan.FromMilliseconds(Constants.Features.Services.DISCOVERY_BROADCAST_PERIOD_MS));
         }
 
+        public static async Task<string> ConfigureCid(IMicroserviceArgs args)
+        {
+	        // it is possible that the user passed in an alias instead a cid for the env var, we should fix that...
+	        if (AliasHelper.IsCid(args.CustomerID)) return args.CustomerID;
+	        
+	        // if here, we can assume the string is an alias... 
+	        var aliasService = new AliasService(new MicroserviceHttpRequester(args, new HttpClient()));
+	        var res = await aliasService.Resolve(args.CustomerID);
+	        return res.Cid.Value;
+        }
+
         public static async Task Start<TMicroService>() where TMicroService : Microservice
         {
 	        var attribute = typeof(TMicroService).GetCustomAttribute<MicroserviceAttribute>();
@@ -452,11 +465,12 @@ namespace Beamable.Server
 		        allowHydration = false
 	        });
 	        InitializeServices(rootServiceScope);
-	        
-	        
+
+	        var resolvedCid = await ConfigureCid(envArgs);
 	        var args = envArgs.Copy(conf =>
 	        {
 		        conf.ServiceScope = rootServiceScope;
+		        conf.CustomerID = resolvedCid;
 	        });
 
 	        for (var i = 0; i < args.BeamInstanceCount; i++)


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3551

# Brief Description
If you started a C#MS with an alias in the CID env var, then it would fail the thorium auth check, because thorium wants it to be a cid. I added step in the Microservicebootstrapper that will check if the given value is a CID, and if not, it'll pass it through the alias mapper and get the CID for it. 
I had to modify the MicroserviceHttpRequester a bit to make the types work, and I didn't want to boil the ocean here, so I left a lot of it as unimplemented.


# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
