### PR TITLE
beam 3734- adds decimal support for top level parameters in C#MS

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `[Callable]` methods can accept and return `decimal` primitives
+
 ### Fixed
 
 - `Create` method in `MongoCRUDExtensions` has been made awaitable

--- a/client/Packages/com.beamable.server/Runtime/MicroserviceClient.cs
+++ b/client/Packages/com.beamable.server/Runtime/MicroserviceClient.cs
@@ -6,6 +6,7 @@ using Beamable.Serialization.SmallerJSON;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
@@ -121,6 +122,8 @@ namespace Beamable.Server
 					return prim.ToString();
 				case int prim:
 					return prim.ToString();
+				case decimal prim:
+					return prim.ToString(CultureInfo.InvariantCulture);
 				case Vector2Int prim:
 					return JsonUtility.ToJson(new Vector2IntEx(prim));
 				case Vector3Int prim:
@@ -170,6 +173,8 @@ namespace Beamable.Server
 					return (T)(object)bool.Parse(json);
 				case int _:
 					return (T)(object)int.Parse(json);
+				case decimal _:
+					return (T)(object)decimal.Parse(json);
 				case Vector2Int _:
 					return (T)(object)Vector2IntEx.DeserializeToVector2(json);
 				case Vector3Int _:
@@ -189,6 +194,10 @@ namespace Beamable.Server
 				else if (typeof(Dictionary<string, double>) == type)
 				{
 					result = ConvertArrayDictToDictionary<double>(arrayDict);
+				}
+				else if (typeof(Dictionary<string, decimal>) == type)
+				{
+					result = ConvertArrayDictToDictionary<decimal>(arrayDict);
 				}
 				else if (typeof(Dictionary<string, float>) == type)
 				{

--- a/microservice/beamable.tooling.common/OpenAPI/SchemaGenerator.cs
+++ b/microservice/beamable.tooling.common/OpenAPI/SchemaGenerator.cs
@@ -114,6 +114,8 @@ public class SchemaGenerator
 			
 			case { } x when x == typeof(bool):
 				return new OpenApiSchema { Type = "boolean"};
+			case { } x when x == typeof(decimal):
+				return new OpenApiSchema { Type = "number", Format = "decimal" };
 			
 			case { } x when x == typeof(string):
 				return new OpenApiSchema { Type = "string"};


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3734

# Brief Description

Tomasz hit an issue where he couldn't include a `decimal` in the DTO of a C#MS and have it work in Unity.
Sadly, this is because Unity doesn't support `decimal` in the `JsonUtility` serialization functions. However, we can add a little support, for top-level decimals 🤷 

Thats what this PR does; it only works if the decimal is in the args, or _is_ the return type.

# Checklist

* [X] Have you added appropriate text to the CHANGELOG.md files?
