### PR TITLE
beam 3580- exit playmode quickly no longer gives error

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Detect issues with parsing baked content.
+- Exiting playmode early no longer causes a service scope exception. 
 
 ### Changed
 - Beamable Environment window leaves version number and environment label unchanged when using preset buttons. 

--- a/client/Packages/com.beamable/Common/Runtime/Dependencies/DependencyProvider.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Dependencies/DependencyProvider.cs
@@ -278,14 +278,14 @@ namespace Beamable.Common.Dependencies
 
 		public bool CanBuildService(Type t)
 		{
-			if (_destroyed) throw new Exception("Provider scope has been destroyed and can no longer be accessed.");
+			if (_destroyed) throw new ServiceScopeDisposedException(nameof(CanBuildService), t, this);
 
 			return Transients.ContainsKey(t) || Scoped.ContainsKey(t) || Singletons.ContainsKey(t) || (Parent?.CanBuildService(t) ?? false);
 		}
 
 		public object GetService(Type t)
 		{
-			if (_destroyed) throw new Exception("Provider scope has been destroyed and can no longer be accessed.");
+			if (_destroyed) throw new ServiceScopeDisposedException(nameof(GetService), t, this);
 
 			if (t == typeof(IDependencyProvider)) return this;
 			if (t == typeof(IDependencyProviderScope)) return this;

--- a/client/Packages/com.beamable/Common/Runtime/Dependencies/Exceptions.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Dependencies/Exceptions.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Beamable.Common.Dependencies
+{
+	public class ServiceScopeDisposedException : Exception 
+	{
+		private readonly string _src;
+		private readonly Type _requestedType;
+		private readonly IDependencyProvider _provider;
+
+		public ServiceScopeDisposedException(string src, Type requestedType, IDependencyProvider provider)
+		: base($"Provider scope has been destroyed and can no longer be accessed. method=[{src}] type=[{requestedType.Name}]")
+		{
+			_src = src;
+			_requestedType = requestedType;
+			_provider = provider;
+		}
+	}
+}

--- a/client/Packages/com.beamable/Common/Runtime/Dependencies/Exceptions.cs.meta
+++ b/client/Packages/com.beamable/Common/Runtime/Dependencies/Exceptions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 279a7617139249e0ad639654f3e681ee
+timeCreated: 1682968956

--- a/client/Packages/com.beamable/Runtime/BeamContext.cs
+++ b/client/Packages/com.beamable/Runtime/BeamContext.cs
@@ -16,6 +16,7 @@ using Beamable.Common.Api.Notifications;
 using Beamable.Common.Api.Presence;
 using Beamable.Common.Content;
 using Beamable.Common.Dependencies;
+using Beamable.Common.Spew;
 using Beamable.Config;
 using Beamable.Connection;
 using Beamable.Content.Utility;
@@ -452,7 +453,15 @@ namespace Beamable
 						.Error(err =>
 						{
 							errors[attemptIndex] = err;
-							Debug.LogException(err);
+							switch (err)
+							{
+								case ServiceScopeDisposedException ex:
+									PlatformLogger.Log($"Beamable is exiting early, and caught a {ex.GetType().Name} exception. msg=[{ex.Message}] stack=[{ex.StackTrace}]" );
+									break;
+								default:
+									Debug.LogException(err);
+									break;
+							}
 						})
 						.Then(__ =>
 						{


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3580

# Brief Description
I've noticed an annoying bug for awhile; if you exit playmode too quickly after starting playmode, you'll get an exception because we are trying to resolve a dependency after the scope has been destroyed. 
1. I made this a better typed exception, and
2. allow it fade away on startup

# Checklist
* [X ] Have you added appropriate text to the CHANGELOG.md files?
* [X] Is there an appropriate JIRA ticket number, and is it named in the title?
* [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
