### PR TITLE
beam 3691 - 2022 content editor compat

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -17,10 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix issues with failing `project new` command
 - `beam project open-mongo` opens the browser to `localhost` instead of `0.0.0.0`
 
-### Fixed
-
-- `beam project generate-env` loads `.dll` files into new context, allowing for multiple versions of similar libraries
-
 ## [1.16.0]
 
 ### Added

--- a/cli/cli/Commands/Project/GenerateClientFileCommand.cs
+++ b/cli/cli/Commands/Project/GenerateClientFileCommand.cs
@@ -4,9 +4,9 @@ using Beamable.Server.Editor;
 using Beamable.Server.Generator;
 using Beamable.Tooling.Common.OpenAPI;
 using cli.Unreal;
+using microservice.Common;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
-using Serilog;
 using System.CommandLine;
 using System.Globalization;
 using System.Reflection;
@@ -40,32 +40,14 @@ public class GenerateClientFileCommand : AppCommand<GenerateClientFileCommandArg
 
 		var absolutePath = Path.GetFullPath(args.microserviceAssemblyPath);
 		var absoluteDir = Path.GetDirectoryName(absolutePath);
-		var loadContext = new AssemblyLoadContext("generate-client-context", false);
-		loadContext.Resolving += (context, name) =>
+		AssemblyLoadContext.Default.Resolving += (context, name) =>
 		{
 			var assemblyPath = Path.Combine(absoluteDir, $"{name.Name}.dll");
-			try
-			{
-				Log.Verbose($"loading dll name=[{name.Name}] version=[{name.Version}]");
-				if (assemblyPath != null)
-					return context.LoadFromAssemblyPath(assemblyPath);
-				return null;
-			}
-			catch (Exception ex)
-			{
-				BeamableLogger.LogError($@"Unable to load dll at path=[{assemblyPath}] 
-name=[{name}] 
-context=[{context.Name}]
-message=[{ex.Message}]
-ex-type=[{ex.GetType().Name}]
-inner-message=[{ex.InnerException?.Message}]
-inner-type=[{ex.InnerException?.GetType().Name}]
-");
-				throw;
-			}
+			if (assemblyPath != null)
+				return context.LoadFromAssemblyPath(assemblyPath);
+			return null;
 		};
-		
-		var userAssembly = loadContext.LoadFromAssemblyPath(absolutePath);
+		var userAssembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(absolutePath);
 
 		#endregion
 


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3691

# Brief Description

The thing in the ticket was that I guess in Unity 2022, they got rid of the function I was calling with "jank-ass-reflection" ™️ , so I changed it to use `TypeCache`, everywhere. `TypeCache` wasn't supported in ye olde 2018 days, but those days are long gone, so, hoozah!

Then I noticed another issue, which is that they fixed a typo they'd made. Good for them :+1: 

# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?
2022 support no changelog needed.
# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
