### PR TITLE
beam 3554 - more type info for swagger docs

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Rare concurrent modification to collection error regarding `IDependencyProvider` when used in a Microservice.
 
+### Changed
+- Generated OpenAPI document for Microservices includes qualified naming extensions.
 
 ## [1.15.0]
 ### Fixed

--- a/microservice/beamable.tooling.common/OpenAPI/ServiceDocGenerator.cs
+++ b/microservice/beamable.tooling.common/OpenAPI/ServiceDocGenerator.cs
@@ -82,7 +82,7 @@ public class ServiceDocGenerator
 		foreach (var type in allTypes)
 		{
 			var schema = SchemaGenerator.Convert(type);
-			doc.Components.Schemas.Add(type.Name, schema);
+			doc.Components.Schemas.Add(SchemaGenerator.GetQualifiedReferenceName(type), schema);
 		}
 
 		foreach (var method in methods)

--- a/microservice/microserviceTests/OpenAPITests/TypeTests.cs
+++ b/microservice/microserviceTests/OpenAPITests/TypeTests.cs
@@ -58,7 +58,7 @@ public class TypeTests
 	public void CheckListOfObjects(Type runtimeType)
 	{
 		var schema = SchemaGenerator.Convert(runtimeType);
-		Assert.AreEqual(nameof(Sample), schema.Items.Reference.Id);
+		Assert.AreEqual("microserviceTests.OpenAPITests.TypeTests+Sample", schema.Items.Reference.Id);
 	}
 
 
@@ -84,7 +84,7 @@ public class TypeTests
 		Assert.AreEqual("this is a sample", schema.Description);
 		Assert.AreEqual(1, schema.Properties.Count);
 		
-		Assert.AreEqual(nameof(Tuna), schema.Properties[nameof(Sample.fish)].Reference.Id);
+		Assert.AreEqual("microserviceTests.OpenAPITests.TypeTests+Tuna", schema.Properties[nameof(Sample.fish)].Reference.Id);
 		Assert.AreEqual("a fish", schema.Properties[nameof(Sample.fish)].Description);
 	}
 
@@ -103,7 +103,7 @@ public class TypeTests
 		Assert.AreEqual(1, schema.Properties.Count);
 
 		var prop = schema.Properties[nameof(FishThing.type)];
-		Assert.AreEqual(nameof(Fish), prop.Reference.Id);
+		Assert.AreEqual("microserviceTests.OpenAPITests.TypeTests+Fish", prop.Reference.Id);
 	}
 
 


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3554

# Brief Description
I added these extension properties
```csharp
				schema.Extensions = new Dictionary<string, IOpenApiExtension>
				{
					["x-beamable-namespace"] = new OpenApiString(runtimeType.Namespace),
					["x-beamable-name"] = new OpenApiString(runtimeType.Name),
					["x-beamable-qualified-name"] = new OpenApiString(GetQualifiedReferenceName(runtimeType)),
					["x-beamable-assembly-name"] = new OpenApiString(runtimeType.Assembly.GetName().Name),
					["x-beamable-assembly-version"] = new OpenApiString(runtimeType.Assembly.GetName().Version.ToString())
				};
```

They should help us figure out in generation phase what to do with type collisions

# Checklist
* [X] Have you added appropriate text to the CHANGELOG.md files?
* [ ] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
