### PR TITLE
added -q flag for install, and changed pd to ls

### DIFF
--- a/cli/cli/CommandContext.cs
+++ b/cli/cli/CommandContext.cs
@@ -96,7 +96,7 @@ public abstract partial class AppCommand<TArgs> : Command, IResultProvider
 		return arg;
 	}
 
-	protected void AddOption<T>(Option<T> arg, Action<TArgs, T> binder)
+	protected Option<T> AddOption<T>(Option<T> arg, Action<TArgs, T> binder)
 	{
 		ArgValidator<T> validator = CommandProvider.CanBuildService<ArgValidator<T>>()
 			? CommandProvider.GetService<ArgValidator<T>>()
@@ -125,6 +125,7 @@ public abstract partial class AppCommand<TArgs> : Command, IResultProvider
 
 		_bindingActions.Add(set);
 		base.AddOption(arg);
+		return arg;
 	}
 
 	/// <summary>

--- a/cli/cli/Commands/Version/VersionListCommand.cs
+++ b/cli/cli/Commands/Version/VersionListCommand.cs
@@ -12,7 +12,7 @@ public class VersionListCommandArgs : CommandArgs
 }
 public class VersionListCommand : AppCommand<VersionListCommandArgs>
 {
-	public VersionListCommand() : base("ps", "Show the most recent available versions")
+	public VersionListCommand() : base("list", "Show the most recent available versions")
 	{
 	}
 
@@ -21,6 +21,7 @@ public class VersionListCommand : AppCommand<VersionListCommandArgs>
 		AddOption(new Option<int>("--limit", () => 10, "How many package versions to display"), (args, i) => args.limit = i);
 		AddOption(new Option<bool>("--include-rc", () => false, "Should release candidates be shown"), (args, i) => args.includeRc = i);
 		AddOption(new Option<bool>("--include-release", () => true, "Should stable releases be shown"), (args, i) => args.includeProd = i);
+		AddAlias("ls");
 	}
 
 	public override async Task Handle(VersionListCommandArgs args)


### PR DESCRIPTION

# Brief Description

The `beam version` command stuff got some feedback during sprint demo
1. `beam version ps` should be `beam version list`, I also added an alias so you can do `beam version ls`
2. the `beam version install` should have a prompt unless you give it the `--quiet` option. I also added an alias for the option as `-q` 

# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
