### PR TITLE
[BEAM-3544] Add UBeamCli Editor subsystem to the Unreal SDK

### DIFF
--- a/cli/cli/App.cs
+++ b/cli/cli/App.cs
@@ -81,7 +81,8 @@ public class App
 		services.AddSingleton<UnrealSourceGenerator>();
 		services.AddSingleton<ProjectService>();
 		services.AddSingleton<SwaggerService.SourceGeneratorListProvider>();
-		services.AddSingleton<ICliGenerator, UnityCliGenerator>();
+		services.AddSingleton<UnityCliGenerator>();
+		services.AddSingleton<UnrealCliGenerator>();
 		OpenApiRegistration.RegisterOpenApis(services);
 
 		_serviceConfigurator?.Invoke(services);

--- a/cli/cli/Commands/CliInterfaceGeneratorCommand.cs
+++ b/cli/cli/Commands/CliInterfaceGeneratorCommand.cs
@@ -3,6 +3,7 @@ using Beamable.Common.Dependencies;
 using cli.Services;
 using cli.Unreal;
 using Serilog;
+using Spectre.Console;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 
@@ -12,6 +13,7 @@ public class CliInterfaceGeneratorCommandArgs : CommandArgs
 {
 	public string? OutputPath;
 	public bool Concat;
+	public string Engine;
 }
 public class CliInterfaceGeneratorCommand : AppCommand<CliInterfaceGeneratorCommandArgs>
 {
@@ -31,6 +33,10 @@ public class CliInterfaceGeneratorCommand : AppCommand<CliInterfaceGeneratorComm
 		AddOption(new Option<string>("--output", () => null,
 				"When null or empty, the generated code will be sent to standard-out. When there is a output value, the file or files will be written to the path"),
 			(args, val) => args.OutputPath = val);
+		
+		AddOption(new Option<string>("--engine", () => "",
+				"Filter which engine code we should generate (unity | unreal). An empty string matches everything"),
+			(args, val) => args.Engine = val);
 
 	}
 
@@ -93,7 +99,14 @@ public class CliInterfaceGeneratorCommand : AppCommand<CliInterfaceGeneratorComm
 
 		// now we have all the beam commands and their call sites
 		// proxy out to a generator... for now, its unity... but someday it'll be unity or unreal.
