### PR TITLE
[BEAM-3608] Version variable name changed and some string formatting

### DIFF
--- a/client/Packages/com.beamable/Editor/BeamableAssistant/BeamableToolbarExtender/BeamableToolbarExtender.cs
+++ b/client/Packages/com.beamable/Editor/BeamableAssistant/BeamableToolbarExtender/BeamableToolbarExtender.cs
@@ -252,12 +252,12 @@ namespace Beamable.Editor.ToolbarExtender
 					// referencing https://docs.unity3d.com/Manual/upm-lifecycle.html
 					if (package.registry == null)
 						return false; // no registry implies a local package, which won't trigger.
-					if (!PackageVersion.TryFromSemanticVersionString(package.version, out var version))
+					if (!PackageVersion.TryFromSemanticVersionString(package.version, out var ver))
 					{
 						return true; // this isn't a valid package version, so we'll assume its a preview.
 					}
 
-					var isPreview = version.IsExperimental || version.IsPreview;
+					var isPreview = ver.IsExperimental || ver.IsPreview;
 					return isPreview;
 				});
 

--- a/client/Packages/com.beamable/Editor/Modules/Content/ContentDatabase.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/ContentDatabase.cs
@@ -138,15 +138,18 @@ namespace Beamable.Editor.Content
 						else
 						{
 							// we weren't able to resolve it :( 
-							Debug.LogError(@$"Unable to find a content type for type=[{currType}].
-This can happen if the content folders have different names than the content attribute strings. 
-Make sure that the {root} folder and sub folder names match the content attribute strings exactly.
-This could also happen if you are missing content classes for content in the realm. 
-
-If you are sure you have all the content classes, but nothing is working, follow these steps...
-1. make a backup of your {root} folder...
-2. delete the {root} folder...
-3. download content from the Content Manager...");
+							Debug.LogError($"Unable to find a content type for type=[{currType}]." +
+							               $"\nThis can happen if the content folders have different names than the " +
+							               $"content attribute strings. " +
+							               $"\nMake sure that the {root} folder and sub folder names match the content " +
+							               $"attribute strings exactly." +
+							               $"\nThis could also happen if you are missing " +
+							               $"content classes for content in the realm. " +
+							               $"\n\nIf you are sure you have " +
+							               $"all the content classes, but nothing is working, follow these steps..." +
+							               $"\n1. make a backup of your {root} folder..." +
+							               $"\n2. delete the {root} folder..." +
+							               $"\n3. download content from the Content Manager...");
 						}
 					}
 				}


### PR DESCRIPTION
# Ticket
https://disruptorbeam.atlassian.net/browse/BEAM-3608

# Brief Description
In Unity 2019 I've had some compilation errors related to duplicated version variable name (one of them was hiding under directive for UNITY 2019 so probably someone was implementing this on higher version). Also I've found that multi line string in ContentDatabase class was causing troubles during recompilation so I've reformatted it.

# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
