### PR TITLE
[BEAM-3780] CLI - Fix archived realms showing in options when selecting realm

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix issue with archived realms showing in options when selecting realm
+
 ## [1.17.2]
 
 ### Fixed

--- a/cli/cli/Commands/InitCommand.cs
+++ b/cli/cli/Commands/InitCommand.cs
@@ -168,7 +168,9 @@ public class InitCommand : AppCommand<InitCommandArgs>, IResultSteam<DefaultStre
 		var game = games.FirstOrDefault(g => g.DisplayName.Replace("[PROD]", "") == gameSelection);
 
 		var realms = await _realmsApi.GetRealms(game).ShowLoading("Fetching realms...");
-		var realmChoices = realms.Select(r => r.DisplayName.Replace("[", "").Replace("]", ""));
+		var realmChoices = realms
+			.Where(r => !r.Archived)
+			.Select(r => r.DisplayName.Replace("[", "").Replace("]", ""));
 		var realmSelection = AnsiConsole.Prompt(
 			new SelectionPrompt<string>()
 				.Title("What [green]realm[/] are you using?")


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3780

# Brief Description

Fix archived realms showing in options when selecting realm

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
