### PR TITLE
beam 3687 skin error on install 2022

### DIFF
--- a/client/Packages/com.beamable/Editor/BeamableAssistant/BeamableToolbarExtender/BeamableToolbarExtender.cs
+++ b/client/Packages/com.beamable/Editor/BeamableAssistant/BeamableToolbarExtender/BeamableToolbarExtender.cs
@@ -184,6 +184,12 @@ namespace Beamable.Editor.ToolbarExtender
 			// Create two containers, left and right
 			// Screen is whole toolbar
 
+			if (GUI.skin == null)
+			{
+				Debug.LogWarning("Editor skin has not been loaded yet, so Beamable Toolbar is creating it.");
+				GUI.skin = EditorGUIUtility.GetBuiltinSkin(EditorSkin.Inspector);
+			}
+			
 			if (_commandStyle == null)
 			{
 				_commandStyle = new GUIStyle("CommandLeft");


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3687

# Brief Description

The error message in the ticket as no description, and I can't reproduce this with a local package install... So I'm taking a shot in the dark that this may be the cause. This only happens in 2022. 
Mostly, I'd like to build a nightly release and see what happens.

# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?
No, part of 2022 support