### PR TITLE
beam 3521 - mongo id field usage

### DIFF
--- a/client/Packages/com.beamable.server/Runtime/Common/Mocks/MongoDB/Bson/BsonElement.cs
+++ b/client/Packages/com.beamable.server/Runtime/Common/Mocks/MongoDB/Bson/BsonElement.cs
@@ -1,0 +1,37 @@
+using System;
+#if !BEAMABLE_IGNORE_MONGO_MOCKS
+
+namespace MongoDB.Bson.Serialization.Attributes
+{
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+	public class BsonElementAttribute : Attribute, IBsonMemberMapAttribute
+	{
+		private string _elementName;
+		private int _order = int.MaxValue;
+
+		public BsonElementAttribute()
+		{
+		}
+
+		public BsonElementAttribute(string elementName) => this._elementName = elementName;
+
+		public string ElementName => this._elementName;
+
+		public int Order
+		{
+			get => this._order;
+			set => this._order = value;
+		}
+
+		/// <summary>
+		/// Do not use this method from Unity.
+		/// </summary>
+		/// <exception cref="InvalidOperationException"></exception>
+		[Obsolete("this method is not meant to be used from Unity, and will throw an exception")]
+		public void Apply()
+		{
+			throw new NotImplementedException(nameof(Apply) + " is not supported in Unity");
+		}
+	}
+}
+#endif

--- a/client/Packages/com.beamable.server/Runtime/Common/Mocks/MongoDB/Bson/BsonElement.cs.meta
+++ b/client/Packages/com.beamable.server/Runtime/Common/Mocks/MongoDB/Bson/BsonElement.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2c016a59b15d42fda67e41728e329ffa
+timeCreated: 1687947003

--- a/client/Packages/com.beamable.server/Runtime/Common/StorageDocument.cs
+++ b/client/Packages/com.beamable.server/Runtime/Common/StorageDocument.cs
@@ -9,16 +9,21 @@ namespace Beamable.Server
 	public class StorageDocument
 	{
 		[SerializeField]
-		[BsonRepresentation(BsonType.ObjectId)]
-		[BsonId]
-		[BsonIgnoreIfDefault]
-		[BsonIgnoreIfNull]
-		private string _id = null; // MongoDb driver will auto-set this.
+		[BsonIgnore]
+		private string _id = null;
 
 		/// <summary>
 		/// The unique Mongo ID of the instance. This is automatically created when the object is first sent to the database.
 		/// </summary>
-		[BsonIgnore]
-		public string Id => _id;
+		[BsonId]
+		[BsonElement(nameof(_id))]
+		[BsonRepresentation(BsonType.ObjectId)]
+		[BsonIgnoreIfDefault]
+		[BsonIgnoreIfNull]
+		public string Id
+		{
+			get => _id;
+			protected set => _id = value;
+		}
 	}
 }

--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -5,13 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.16.1]
 
 ### Added
 
 ### Changed
 
 ### Fixed
+
+- `StorageDocument` types can use `Id` in Mongo Filter Expressions.
 
 ## [1.16.0]
 


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3521

# Brief Description

Before, if you tried to write this,
```csharp
[ClientCallable]
public async Task<CanO> Toast(string id)
{
	var coll = await Storage.TunaCollection<CanO>();
	var res = await coll.FindAsync(d => d.Id == id);
	var doc = await res.FirstOrDefaultAsync();
	return doc;
}
```

With a storage document like this,
```csharp
public class CanO : StorageDocument
{
   public int a;
}
```

It would break, because the `FindAsync(d => d.Id == id);` is actually a tricksy call that is using C# `Expression` trees to map the `Id` property to some backing mongo field. But, our `Id` property comes from `StorageDocument`, and we used to have `[BsonIgnore]` on it, which meant we'd get an error saying, "no field for Id"...

We are trying to meet several constraints all at once
1. the storage document should be serializable in Unity with Json
2. the storage document should be serializable in Mongo with Bson
3. we shouldn't have duplicated information outside of _memory_. Like, the mongo class and other serialization structures shouldn't have _two_ Id fields.
4. we need to keep all backwards compat


What I did, was to invert the control on which member in `StorageDocument` "owns" the mongo id. I changed it from `_id` to `Id`, so that the property itself is the id owner. I used the `[BsonElement(nameof(_id))]` attribute on the `Id` property to make Mongo serialize it as before (for backwards compat). The `_id` field is now a JSON serialization utility for Unity.

I've tested this in SAMS, and also In Unity. I've created a C#MS and Storage in Unity with a `StorageDocument` in the common folder, and created this example
```csharp
public MatchDocTest wignut;
public List<MatchDocTest> wignu2;

  // Start is called before the first frame update
  async void Start()
  {
	  var ctx = await BeamContext.Default.Instance;
	  wignut = await ctx.Microservices().Dispatching().AddWingNut(6);

	  wignu2 = await ctx.Microservices().Dispatching().GetById(wignut.Id);
  }
 ```

And indeed, Unity is able to handle this correctly. I've checked in MongoExpress to make sure there is still a `ObjectId(_id)` field. 


---

At this point, I don't think the Docs need an update, because now the intuitive, "you can just use the Id" works as people would have expected. 

# Checklist

* [X] Have you added appropriate text to the CHANGELOG.md files?

