### PR TITLE
[BEAM-3712] RecoverAccountWithRefreshToken methods

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.16.2]
 
+### Added
+
+- new `RecoverAccountWithRefreshToken` methods in the `PlayerAccounts` class.
+
 ### Fixed
 
 - GPGS compilation issue- move non static action invoke out of a static method

--- a/client/Packages/com.beamable/Runtime/Player/PlayerAccounts.cs
+++ b/client/Packages/com.beamable/Runtime/Player/PlayerAccounts.cs
@@ -1157,6 +1157,43 @@ namespace Beamable.Player
 			return RecoverAccount((auth, merge) => auth.LoginThirdParty(thirdParty, token, merge));
 		}
 
+
+		/// <summary>
+		/// Find an existing account by a <see cref="TokenResponse"/>.
+		///
+		/// Depending on the state of the realm, this method may produce different behaviour.
+		/// The returned <see cref="PlayerRecoveryOperation"/> will either contain the <see cref="PlayerAccount"/>
+		/// for the given <see cref="TokenResponse"/>, or it will have a <see cref="PlayerRecoveryError"/> value.
+		///
+		/// </summary>
+		/// <param name="tokenResponse">
+		/// The auth token.
+		/// </param>
+		/// <returns>A <see cref="PlayerRecoveryOperation"/> containing the <see cref="PlayerAccount"/> or a <see cref="PlayerRecoveryError"/> value.</returns>
+		public Promise<PlayerRecoveryOperation> RecoverAccountWithRefreshToken(
+			TokenResponse tokenResponse)
+		{
+			return RecoverAccountWithRefreshToken(tokenResponse.refresh_token);
+		}
+		
+		/// <summary>
+		/// Find an existing account by a refresh token from a <see cref="TokenResponse"/>.
+		///
+		/// Depending on the state of the realm, this method may produce different behaviour.
+		/// The returned <see cref="PlayerRecoveryOperation"/> will either contain the <see cref="PlayerAccount"/>
+		/// for the given <see cref="TokenResponse"/>, or it will have a <see cref="PlayerRecoveryError"/> value.
+		///
+		/// </summary>
+		/// <param name="refreshToken">
+		/// The refresh token from a <see cref="TokenResponse"/>.
+		/// </param>
+		/// <returns>A <see cref="PlayerRecoveryOperation"/> containing the <see cref="PlayerAccount"/> or a <see cref="PlayerRecoveryError"/> value.</returns>
+		public Promise<PlayerRecoveryOperation> RecoverAccountWithRefreshToken(
+			string refreshToken)
+		{
+			return RecoverAccount((auth, _) => auth.LoginRefreshToken(refreshToken));
+		}
+
 		private async Promise<PlayerRecoveryOperation> RecoverAccount(
 			Func<IAuthService, bool, Promise<TokenResponse>> loginFunction)
 		{


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3712

# Brief Description

> Adds RecoverAccountWithRefreshToken methods to the PlayerAccounts class.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?
* [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
