### PR TITLE
beamable common builds to netstandard2.0

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Beamable.Common nuget package is available for netstandard2.0
+
+### Removed
+
+- `Quaternion` method implementations no longer work in Microservices using netstandard2.0
+
 ## [1.16.3]
 
 ### Added

--- a/client/Packages/com.beamable/Common/Runtime/Promise.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Promise.cs
@@ -12,7 +12,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 
-#if !DISABLE_BEAMABLE_ASYNCMETHODBUILDER && !UNITY_2021_2_OR_NEWER
+#if (!DISABLE_BEAMABLE_ASYNCMETHODBUILDER && !UNITY_2021_2_OR_NEWER) || (NETSTANDARD2_0)
 namespace System.Runtime.CompilerServices
 {
 	public sealed class AsyncMethodBuilderAttribute : Attribute

--- a/client/Packages/com.beamable/Common/Runtime/Scheduler/BeamScheduler.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Scheduler/BeamScheduler.cs
@@ -220,7 +220,10 @@ namespace Beamable.Common.Scheduler
 				ISchedulerTrigger[] triggers,
 				RetryPolicy retryPolicy = null)
 			{
-				retryPolicy ??= new RetryPolicy();
+				if (retryPolicy == null)
+				{
+					retryPolicy = new RetryPolicy();
+				}
 				return new JobDefinitionSaveRequest
 				{
 					name = new OptionalString(name),

--- a/client/Packages/com.beamable/Common/beamable.common.csproj
+++ b/client/Packages/com.beamable/Common/beamable.common.csproj
@@ -11,7 +11,7 @@
         <OutputType>Library</OutputType>
         <VersionPrefix>$(VersionPrefix)</VersionPrefix>
         <PackageOutputPath>./nupkg</PackageOutputPath>
-        <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0;net7.0;netstandard2.1</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/microservice/unityEngineStubs/UnityEngine/Mathf.cs
+++ b/microservice/unityEngineStubs/UnityEngine/Mathf.cs
@@ -59,7 +59,7 @@ namespace UnityEngine {
         }
 
         public static float Sqrt(float a) {
-            return MathF.Sqrt(a);
+            return (float)Math.Sqrt(a);
         }
 
         public static float Clamp01(float a) {
@@ -92,8 +92,12 @@ namespace UnityEngine {
             return a == b ? 0f : Clamp01((t - a) / (b - a));
         }
 
-        public static float Acos(float a) => MathF.Acos(a);
+        public static float Acos(float a) => (float)Math.Acos(a);
 
-        public static float Abs(float a) => MathF.Abs(a);
+        public static float Abs(float a) => Math.Abs(a);
+
+        public static float Sin(float a) => (float)Math.Sin(a);
+
+        public static float Atan2(float a, float b) => (float)Math.Atan2(a, b);
     }
 }

--- a/microservice/unityEngineStubs/UnityEngine/Quaternion.cs
+++ b/microservice/unityEngineStubs/UnityEngine/Quaternion.cs
@@ -5,44 +5,54 @@ using Newtonsoft.Json;
 
 namespace UnityEngine
 {
+
   /// <summary>
   ///   <para>Quaternions are used to represent rotations.</para>
   /// </summary>
   [JsonObject(MemberSerialization.Fields)]
   public struct Quaternion : IEquatable<Quaternion>
   {
-    /// <summary>
-    ///   <para>X component of the Quaternion. Don't modify this directly unless you know quaternions inside out.</para>
-    /// </summary>
-    public float x;
-    /// <summary>
-    ///   <para>Y component of the Quaternion. Don't modify this directly unless you know quaternions inside out.</para>
-    /// </summary>
-    public float y;
-    /// <summary>
-    ///   <para>Z component of the Quaternion. Don't modify this directly unless you know quaternions inside out.</para>
-    /// </summary>
-    public float z;
-    /// <summary>
-    ///   <para>W component of the Quaternion. Do not directly modify quaternions.</para>
-    /// </summary>
-    public float w;
-    public const float kEpsilon = 1E-06f;
+	  
+	  /// <summary>
+	  ///   <para>X component of the Quaternion. Don't modify this directly unless you know quaternions inside out.</para>
+	  /// </summary>
+	  public float x;
+	  /// <summary>
+	  ///   <para>Y component of the Quaternion. Don't modify this directly unless you know quaternions inside out.</para>
+	  /// </summary>
+	  public float y;
+	  /// <summary>
+	  ///   <para>Z component of the Quaternion. Don't modify this directly unless you know quaternions inside out.</para>
+	  /// </summary>
+	  public float z;
+	  /// <summary>
+	  ///   <para>W component of the Quaternion. Do not directly modify quaternions.</para>
+	  /// </summary>
+	  public float w;
+	  public const float kEpsilon = 1E-06f;
 
-    /// <summary>
-    ///   <para>Constructs new Quaternion with given x,y,z,w components.</para>
-    /// </summary>
-    /// <param name="x"></param>
-    /// <param name="y"></param>
-    /// <param name="z"></param>
-    /// <param name="w"></param>
-    public Quaternion(float x, float y, float z, float w)
-    {
-      this.x = x;
-      this.y = y;
-      this.z = z;
-      this.w = w;
-    }
+	  /// <summary>
+	  ///   <para>Constructs new Quaternion with given x,y,z,w components.</para>
+	  /// </summary>
+	  /// <param name="x"></param>
+	  /// <param name="y"></param>
+	  /// <param name="z"></param>
+	  /// <param name="w"></param>
+	  public Quaternion(float x, float y, float z, float w)
+	  {
+		  this.x = x;
+		  this.y = y;
+		  this.z = z;
+		  this.w = w;
+	  }
+	  
+#if NETSTANDARD2_0
+	  public bool Equals(Quaternion other)
+	  {
+		  throw new NotImplementedException("This method is not supported on net standard 2.0");
+	  }
+#else
+
 
     /// <summary>
     ///   <para>Creates a rotation which rotates from fromDirection to toDirection.</para>
@@ -53,8 +63,8 @@ namespace UnityEngine
       var dot = Vector3.Dot(fromDirection, toDirection);
       if (Mathf.Abs(dot) > .99999f) return identity;
       var cross = Vector3.Cross(fromDirection, toDirection);
-      var w = MathF.Sqrt((fromDirection.sqrMagnitude) * (toDirection.sqrMagnitude)) + dot;
-      return new Quaternion(cross.x, cross.y, cross.z, w);
+      var w = Math.Sqrt((fromDirection.sqrMagnitude) * (toDirection.sqrMagnitude)) + dot;
+      return new Quaternion(cross.x, cross.y, cross.z, (float)w);
     }
 
     /// <summary>
@@ -326,14 +336,14 @@ namespace UnityEngine
         float x, y, z;
         if (!singular)
         {
-          x = MathF.Atan2(matrix.M32 , matrix.M33);
-          y =  MathF.Atan2(-matrix.M31, sy);
-          z =  MathF.Atan2(matrix.M21, matrix.M11);
+          x = Mathf.Atan2(matrix.M32 , matrix.M33);
+          y =  Mathf.Atan2(-matrix.M31, sy);
+          z =  Mathf.Atan2(matrix.M21, matrix.M11);
         }
         else
         {
-          x =  MathF.Atan2(-matrix.M23, matrix.M22);
-          y =  MathF.Atan2(-matrix.M31, sy);
+          x =  Mathf.Atan2(-matrix.M23, matrix.M22);
+          y =  Mathf.Atan2(-matrix.M31, sy);
           z = 0;
         }
         return new Vector3(x, y, z);
@@ -527,5 +537,6 @@ namespace UnityEngine
     {
       return AngleAxis(57.29578f * angle, axis);
     }
+#endif
   }
 }