-		var generator = args.DependencyProvider.GetService<ICliGenerator>();
+		args.Engine = string.IsNullOrEmpty(args.Engine) ? AnsiConsole.Ask<SelectionPrompt<string>>("").AddChoices("unity", "unreal").Show(AnsiConsole.Console) : args.Engine;
+		ICliGenerator generator = args.Engine.ToLower() switch
+		{
+			"unity" => args.DependencyProvider.GetService<UnityCliGenerator>(),
+			"unreal" => args.DependencyProvider.GetService<UnrealCliGenerator>(),
+			_ => throw new ArgumentOutOfRangeException("Should be impossible!")
+		};
+
 		var output = generator.Generate(new CliGeneratorContext
 		{
 			Root = rootBeamCommand,

--- a/cli/cli/Services/UnrealCliGenerator.cs
+++ b/cli/cli/Services/UnrealCliGenerator.cs
@@ -1,0 +1,248 @@
+﻿using cli.Unreal;
+using Newtonsoft.Json;
+using System.CommandLine;
+using System.CommandLine.Help;
+using System.Reflection;
+
+namespace cli.Services;
+
+public struct UnrealCliCommandDeclaration
+{
+	/// <summary>
+	/// BeamCli<Commands>
+	/// </summary>
+	public string CommandName;
+
+	public string CommandKeywords;
+	public string HelpString;
+
+	public List<UnrealCliStreamDeclaration> Streams;
+
+	private string _streamFieldDeclarations;
+	private string _parseStreamDataImpl;
+
+	public void IntoProcessDict(Dictionary<string, string> dict)
+	{
+		_streamFieldDeclarations = string.Join("\n\n", Streams.Select(s =>
+		{
+			dict.Clear();
+			s.IntoProcessDict(dict);
+			return UnrealCliStreamDeclaration.STREAM_COMMAND_FIELDS.ProcessReplacement(dict);
+		}));
+
+		var streams = string.Join("\n", Streams.Select(s =>
+		{
+			dict.Clear();
+			s.IntoProcessDict(dict);
+			return UnrealCliStreamDeclaration.STREAM_STRUCTS_DECL.ProcessReplacement(dict);
+		}));
+
+		_parseStreamDataImpl = string.Join("\n", Streams.Select(s =>
+		{
+			dict.Clear();
+			s.IntoProcessDict(dict);
+			return UnrealCliStreamDeclaration.STREAM_PARSE_IMPL.ProcessReplacement(dict);
+
+		}));
+		
+		dict.Clear();
+		dict.Add(nameof(CommandName), CommandName);
+		dict.Add(nameof(CommandKeywords), CommandKeywords);
+		dict.Add(nameof(HelpString), HelpString);
+		dict.Add(nameof(Streams), streams);
+		dict.Add(nameof(_streamFieldDeclarations), _streamFieldDeclarations);
+		dict.Add(nameof(_parseStreamDataImpl), _parseStreamDataImpl);
+	}
+
+	public const string HEADER_COMMAND_TEMPLATE = $@"#pragma once
+
+#include ""Subsystems/CLI/BeamCliCommand.h""
+#include ""₢{nameof(CommandName)}₢Command.generated.h""
+
+class FMonitoredProcess;
+
+₢{nameof(Streams)}₢
+
+/**
+ ₢{nameof(HelpString)}₢
+ */
+UCLASS()
+class U₢{nameof(CommandName)}₢Command : public UBeamCliCommand
+{{
+	GENERATED_BODY()
+
+public:
+	₢{nameof(_streamFieldDeclarations)}₢	
+
+	TFunction<void (const int& ResCode, const FBeamOperationHandle& Op)> OnCompleted;
+	virtual TSharedPtr<FMonitoredProcess> RunImpl(const TArray<FString>& CommandParams, const FBeamOperationHandle& Op = {{}}) override;
+}};
+";
+
+	public const string CPP_COMMAND_TEMPLATE = $@"#include ""₢{nameof(CommandName)}₢Command.h""
+
+#include ""BeamLogging.h""
+#include ""Misc/MonitoredProcess.h""
+#include ""JsonObjectConverter.h""
+#include ""Serialization/JsonSerializerMacros.h""
+		
+inline TSharedPtr<FMonitoredProcess> U₢{nameof(CommandName)}₢Command::RunImpl(const TArray<FString>& CommandParams, const FBeamOperationHandle& Op)
+{{
+	FString Params = (""₢{nameof(CommandKeywords)}₢"");
+	for (const auto& CommandParam : CommandParams)
+		Params.Appendf(TEXT("" %s""), *CommandParam);
+	Params = PrepareParams(Params);
+	UE_LOG(LogBeamCli, Verbose, TEXT(""₢{nameof(CommandName)}₢ Command - Invocation: %s %s""), *PathToCli, *Params)
+
+	const auto CliProcess = MakeShared<FMonitoredProcess>(PathToCli, Params, FPaths::ProjectDir(), true, true);
+	CliProcess->OnOutput().BindLambda([this, Op](const FString& Out)
+	{{
+		UE_LOG(LogBeamCli, Verbose, TEXT(""₢{nameof(CommandName)}₢ Command - Std Out: %s""), *Out);
+		FString OutCopy = Out;
+		FString MessageJson;
+		while (ConsumeMessageFromOutput(OutCopy, MessageJson))
+		{{
+			auto Bag = FJsonDataBag();
+			Bag.FromJson(MessageJson);
+			const auto StreamType = Bag.GetString(""type"");
+			const auto Timestamp = static_cast<int64>(Bag.GetField(""ts"")->AsNumber());
+			const auto DataJson = Bag.JsonObject->GetObjectField(""data"").ToSharedRef();
+
+			₢{nameof(_parseStreamDataImpl)}₢
+		}}
+	}});
+	CliProcess->OnCompleted().BindLambda([this, Op](int ResultCode)
+	{{
+		if (OnCompleted)
+		{{
+			OnCompleted(ResultCode, Op);
+		}}
+	}});
+	CliProcess->Launch();
+	return CliProcess;
+}}
+";
+}
+
+public struct UnrealCliStreamDeclaration
+{
+	public string CommandName;
+	public string RawStreamName;
+	public string StreamName;
+
+	public string StreamDataName;
+	public List<UnrealPropertyDeclaration> StreamDataProperties;
+
+	public void IntoProcessDict(Dictionary<string, string> dictionary)
+	{
+		var properties = string.Join("\n\t", StreamDataProperties.Select(p => $"UPROPERTY()\n\t{p.PropertyUnrealType} {p.PropertyName};"));
+
+		dictionary.Clear();
+		dictionary.Add(nameof(CommandName), CommandName);
+		dictionary.Add(nameof(RawStreamName), RawStreamName);
+		dictionary.Add(nameof(StreamName), StreamName);
+		dictionary.Add(nameof(StreamDataName), StreamDataName);
+		dictionary.Add(nameof(StreamDataProperties), properties);
+	}
+
+	public const string STREAM_COMMAND_FIELDS = $@"TArray<F₢{nameof(StreamDataName)}₢> ₢{nameof(StreamName)}₢Stream;
+	TArray<int64> ₢{nameof(StreamName)}₢Timestamps;
+	TFunction<void (const TArray<F₢{nameof(StreamDataName)}₢>& StreamData, const TArray<int64>& Timestamps, const FBeamOperationHandle& Op)> On₢{nameof(StreamName)}₢StreamOutput;";
+
+	public const string STREAM_STRUCTS_DECL = $@"
+USTRUCT()
+struct F₢{nameof(StreamDataName)}₢
+{{
+	GENERATED_BODY()
+
+	inline static FString StreamTypeName = FString(TEXT(""₢{nameof(RawStreamName)}₢""));
+
+	₢{nameof(StreamDataProperties)}₢	
+}};
+";
+
+	public const string STREAM_PARSE_IMPL = $@"
+			if(StreamType.Equals(F₢{nameof(StreamDataName)}₢::StreamTypeName))
+			{{
+				F₢{nameof(StreamDataName)}₢ Data;
+				FJsonObjectConverter::JsonObjectToUStruct(DataJson, F₢{nameof(StreamDataName)}₢::StaticStruct(), &Data);
+
+				₢{nameof(StreamName)}₢Stream.Add(Data);
+				₢{nameof(StreamName)}₢Timestamps.Add(Timestamp);
+
+				UE_LOG(LogBeamCli, Verbose, TEXT(""₢{nameof(CommandName)}₢ Command - Message Received: %s""), *MessageJson);
+				On₢{nameof(StreamName)}₢StreamOutput.CheckCallable();
+				On₢{nameof(StreamName)}₢StreamOutput(₢{nameof(StreamName)}₢Stream, ₢{nameof(StreamName)}₢Timestamps, Op);
+			}}
+";
+}
+
+public class UnrealCliGenerator : ICliGenerator
+{
+	public List<GeneratedFileDescriptor> Generate(CliGeneratorContext context)
+	{
+		// the following commands are more complicated and either use nullables or enums
+		var invalidCommands = new string[] { "beam", "beam services register", "beam services modify", "beam services enable", "beam oapi generate", };
+
+		var files = new List<GeneratedFileDescriptor>();
+		foreach (var command in context.Commands)
+		{
+			if (!command.hasValidOutput && command.executionPath != "beam") continue;
+			if (invalidCommands.Contains(command.executionPath)) continue;
+
+			var nonBeamCommandNames = command.executionPath.Substring(command.executionPath.IndexOf(" ", StringComparison.Ordinal) + 1);
+			var commandName = $"BeamCli{string.Join("", nonBeamCommandNames.Split(" ").Select(c => c.Capitalize()))}";
+			var cliCommandDeclaration = new UnrealCliCommandDeclaration()
+			{
+				CommandName = commandName,
+				// execution path => "beam project ps"; what we want is only the "project ps"
+				CommandKeywords = nonBeamCommandNames,
+				HelpString = GenerateHelpString(command),
+				Streams = command.resultStreams.Select(rs =>
+				{
+					// For the default stream, we don't add it to the type name
+					var streamChannel = rs.channel == "stream" ? "" : rs.channel.Capitalize();
+
+					var streamDataProperties = rs.runtimeType.GetFields().Select(fieldInfo => new UnrealPropertyDeclaration()
+					{
+						PropertyName = fieldInfo.Name, PropertyUnrealType = UnrealSourceGenerator.GetUnrealTypeFromReflectionType(fieldInfo.FieldType)
+					}).ToList();
+
+					return new UnrealCliStreamDeclaration()
+					{
+						CommandName = commandName,
+						RawStreamName = rs.channel,
+						StreamName = streamChannel,
+						StreamDataName = $"{commandName}{streamChannel}StreamData",
+						StreamDataProperties = streamDataProperties
+					};
+				}).ToList()
+			};
+
+			var dict = new Dictionary<string, string>();
+
+			cliCommandDeclaration.IntoProcessDict(dict);
+			files.Add(new GeneratedFileDescriptor()
+			{
+				FileName = $"BeamableCoreEditor/Public/Subsystems/CLI/Autogen/{commandName}Command.h",
+				Content = UnrealCliCommandDeclaration.HEADER_COMMAND_TEMPLATE.ProcessReplacement(dict)
+			});
+			files.Add(new GeneratedFileDescriptor()
+			{
+				FileName = $"BeamableCoreEditor/Public/Subsystems/CLI/Autogen/{commandName}Command.cpp",
+				Content = UnrealCliCommandDeclaration.CPP_COMMAND_TEMPLATE.ProcessReplacement(dict)
+			});
+		}
+
+
+		return files;
+	}
+
+	public static string GenerateHelpString(BeamCommandDescriptor descriptor)
+	{
+		var textWriter = new StringWriter();
+		var helpContext = new HelpContext(new HelpBuilder(LocalizationResources.Instance), descriptor.command, textWriter);
+		helpContext.HelpBuilder.Write(helpContext);
+		return textWriter.GetStringBuilder().ToString();
+	}
+}

--- a/cli/cli/Services/UnrealSourceGenerator/UnrealSourceGenerator.cs
+++ b/cli/cli/Services/UnrealSourceGenerator/UnrealSourceGenerator.cs
@@ -310,8 +310,14 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 			{
 				new GeneratedFileDescriptor { FileName = $"{headerFileOutputPath}AutoGen/{serializedTypeName.NamespacedTypeName}.h", Content = s.serializableHeader, },
 				new GeneratedFileDescriptor { FileName = $"{cppFileOutputPath}AutoGen/{serializedTypeName.NamespacedTypeName}.cpp", Content = s.serializableCpp, },
-				new GeneratedFileDescriptor { FileName = $"{headerFileOutputPath}AutoGen/{serializedTypeName.NamespacedTypeName}Library.h", Content = s.serializableTypeLibraryHeader, },
-				new GeneratedFileDescriptor { FileName = $"{cppFileOutputPath}AutoGen/{serializedTypeName.NamespacedTypeName}Library.cpp", Content = s.serializableTypeLibraryCpp, },
+				new GeneratedFileDescriptor
+				{
+					FileName = $"{headerFileOutputPath}AutoGen/{serializedTypeName.NamespacedTypeName}Library.h", Content = s.serializableTypeLibraryHeader,
+				},
+				new GeneratedFileDescriptor
+				{
+					FileName = $"{cppFileOutputPath}AutoGen/{serializedTypeName.NamespacedTypeName}Library.cpp", Content = s.serializableTypeLibraryCpp,
+				},
 			};
 		}));
 
