### PR TITLE
beam 3648 - use localhost for local mongo

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - fix issues with failing `project new` command
+- `beam project open-mongo` opens the browser to `localhost` instead of `0.0.0.0`
 
 ## [1.16.0]
 

--- a/cli/cli/Commands/Project/OpenMongoExpressCommand.cs
+++ b/cli/cli/Commands/Project/OpenMongoExpressCommand.cs
@@ -40,7 +40,7 @@ public class OpenMongoExpressCommand : AppCommand<OpenMongoExpressCommandArgs>
 			var res = await args.BeamoLocalSystem.GetOrCreateMongoExpress(args.storageName, connStr.Value);
 
 			var port = res.NetworkSettings.Ports["8081/tcp"][0];
-			var url = $"http://{port.HostIP}:{port.HostPort}";
+			var url = $"http://localhost:{port.HostPort}";
 			Log.Information($"Opening web page {url}");
 			await Task.Delay(250); // give mongo a chance to boot :(
 			MachineHelper.OpenBrowser(url);


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3648

# Brief Description

The ip that we were getting back from docker is the machine ip; but we always want to use localhost.

# Checklist

* [X] Have you added appropriate text to the CHANGELOG.md files?

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
