### PR TITLE
[BEAM-3565] Fix issue with CLI gen that causes "-----" to keep appearing on the file

### DIFF
--- a/cli/cli/Services/UnitySourceGenerator.cs
+++ b/cli/cli/Services/UnitySourceGenerator.cs
@@ -11,6 +11,7 @@ using System.CodeDom;
 using System.CodeDom.Compiler;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace cli;
 
@@ -1532,7 +1533,7 @@ public static class UnityHelper
 
 	public static string GenerateCsharp(CodeCompileUnit unit)
 	{
-		const int COUNT_OF_AUTO_GENERATED_MESSAGE_TEXT = 357;
+		
 		CodeDomProvider provider = CodeDomProvider.CreateProvider("CSharp");
 		CodeGeneratorOptions options = new CodeGeneratorOptions { BracingStyle = "C", BlankLinesBetweenMembers = false };
 		var sb = new StringBuilder();
@@ -1542,7 +1543,10 @@ public static class UnityHelper
 			unit, sourceWriter, options);
 		sourceWriter.Flush();
 		var source = sb.ToString();
-		return source.Substring(COUNT_OF_AUTO_GENERATED_MESSAGE_TEXT);
+		
+		// CodeDom adds some comments we don't want before the namespace declaration.
+		var expectedFirstLineMinusAutoGenComments = new Regex("(namespace.*\n{)|(using.*;)");
+		return source.Substring(expectedFirstLineMinusAutoGenComments.Matches(source).First().Index).Insert(0, "\n");
 	}
 }
 


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3565

# Brief Description
Using a regex to extract everything up to the first using or namespace declaration in a csharp code-gen'ed file

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
