### PR TITLE
use latest image for C#MS

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix issue with archived realms showing in options when selecting realm
+- Rerunning `beam services run` will detect code changes
 
 ## [1.17.2]
 

--- a/cli/cli/Services/BeamoLocalSystem_Docker.cs
+++ b/cli/cli/Services/BeamoLocalSystem_Docker.cs
@@ -49,11 +49,23 @@ public partial class BeamoLocalSystem
 		var existingInstance = BeamoRuntime.ExistingLocalServiceInstances.FirstOrDefault(si => si.ContainerName.Contains(containerName));
 		if (existingInstance != null)
 		{
-			if (existingInstance.IsRunning)
-				return true;
+			if (existingInstance.ImageId == image)
+			{
+				// the image is the same, so we can re-use it.
+				if (existingInstance.IsRunning)
+				{
+					// since the exact right image is already running for this container; do nothing.
+					return true;
+				}
 
+				return await RunContainer(containerName);
+			}
+			else
+			{
+				// the image is not correct, so we need to erase the old container before recreating it.
+				await DeleteContainer(containerName);
+			}
 
-			return await RunContainer(containerName);
 		}
 
 		_ = await CreateContainer(image, containerName, healthConfig, autoRemoveWhenStopped, portBindings, volumes, bindMounts, environmentVars);

--- a/cli/cli/Services/BeamoLocalSystem_LocalRuntime.cs
+++ b/cli/cli/Services/BeamoLocalSystem_LocalRuntime.cs
@@ -99,6 +99,7 @@ public partial class BeamoLocalSystem
 				existingServiceInstances.Add(new BeamoServiceInstance
 				{
 					BeamoId = beamoId,
+					ImageId = dockerContainer.ImageID,
 					ContainerId = containerId,
 					ContainerName = containerName,
 					ActivePortBindings = ports,
@@ -168,6 +169,7 @@ public partial class BeamoLocalSystem
 
 						var newServiceInstance = new BeamoServiceInstance()
 						{
+							ImageId = containerData.Image,
 							BeamoId = beamoId,
 							ContainerId = message.ID,
 							ContainerName = containerName,
@@ -457,6 +459,7 @@ public class BeamoServiceInstance : IEquatable<BeamoServiceInstance>
 	public string BeamoId;
 	public string ContainerId;
 	public string ContainerName;
+	public string ImageId;
 	public List<DockerPortBinding> ActivePortBindings;
 
 	public bool IsRunning;


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3793

# Brief Description

We had a tiny bug in the `beam services run` command. If you changed the source code or something, and re-ran the command while the container was running- you wouldn't get the right behaviour. The fact that the container _name_ was in use was causing a code path to trigger that would just re-run (or do nothing) the existing container. 

To fix it, I added the `imageId` to the data, and now match on that as well... The logic should be, "if the container name is in use, and it is using the exact image we want, then we can re-use it; otherwise, delete the container and re-run it with the requested imageId"

# Checklist

* [X] Have you added appropriate text to the CHANGELOG.md files?
