### PR TITLE
[BEAM-3567] CLI - add support for paths with spaces

### DIFF
--- a/cli/cli/Commands/ConfigCommand.cs
+++ b/cli/cli/Commands/ConfigCommand.cs
@@ -5,12 +5,10 @@ namespace cli;
 
 public class ConfigCommandArgs : CommandArgs
 {
-
 }
 
-public class ConfigCommand : AppCommand<ConfigCommandArgs>
+public class ConfigCommand : AppCommand<ConfigCommandArgs>, IResultSteam<DefaultStreamResultChannel, ConfigCommandResult>
 {
-
 	public ConfigCommand() : base("config", "List the current configuration")
 	{
 	}
@@ -25,6 +23,21 @@ public class ConfigCommand : AppCommand<ConfigCommandArgs>
 		BeamableLogger.Log(args.ConfigService.ConfigFilePath);
 		BeamableLogger.Log($"cid=[{args.AppContext.Cid}] pid=[{args.AppContext.Pid}]");
 		BeamableLogger.Log(args.ConfigService.PrettyPrint());
+
+		this.SendResults(new ConfigCommandResult()
+		{
+			host = args.ConfigService.GetConfigString(Constants.CONFIG_PLATFORM),
+			cid = args.ConfigService.GetConfigString(Constants.CONFIG_CID),
+			pid = args.ConfigService.GetConfigString(Constants.CONFIG_PID)
+		});
+
 		return Task.CompletedTask;
 	}
+}
+
+public class ConfigCommandResult
+{
+	public string host;
+	public string cid;
+	public string pid;
 }

--- a/cli/cli/Services/ProjectService.cs
+++ b/cli/cli/Services/ProjectService.cs
@@ -74,10 +74,8 @@ public class ProjectService
 		{
 			CoreProjectName = projectName,
 			BlueprintNodesProjectName = $"{projectName}BlueprintNodes",
-
 			Path = relativePath,
 			SourceFilesPath = relativePath + $"\\Source\\",
-
 			MsCoreHeaderPath = msPath,
 			MsCoreCppPath = msPath,
 			MsBlueprintNodesHeaderPath = msBlueprintPath,
@@ -139,7 +137,7 @@ public class ProjectService
 	{
 		if (string.IsNullOrEmpty(directory))
 		{
-			directory = projectName;
+			directory = solutionName;
 		}
 
 		var solutionPath = Path.Combine(_configService.WorkingDirectory, directory);
@@ -157,44 +155,44 @@ public class ProjectService
 		await EnsureCanUseTemplates();
 		// create the solution
 		await Cli.Wrap($"dotnet")
-			.WithArguments($"new sln -n {solutionName} -o {solutionPath}")
+			.WithArguments($"new sln -n \"{solutionName}\" -o \"{solutionPath}\"")
 			.ExecuteAsyncAndLog().Task;
 
 		// create the beam microservice project
 		await Cli.Wrap($"dotnet")
-			.WithArguments($"new beamservice -n {projectName} -o {projectPath}")
+			.WithArguments($"new beamservice -n \"{projectName}\" -o \"{projectPath}\"")
 			.ExecuteAsyncAndLog().Task;
 
 		// restore the microservice tools
 		await Cli.Wrap($"dotnet")
-			.WithArguments($"tool restore --tool-manifest {Path.Combine(projectName, ".config", "dotnet-tools.json")}")
+			.WithArguments($"tool restore --tool-manifest \"{Path.Combine(projectName, ".config", "dotnet-tools.json")}\"")
 			.ExecuteAsyncAndLog().Task;
 
 		// add the microservice to the solution
 		await Cli.Wrap($"dotnet")
-			.WithArguments($"sln {solutionPath} add {projectPath}")
+			.WithArguments($"sln \"{solutionPath}\" add \"{projectPath}\"")
 			.ExecuteAsyncAndLog().Task;
 
 		// create the shared library project only if requested
 		if (createCommonLibrary)
 		{
 			await Cli.Wrap($"dotnet")
-				.WithArguments($"new beamlib -n {commonProjectName} -o {commonProjectPath}")
+				.WithArguments($"new beamlib -n \"{commonProjectName}\" -o \"{commonProjectPath}\"")
 				.ExecuteAsyncAndLog().Task;
 
 			// restore the shared library tools
 			await Cli.Wrap($"dotnet")
-				.WithArguments($"tool restore --tool-manifest {Path.Combine(commonProjectPath, ".config", "dotnet-tools.json")}")
+				.WithArguments($"tool restore --tool-manifest \"{Path.Combine(commonProjectPath, ".config", "dotnet-tools.json")}\"")
 				.ExecuteAsyncAndLog().Task;
 
 			// add the shared library to the solution
 			await Cli.Wrap($"dotnet")
-				.WithArguments($"sln {solutionPath} add {commonProjectPath}")
+				.WithArguments($"sln \"{solutionPath}\" add \"{commonProjectPath}\"")
 				.ExecuteAsyncAndLog().Task;
 
 			// add the shared library as a reference of the project
 			await Cli.Wrap($"dotnet")
-				.WithArguments($"add {projectPath} reference {commonProjectPath}")
+				.WithArguments($"add \"{projectPath}\" reference \"{commonProjectPath}\"")
 				.ExecuteAsyncAndLog().Task;
 		}
 


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3567

# Brief Description
"beam project new" now correctly supports names with spaces in them (though we don't recommend doing so)

- Added ResultStream to Config Command for ease of integration testing with UE
- Added support for specifying a solution name when invoking beam project new (defaults to the project name argument)

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
