### PR TITLE
[BEAM-3680] CLI - filter storage object out of beam services enable selection wizard

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for storing locally content from multiple namespaces.
+- Filter out storage objects from `beam services enable` selection wizard.
 
 ### Changed
 - `run-nbomber` cli command accepts a json file as body for request instead of an argument.

--- a/cli/cli/Commands/Services/ServicesEnableCommand.cs
+++ b/cli/cli/Commands/Services/ServicesEnableCommand.cs
@@ -55,12 +55,17 @@ public class ServicesEnableCommand : AppCommand<ServicesEnableCommandArgs>
 			BeamableLogger.LogError("There are no services in BeamoManifest.");
 		}
 
-		// Handle Beamo Id Option 
-		var existingBeamoIds = _localBeamo.BeamoManifest.ServiceDefinitions.Select(c => c.BeamoId).ToList();
+		// Handle Microservice Beamo Id Option 
+		var existingMicroserviceBeamoIds = _localBeamo.BeamoManifest.ServiceDefinitions
+			.Where(c => c.Protocol == BeamoProtocolType.HttpMicroservice)
+			.Select(c => c.BeamoId)
+			.ToList();
+
 		if (string.IsNullOrEmpty(args.BeamoId))
 		{
 			args.BeamoId = AnsiConsole.Prompt(new SelectionPrompt<string>()
-				.Title("Choose the [lightskyblue1]Beamo-O Service[/] to Modify:").AddChoices(existingBeamoIds));
+				.Title("Choose the [lightskyblue1]Beamo-O Service[/] to Modify:")
+				.AddChoices(existingMicroserviceBeamoIds));
 		}
 
 		var serviceDefinition = _localBeamo.BeamoManifest.ServiceDefinitions.FirstOrDefault(sd => sd.BeamoId == args.BeamoId);


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3680

# Brief Description

Filter storage object out of beam services enable selection wizard

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