@@ -407,11 +413,13 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 			{
 				new GeneratedFileDescriptor
 				{
-					FileName = $"{headerFileOutputPath}AutoGen/SubSystems/{decl.NamespacedOwnerServiceName}/{decl.GlobalNamespacedEndpointName}Request.h", Content = sc.endpointHeader
+					FileName = $"{headerFileOutputPath}AutoGen/SubSystems/{decl.NamespacedOwnerServiceName}/{decl.GlobalNamespacedEndpointName}Request.h",
+					Content = sc.endpointHeader
 				},
 				new GeneratedFileDescriptor
 				{
-					FileName = $"{cppFileOutputPath}AutoGen/SubSystems/{decl.NamespacedOwnerServiceName}/{decl.GlobalNamespacedEndpointName}Request.cpp", Content = sc.endpointCpp
+					FileName = $"{cppFileOutputPath}AutoGen/SubSystems/{decl.NamespacedOwnerServiceName}/{decl.GlobalNamespacedEndpointName}Request.cpp",
+					Content = sc.endpointCpp
 				},
 				new GeneratedFileDescriptor
 				{
@@ -467,9 +475,7 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 			{
 				var enumDecl = new UnrealEnumDeclaration
 				{
-					UnrealTypeName = schemaUnrealType,
-					NamespacedTypeName = schemaNamespacedType,
-					EnumValues = schema.Enum.OfType<OpenApiString>().Select(v => v.Value).ToList()
+					UnrealTypeName = schemaUnrealType, NamespacedTypeName = schemaNamespacedType, EnumValues = schema.Enum.OfType<OpenApiString>().Select(v => v.Value).ToList()
 				};
 
 				enumTypes.Add(enumDecl);
@@ -583,7 +589,8 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 						{
 							NamespacedTypeName = GetNamespacedTypeNameFromUnrealType(overridenWrapperType),
 							PolymorphicWrappedTypes =
-								ptrWrappedTypes.Select(s => new PolymorphicWrappedData { UnrealType = s, ExpectedTypeValue = polymorphicWrappedSchemaExpectedTypeValues[s] }).ToList(),
+								ptrWrappedTypes.Select(s => new PolymorphicWrappedData { UnrealType = s, ExpectedTypeValue = polymorphicWrappedSchemaExpectedTypeValues[s] })
+									.ToList(),
 							UPropertyDeclarations = ptrWrappedTypes.Select(s => new UnrealPropertyDeclaration
 							{
 								PropertyUnrealType = s,
@@ -879,7 +886,8 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 								var arrayTypeSchema = isReference ? fieldSchema.Items.GetEffective(openApiDocument) : fieldSchema.Items;
 								if (arrayTypeSchema.Extensions.TryGetValue(EXTENSION_BEAMABLE_SEMANTIC_TYPE, out var e) && e is OpenApiString)
 								{
-									var arraySerializationUnrealType = GetNonOptionalUnrealTypeFromFieldSchema(ns.Document, arrayTypeSchema, out _, UnrealTypeGetFlags.NeverSemanticType);
+									var arraySerializationUnrealType =
+										GetNonOptionalUnrealTypeFromFieldSchema(ns.Document, arrayTypeSchema, out _, UnrealTypeGetFlags.NeverSemanticType);
 									fieldSemanticTypesUnderlyingTypeMap.TryAdd(handle, arraySerializationUnrealType);
 									continue;
 								}
@@ -1014,7 +1022,8 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 						var unrealProperty = new UnrealPropertyDeclaration();
 						unrealProperty.PropertyUnrealType = GetUnrealTypeFromSchema(openApiDocument, paramFieldHandle, paramSchema, out _);
 						unrealProperty.PropertyNamespacedType = GetNamespacedTypeNameFromUnrealType(unrealProperty.PropertyUnrealType);
-						unrealProperty.PropertyName = UnrealPropertyDeclaration.GetPrimitiveUPropertyFieldName(unrealProperty.PropertyUnrealType, param.Name, kSchemaGenerationBuilder);
+						unrealProperty.PropertyName =
+							UnrealPropertyDeclaration.GetPrimitiveUPropertyFieldName(unrealProperty.PropertyUnrealType, param.Name, kSchemaGenerationBuilder);
 						unrealProperty.RawFieldName = param.Name;
 						unrealProperty.PropertyDisplayName = unrealProperty.PropertyName.SpaceOutOnUpperCase();
 						unrealProperty.NonOptionalTypeName = GetNonOptionalUnrealTypeFromFieldSchema(openApiDocument, paramSchema, out _);
@@ -1036,7 +1045,8 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 								unrealEndpoint.RequestPathParameters.Add(unrealProperty);
 								break;
 							default:
-								Console.WriteLine($"Skipping Endpoint Param. ENDPOINT={unrealEndpoint.GlobalNamespacedEndpointName}, PARAM={param.Name}, PARAM.IN={param.In.ToString()}");
+								Console.WriteLine(
+									$"Skipping Endpoint Param. ENDPOINT={unrealEndpoint.GlobalNamespacedEndpointName}, PARAM={param.Name}, PARAM.IN={param.In.ToString()}");
 								break;
 						}
 					}
@@ -1078,11 +1088,11 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 								var writer = new OpenApiJsonWriter(sw);
 								bodySchema.SerializeAsV3WithoutReference(writer);
 								Console.WriteLine($"{serviceTitle}-{serviceName}-{unrealEndpoint.GlobalNamespacedEndpointName} FROM {operationType.ToString()} {endpointPath}\n" +
-												  string.Join("\n", unrealEndpoint.RequestQueryParameters.Select(qd => $"{qd.PropertyUnrealType} {qd.PropertyName}")) +
-												  "\n" + string.Join("\n", unrealEndpoint.RequestPathParameters.Select(qd => $"{qd.PropertyUnrealType} {qd.PropertyName}")) +
-												  "\n" + string.Join("\n", unrealEndpoint.RequestBodyParameters.Select(qd => $"{qd.PropertyUnrealType} {qd.PropertyName}")) +
-												  $"\n{unrealEndpoint.ResponseBodyUnrealType}" +
-												  $"\n{sw}");
+								                  string.Join("\n", unrealEndpoint.RequestQueryParameters.Select(qd => $"{qd.PropertyUnrealType} {qd.PropertyName}")) +
+								                  "\n" + string.Join("\n", unrealEndpoint.RequestPathParameters.Select(qd => $"{qd.PropertyUnrealType} {qd.PropertyName}")) +
+								                  "\n" + string.Join("\n", unrealEndpoint.RequestBodyParameters.Select(qd => $"{qd.PropertyUnrealType} {qd.PropertyName}")) +
+								                  $"\n{unrealEndpoint.ResponseBodyUnrealType}" +
+								                  $"\n{sw}");
 							}
 							else
 							{
@@ -1129,11 +1139,11 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 								var writer = new OpenApiJsonWriter(sw);
 								bodySchema.SerializeAsV3WithoutReference(writer);
 								Console.WriteLine($"{serviceTitle}-{serviceName}-{unrealEndpoint.GlobalNamespacedEndpointName} FROM {operationType.ToString()} {endpointPath}\n" +
-												  string.Join("\n", unrealEndpoint.RequestQueryParameters.Select(qd => $"{qd.PropertyUnrealType} {qd.PropertyName}")) +
-												  "\n" + string.Join("\n", unrealEndpoint.RequestPathParameters.Select(qd => $"{qd.PropertyUnrealType} {qd.PropertyName}")) +
-												  "\n" + string.Join("\n", unrealEndpoint.RequestBodyParameters.Select(qd => $"{qd.PropertyUnrealType} {qd.PropertyName}")) +
-												  $"\n{unrealEndpoint.ResponseBodyUnrealType}" +
-												  $"\n{sw}");
+								                  string.Join("\n", unrealEndpoint.RequestQueryParameters.Select(qd => $"{qd.PropertyUnrealType} {qd.PropertyName}")) +
+								                  "\n" + string.Join("\n", unrealEndpoint.RequestPathParameters.Select(qd => $"{qd.PropertyUnrealType} {qd.PropertyName}")) +
+								                  "\n" + string.Join("\n", unrealEndpoint.RequestBodyParameters.Select(qd => $"{qd.PropertyUnrealType} {qd.PropertyName}")) +
+								                  $"\n{unrealEndpoint.ResponseBodyUnrealType}" +
+								                  $"\n{sw}");
 							}
 						}
 						else if (response.Content.TryGetValue("text/plain", out jsonResponse))
