### PR TITLE
beam 3688 - fix various enter/exit playmode errors

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Beamable.Common nuget package is available for netstandard2.0
 
+### Fixed
+
+- Error message, `"Cannot schedule work, because the scheduler has been stopped."`, for Docker commands that finish processing during domain reloads.
+
 ### Removed
 
 - `Quaternion` method implementations no longer work in Microservices using netstandard2.0

--- a/client/Packages/com.beamable.server/Editor/DockerCommands/ProcessCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/ProcessCommand.cs
@@ -247,6 +247,7 @@ namespace Beamable.Server.Editor.DockerCommands
 						Task.Run(async () =>
 						{
 							await Task.Delay(1); // give 1 ms for log messages to eep out
+							if (_dispatcher.IsForceStopped) return;
 							_dispatcher.Schedule(() =>
 							{
 								// there still may pending log lines, so we need to make sure they get processed before claiming the process is complete
@@ -269,6 +270,7 @@ namespace Beamable.Server.Editor.DockerCommands
 
 						_process.OutputDataReceived += (sender, args) =>
 						{
+							if (_dispatcher.IsForceStopped) return;
 							_dispatcher.Schedule(() =>
 							{
 								try
@@ -283,6 +285,7 @@ namespace Beamable.Server.Editor.DockerCommands
 						};
 						_process.ErrorDataReceived += (sender, args) =>
 						{
+							if (_dispatcher.IsForceStopped) return;
 							_dispatcher.Schedule(() =>
 							{
 								try

--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Missing `TextReference` exception in the `LoadingIndicator` when entering and exiting Playmode quickly
+- Disposed `CoroutineService` exception in the `BeamMainThreadUtil` when entering and exiting Playmode quickly
+
 ## [1.16.3]
 
 ### Fixed

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCommand.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCommand.cs
@@ -283,7 +283,7 @@ namespace Beamable.Editor.BeamCli
 						   await Task.Delay(1); // give 1 ms for log messages to eep out
 						   if (_dispatcher.IsForceStopped)
 						   {
-							   _process.Kill();
+							   KillProc();
 							   return;
 						   }
 						   _dispatcher.Schedule(() =>
@@ -311,7 +311,7 @@ namespace Beamable.Editor.BeamCli
 						{
 							if (_dispatcher.IsForceStopped)
 							{
-								_process.Kill();
+								KillProc();
 								return;
 							}
 							_dispatcher.Schedule(() =>
@@ -330,7 +330,7 @@ namespace Beamable.Editor.BeamCli
 						{
 							if (_dispatcher.IsForceStopped)
 							{
-								_process.Kill();
+								KillProc();
 								return;
 							}
 							_dispatcher.Schedule(() =>
@@ -373,6 +373,24 @@ namespace Beamable.Editor.BeamCli
 				// Debug.LogException(e);
 				throw;
 			}
+		}
+
+		private void KillProc()
+		{
+			if (_process.HasExited)
+			{
+				return;
+			}
+
+			try
+			{
+				_process.Kill();
+			}
+			catch
+			{
+				Debug.LogWarning($"Unable to kill beamCLI process. This <i>may</i> mean that there are pending beamCLI tasks on your machine. \n command=[{_command}]");
+			}
+
 		}
 
 

--- a/client/Packages/com.beamable/Runtime/3rdParty/WebSocket/WebSocket.cs
+++ b/client/Packages/com.beamable/Runtime/3rdParty/WebSocket/WebSocket.cs
@@ -28,6 +28,7 @@ namespace Beamable.Endel
 		{
 			synchronizationContext.Post(_ =>
 			{
+				if (!coroutineService) return;
 				coroutineService.StartCoroutine(waitForUpdate);
 			}, null);
 		}

--- a/client/Packages/com.beamable/Runtime/UI/Scripts/LoadingIndicator.cs
+++ b/client/Packages/com.beamable/Runtime/UI/Scripts/LoadingIndicator.cs
@@ -33,7 +33,6 @@ public class LoadingIndicator : MonoBehaviour
 
 		if (_currentSession == null)
 		{
-			//ServiceManager.Resolve<CoroutineService>().StartCoroutine(ShowAfterFlashProtection());
 			BeamContext.Default.ServiceProvider.GetService<CoroutineService>()
 					   .StartCoroutine(ShowAfterFlashProtection());
 
@@ -48,6 +47,11 @@ public class LoadingIndicator : MonoBehaviour
 
 	public void Hide()
 	{
+		if (!this) // if this component has been removed by the Unity lifecycle, then we shouldn't do anything...
+		{
+			return;
+		}
+		
 		_currentSession = null;
 
 		if (_sessionQueue.Count == 0)


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3688

# Brief Description

If you enter & exit playmode quickly, you'd get a variety of errors... I saw these 3 errors appear 

```
MissingReferenceException: The object of type 'CoroutineService' has been destroyed but you are still trying to access it.
Your script should either check if it is null or you should not destroy the object.
UnityEngine.MonoBehaviour.StartCoroutine (System.Collections.IEnumerator routine) (at /Users/bokken/build/output/unity/unity/Runtime/Export/Scripting/MonoBehaviour.bindings.cs:88)
Beamable.Endel.BeamMainThreadUtil+<>c__DisplayClass5_0.<Run>b__0 (System.Object _) (at Packages/com.beamable/Runtime/3rdParty/WebSocket/WebSocket.cs:31)
```

```
Exception: Cannot schedule work, because the scheduler has been stopped.
UnityEngine.Debug:LogException(Exception)
Beamable.Editor.BeamableDispatcher:Schedule(String, Action) (at Library/PackageCache/com.beamable@1.16.3-PREVIEW.RC1/Editor/Utility/BeamableDispatcher.cs:125)
Beamable.Editor.BeamableDispatcher:Schedule(Action) (at Library/PackageCache/com.beamable@1.16.3-PREVIEW.RC1/Editor/Utility/BeamableDispatcher.cs:111)
Beamable.Server.Editor.DockerCommands.DockerCommand:<Run>b__58_1(Object, DataReceivedEventArgs) (at Library/PackageCache/com.beamable.server@1.16.3-PREVIEW.RC1/Editor/DockerCommands/ProcessCommand.cs:272)
```

```
MissingReferenceException: The object of type 'TextReference' has been destroyed but you are still trying to access it.
Your script should either check if it is null or you should not destroy the object.
LoadingIndicator.Hide () (at Packages/com.beamable/Runtime/UI/Scripts/LoadingIndicator.cs:55)
```

We probably need a better general purpose solution to these sorts of issues instead of this PR; which just plays whack-a-mole and fixes these specific ones. The root cause is "delayed work gets triggered during, or after a domain reload".

In the dispatcher case, if we start a command like `docker ps`, and then we domain-reload, and _then_ the script thread comes back, it'll freak out because the entire editor scope is shutting down.
In the LoadingIndicator case, a `Promise` is finishing as the scope is shutting down...
And the Coroutine one is similar, the thread util is running as the scope is shutting down.

In all of these cases, we can essentially just "check that it _isn't_ shutting down"... But that does feel, ... bad... 
On the other hand, the idea of somehow fixing this so that the callbacks _don't_ get run during a shutdown feels like it would be super dangerous and tricky to get right.


# Checklist

* [X] Have you added appropriate text to the CHANGELOG.md files?
