### PR TITLE
[BEAM-3688] Separate CoroutineService in WaitForUpdate

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use separate `CoroutineService` in WebSocket so it will not fail after `BeamContext` disposal
+
 ### Added
 
 - `PerformLocalLogin` method in `SignInWithGPG` class

--- a/client/Packages/com.beamable/Runtime/3rdParty/WebSocket/WebSocket.cs
+++ b/client/Packages/com.beamable/Runtime/3rdParty/WebSocket/WebSocket.cs
@@ -22,6 +22,7 @@ namespace Beamable.Endel
 		public static void Setup()
 		{
 			synchronizationContext = SynchronizationContext.Current;
+			WaitForUpdate.Init();
 		}
 
 		public static void Run(IEnumerator waitForUpdate, CoroutineService coroutineService)
@@ -35,22 +36,23 @@ namespace Beamable.Endel
 
 	public class WaitForUpdate : CustomYieldInstruction
 	{
-		private readonly CoroutineService _coroutineService;
+		static CoroutineService CoroutineService;
 
 		public override bool keepWaiting
 		{
 			get { return false; }
 		}
 
-		public WaitForUpdate(CoroutineService coroutineService)
+		public static void Init()
 		{
-			_coroutineService = coroutineService;
+			CoroutineService = new GameObject(nameof(BeamMainThreadUtil)).AddComponent<CoroutineService>();
+			CoroutineService.gameObject.hideFlags = HideFlags.HideAndDontSave;
 		}
 
 		public MainThreadAwaiter GetAwaiter()
 		{
 			var awaiter = new MainThreadAwaiter();
-			BeamMainThreadUtil.Run(CoroutineWrapper(this, awaiter), _coroutineService);
+			BeamMainThreadUtil.Run(CoroutineWrapper(this, awaiter), CoroutineService);
 			return awaiter;
 		}
 
@@ -712,7 +714,7 @@ namespace Beamable.Endel
 				}
 				finally
 				{
-					await new WaitForUpdate(_coroutineService);
+					await new WaitForUpdate();
 					OnClose?.Invoke(closeCode);
 				}
 			}


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3688

# Brief Description

> Use separate `CoroutineService` in WebSocket so it will not fail after `BeamContext` disposal

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