--- a/microservice/unityEngineStubs/UnityEngine/Vector2Int.cs
+++ b/microservice/unityEngineStubs/UnityEngine/Vector2Int.cs
@@ -72,7 +72,7 @@ namespace UnityEngine {
     {
       get
       {
-        return MathF.Sqrt(sqrMagnitude);
+        return Mathf.Sqrt(sqrMagnitude);
       }
     }
 

--- a/microservice/unityEngineStubs/UnityEngine/Vector3.cs
+++ b/microservice/unityEngineStubs/UnityEngine/Vector3.cs
@@ -35,8 +35,9 @@ namespace UnityEngine {
         public static Vector3 Slerp(Vector3 a, Vector3 b, float t) {
             t = Mathf.Clamp01(t);
             var angle = Vector3.Angle(a, b);
-            var sinR = 1f / MathF.Sin(angle);
-            return MathF.Sin((1f - t) * angle) * sinR * a + MathF.Sin(t * angle) * sinR * b;
+            
+            var sinR = 1f / Mathf.Sin(angle);
+            return Mathf.Sin((1f - t) * angle) * sinR * a + Mathf.Sin(t * angle) * sinR * b;
         }
 
         /// <summary>
@@ -47,8 +48,8 @@ namespace UnityEngine {
         /// <param name="t"></param>
         public static Vector3 SlerpUnclamped(Vector3 a, Vector3 b, float t) {
             var angle = Vector3.Angle(a, b);
-            var sinR = 1f / MathF.Sin(angle);
-            return MathF.Sin((1f - t) * angle) * sinR * a + MathF.Sin(t * angle) * sinR * b;
+            var sinR = 1f / Mathf.Sin(angle);
+            return Mathf.Sin((1f - t) * angle) * sinR * a + Mathf.Sin(t * angle) * sinR * b;
         }
 
         public static void OrthoNormalize(ref Vector3 normal, ref Vector3 tangent) {

--- a/microservice/unityEngineStubs/unityenginestubs.csproj
+++ b/microservice/unityEngineStubs/unityenginestubs.csproj
@@ -11,7 +11,7 @@
       <VersionPrefix>$(VersionPrefix)</VersionPrefix>
       <PackageOutputPath>./nupkg</PackageOutputPath>
       <AssemblyName>UnityEngine</AssemblyName>
-      <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
+      <TargetFrameworks>netstandard2.0;net6.0;net7.0;netstandard2.1</TargetFrameworks>
    </PropertyGroup>
    <ItemGroup>
      <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3618

# Brief Description

To make unityEngine stubs work on netStandard2.0, I had to essentially remove the Quaternion class. Microservices are actually going to reference the net6 version of the library, so it will work fine for them. The only time this is actually going to cause a problem is if the unityEngineStubs project is brought into a netstandard2.0 project... But guess what? We don't have any of those at the moment! 

TO make beamable.common work, I had to fuss with the Promise class a bit, and take out a few language features that aren't available in net standard 2.0


# Checklist

* [X] Have you added appropriate text to the CHANGELOG.md files?