@@ -1175,7 +1185,8 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 			}
 
 			unrealServiceDecl.IncludeStatements.AddRange(
-				unrealServiceDecl.GetAllEndpoints().Select(e => $"#include \"{headerFileOutputPath}AutoGen/SubSystems/{e.NamespacedOwnerServiceName}/{e.GlobalNamespacedEndpointName}Request.h\"")
+				unrealServiceDecl.GetAllEndpoints().Select(e =>
+					$"#include \"{headerFileOutputPath}AutoGen/SubSystems/{e.NamespacedOwnerServiceName}/{e.GlobalNamespacedEndpointName}Request.h\"")
 			);
 
 			// If we had declared it already, replace that old declaration with the new one.
@@ -1210,14 +1221,15 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 
 	private static bool IsUnrealContainerOrWrapperType(string unrealType)
 	{
-		return unrealType.StartsWith(UNREAL_ARRAY) || unrealType.StartsWith(UNREAL_MAP) || unrealType.StartsWith(UNREAL_OPTIONAL) || unrealType.StartsWith(UNREAL_U_OBJECT_PREFIX) ||
-			   UNREAL_ALL_SEMTYPES.Contains(unrealType);
+		return unrealType.StartsWith(UNREAL_ARRAY) || unrealType.StartsWith(UNREAL_MAP) || unrealType.StartsWith(UNREAL_OPTIONAL) ||
+		       unrealType.StartsWith(UNREAL_U_OBJECT_PREFIX) ||
+		       UNREAL_ALL_SEMTYPES.Contains(unrealType);
 	}
 
 	private static bool IsUnrealPrimitiveType(string unrealType)
 	{
 		return unrealType.StartsWith(UNREAL_BYTE) || unrealType.StartsWith(UNREAL_SHORT) || unrealType.StartsWith(UNREAL_INT) || unrealType.StartsWith(UNREAL_LONG) ||
-			   unrealType.StartsWith(UNREAL_FLOAT) || unrealType.StartsWith(UNREAL_DOUBLE);
+		       unrealType.StartsWith(UNREAL_FLOAT) || unrealType.StartsWith(UNREAL_DOUBLE);
 	}
 
 
