### PR TITLE
[BEAM-3689] Unity 2022 window styling bug

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Common/Common.2022.uss
+++ b/client/Packages/com.beamable/Editor/UI/Common/Common.2022.uss
@@ -1,0 +1,6 @@
+
+.beamableErrorLabel.beamableErrorHidden {
+    position: absolute;
+    left: 0px;
+    display: none;
+}

--- a/client/Packages/com.beamable/Editor/UI/Common/Common.2022.uss.meta
+++ b/client/Packages/com.beamable/Editor/UI/Common/Common.2022.uss.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 83f4c2e2821ae764a977d18f38fb6a1d
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: stylesheet
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}

--- a/client/Packages/com.beamable/Editor/UI/Common/UIElementsPolyfill.cs
+++ b/client/Packages/com.beamable/Editor/UI/Common/UIElementsPolyfill.cs
@@ -484,12 +484,14 @@ public static class UssLoader
 		var u2019Path = ussPath.Replace(".uss", ".2019.uss");
 		var u2020Path = ussPath.Replace(".uss", ".2020.uss");
 		var u2021Path = ussPath.Replace(".uss", ".2021.uss");
+		var u2022Path = ussPath.Replace(".uss", ".2022.uss");
 		var darkAvailable = File.Exists(darkPath);
 		var lightAvailable = File.Exists(lightPath);
 		var u2018Available = File.Exists(u2018Path);
 		var u2019Available = File.Exists(u2019Path);
 		var u2020Available = File.Exists(u2020Path);
 		var u2021Available = File.Exists(u2021Path);
+		var u2022Available = File.Exists(u2022Path);
 
 		if (EditorGUIUtility.isProSkin && darkAvailable)
 		{
@@ -523,8 +525,15 @@ public static class UssLoader
 
 		if (u2021Available)
 		{
-#if UNITY_2021_1_OR_NEWER // 2021 is the max supported version, so we forward lean and assume all uss works in 2022.
+#if UNITY_2021_1_OR_NEWER
 			ussPaths.Add(u2021Path);
+#endif
+		}
+
+		if (u2022Available)
+		{
+#if UNITY_2022_1_OR_NEWER // 2022 is the max supported version, so we forward lean and assume all uss works in 2023.
+			ussPaths.Add(u2022Path);
 #endif
 		}
 


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3689

# Brief Description
![image](https://github.com/beamable/BeamableProduct/assets/13188195/fc40ea03-99b2-4c38-9e28-b2bcee2e8310)

# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