@@ -1322,7 +1334,8 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 	/// <param name="httpVerb"></param>
 	/// <param name="endpointPath"></param>
 	/// <param name="endpointNameOverlaps">Not passing in this, will make you ignore name overlap resolution</param>
-	public static string GetSubsystemNamespacedEndpointName(string serviceName, bool isObjectService, OperationType httpVerb, string endpointPath, Dictionary<string, bool> endpointNameOverlaps = null)
+	public static string GetSubsystemNamespacedEndpointName(string serviceName, bool isObjectService, OperationType httpVerb, string endpointPath,
+		Dictionary<string, bool> endpointNameOverlaps = null)
 	{
 		// If an object service, we need to skip 4 '/' to get what we want (/object/mail/{objectId}/whatWeWant)
 		var skipsLeft = isObjectService ? 4 : 3;
@@ -1402,8 +1415,8 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 		if (doesConflict)
 		{
 			throw new ArgumentException($"{methodName} was found in more than one service. " +
-										$"In this case, this is because you have two microservices with the same name OR because this name clashes with an existing Beamable API. " +
-										$"Please change your Microservice name to resolve this.");
+			                            $"In this case, this is because you have two microservices with the same name OR because this name clashes with an existing Beamable API. " +
+			                            $"Please change your Microservice name to resolve this.");
 		}
 
 		// In case we want to manually override an endpoint's name...
@@ -1434,8 +1447,8 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 		if (doesConflict)
 		{
 			throw new ArgumentException($"{methodName} was overloaded in {serviceName}. " +
-										$"We do not support overloading Callable/ClientCallable/AdminCallable functions." +
-										$"Please rename all overloads to resolve this.");
+			                            $"We do not support overloading Callable/ClientCallable/AdminCallable functions." +
+			                            $"Please rename all overloads to resolve this.");
 		}
 
 		// In case we want to manually override an endpoint's name...
@@ -1461,7 +1474,8 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 	/// <param name="fieldDeclarationHandle">A string created by <see cref="GetFieldDeclarationHandle"/>. Should null or empty, if generating the type name instead of a field/parameter's declaration.</param>
 	/// <param name="schema">The field schema (value of <see cref="OpenApiSchema.Properties"/>).</param>
 	/// <returns>The correct Unreal-land type as a string.</returns>
-	public static string GetUnrealTypeFromSchema([NotNull] OpenApiDocument parentDoc, [NotNull] string fieldDeclarationHandle, [NotNull] OpenApiSchema schema, out string nonOverridenUnrealType,
+	public static string GetUnrealTypeFromSchema([NotNull] OpenApiDocument parentDoc, [NotNull] string fieldDeclarationHandle, [NotNull] OpenApiSchema schema,
+		out string nonOverridenUnrealType,
 		UnrealTypeGetFlags Flags = UnrealTypeGetFlags.None)
 	{
 		// The field is considered an optional type ONLY if it is in the dictionary AND it's value in the dictionary is false.
@@ -1514,7 +1528,8 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 					unrealType = $"F{referenceId}";
 
 					if (isEnum)
-						Console.WriteLine($"ENUM ={unrealType}, {referenceId}, {string.Join("-", schema.GetEffective(parentDoc).Enum.OfType<OpenApiString>().Select(s => s.Value))}\n");
+						Console.WriteLine(
+							$"ENUM ={unrealType}, {referenceId}, {string.Join("-", schema.GetEffective(parentDoc).Enum.OfType<OpenApiString>().Select(s => s.Value))}\n");
 				}
 				else if (isEnum)
 				{
@@ -1941,6 +1956,33 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 
 		// If (SomethingArrayey | SomethingMappy | SomethingOptional) aren't any of the raw cases above, we just prepend an 'U' and '*' to it.
 		return $"U{namespacedWrappedType}*";
+	}
+
+	/// <summary>
+	/// Gets an Unreal type from a <see cref="System.Type"/>. Used primarily for code generating the CLI interface for invocation from inside Unreal. 
+	/// </summary>
+	public static string GetUnrealTypeFromReflectionType(Type unrealWrapperType)
+	{
+		if (unrealWrapperType == typeof(byte))
+			return UNREAL_BYTE;
+		if (unrealWrapperType == typeof(short))
+			return UNREAL_SHORT;
+		if (unrealWrapperType == typeof(int))
+			return UNREAL_INT;
+		if (unrealWrapperType == typeof(long))
+			return UNREAL_LONG;
+		if (unrealWrapperType == typeof(bool))
+			return UNREAL_BOOL;
+		if (unrealWrapperType == typeof(float))
+			return UNREAL_FLOAT;
+		if (unrealWrapperType == typeof(double))
+			return UNREAL_DOUBLE;
+		if (unrealWrapperType == typeof(string))
+			return UNREAL_STRING;
+		if (unrealWrapperType == typeof(Guid))
+			return UNREAL_GUID;
+
+		throw new ArgumentException("We don't support making unreal types from non-primitive reflection types");
 	}
 
 	/// <summary>

--- a/cli/cli/cli.csproj
+++ b/cli/cli/cli.csproj
@@ -74,8 +74,8 @@
     <Exec Command="dotnet tool restore"/>
   </Target>
   <Target Name="BuildCLIInterface" AfterTargets="Build" Condition="$(DOTNET_RUNNING_IN_CONTAINER)!=true">
-    <Exec Condition="'$(IsWindows)'!='true'" Command="./$(OutDir)/$(AssemblyName) generate-interface --output=../../client/Packages/com.beamable/Editor/BeamCli/Commands" />
-    <Exec Condition="'$(IsWindows)'=='true'" Command=".\$(OutDir)$(AssemblyName) generate-interface --output=..\..\client\Packages\com.beamable\Editor\BeamCli\Commands" />
+    <Exec Condition="'$(IsWindows)'!='true'" Command="./$(OutDir)/$(AssemblyName) generate-interface --engine unity --output=../../client/Packages/com.beamable/Editor/BeamCli/Commands" />
+    <Exec Condition="'$(IsWindows)'=='true'" Command=".\$(OutDir)$(AssemblyName) generate-interface --engine unity --output=..\..\client\Packages\com.beamable\Editor\BeamCli\Commands" />
     <Exec Command="dotnet tool run dotnet-format ../../client/Packages/com.beamable/Editor/BeamCli/Commands" />
 
   </Target>


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3544

# Brief Description
We don't generate type-safe args for Unreal. At the moment, I think the maintenance costs outweight the advantages. Let's see if we can get away with simply having the docs from the --help commands transferred to the generated code's comments.

As we build the UE integration with SAMS, we can decided whether or not it is worth it.

# Checklist
* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Is there an appropriate JIRA ticket number, and is it named in the title?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
* [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)
* [ ] Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

# Notes
When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 
