### PR TITLE
beam 3776 - reset command for beamable notifs

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `HttpUtility` throwing compilation error in Unity.
+- `Reset` command works for realms configured to use Beamable notification channel.
+
+### Added
+
+- `IBeamableDisposableOrder` interface allows services to dispose in configurable order. 
 
 ## [1.17.3]
 

--- a/client/Packages/com.beamable/Common/Runtime/Dependencies/DependencyProvider.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Dependencies/DependencyProvider.cs
@@ -337,7 +337,6 @@ namespace Beamable.Common.Dependencies
 			throw new Exception($"Service not found {t.Name}");
 		}
 
-		List<Promise<Unit>> disposalPromises = new List<Promise<Unit>>();
 		List<Promise<Unit>> childRemovalPromises = new List<Promise<Unit>>();
 
 		// ReSharper disable Unity.PerformanceAnalysis
@@ -346,7 +345,6 @@ namespace Beamable.Common.Dependencies
 			if (_isDestroying || _destroyed) return; // don't dispose twice!
 			_isDestroying = true;
 
-			disposalPromises.Clear();
 			childRemovalPromises.Clear();
 
 
@@ -368,20 +366,35 @@ namespace Beamable.Common.Dependencies
 
 			await Promise.Sequence(childRemovalPromises);
 
-			void DisposeServices(IEnumerable<object> services)
+			async Promise DisposeServices(IEnumerable<object> services)
 			{
 				var clonedList = new List<object>(services);
-				foreach (var service in clonedList)
+				var groups = clonedList.GroupBy(x =>
 				{
-					if (service == null) continue;
-					if (service is IBeamableDisposable disposable)
+					if (x is IBeamableDisposableOrder disposableOrder)
+						return disposableOrder.DisposeOrder;
+					return 0;
+				});
+				groups = groups.OrderBy(x => x.Key);
+				foreach (var group in groups)
+				{
+					var promises = new List<Promise<Unit>>();
+
+					foreach (var service in group)
 					{
-						var promise = disposable.OnDispose();
-						if (promise != null)
+						if (service == null) continue;
+						if (service is IBeamableDisposable disposable)
 						{
-							disposalPromises.Add(promise);
+							var promise = disposable.OnDispose();
+							if (promise != null)
+							{
+								promises.Add(promise);
+							}
 						}
 					}
+
+					var final = Promise.Sequence(promises);
+					await final;
 				}
 			}
 
@@ -397,12 +410,9 @@ namespace Beamable.Common.Dependencies
 				descriptors.Clear();
 			}
 
-
-
-			DisposeServices(SingletonCache.Values.Distinct());
-			DisposeServices(ScopeCache.Values.Distinct());
-
-			await Promise.Sequence(disposalPromises);
+			
+			await DisposeServices(SingletonCache.Values.Distinct());
+			await DisposeServices(ScopeCache.Values.Distinct());
 
 			SingletonCache.Clear();
 			ScopeCache.Clear();

--- a/client/Packages/com.beamable/Common/Runtime/Dependencies/Utils.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Dependencies/Utils.cs
@@ -18,6 +18,20 @@ namespace Beamable.Common.Dependencies
 	}
 
 	/// <summary>
+	/// <inheritdoc cref="IBeamableDisposable"/>
+	/// </summary>
+	public interface IBeamableDisposableOrder : IBeamableDisposable
+	{
+		/// <summary>
+		/// By default, all services are disposed in one group, and therefor, cannot have dependencies on eachother
+		/// when disposing.
+		/// However, if the service is critical and other services require it for shutdown, then the <see cref="DisposeOrder"/>
+		/// flag can be used. The higher the number, the more important the service is, and the later in the dispose cycle it will occur.
+		/// </summary>
+		int DisposeOrder { get; }
+	}
+
+	/// <summary>
 	/// Describes how to create a service instance
 	/// </summary>
 	public class ServiceDescriptor

--- a/client/Packages/com.beamable/Runtime/3rdParty/WebSocket/WebSocket.cs
+++ b/client/Packages/com.beamable/Runtime/3rdParty/WebSocket/WebSocket.cs
@@ -724,6 +724,7 @@ namespace Beamable.Endel
 				{
 					await m_Socket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, m_CancellationToken);
 				}
+				await new WaitForUpdate(_coroutineService); // dispatch back onto main thread
 			}
 		}
 #endif

--- a/client/Packages/com.beamable/Runtime/BeamContext.cs
+++ b/client/Packages/com.beamable/Runtime/BeamContext.cs
@@ -71,7 +71,7 @@ namespace Beamable
 	/// </para>
 	/// </summary>
 	[Serializable]
-	public class BeamContext : IPlatformService, IGameObjectContext, IObservedPlayer, IBeamableDisposable, IDependencyNameProvider, IDependencyScopeNameProvider
+	public class BeamContext : IPlatformService, IGameObjectContext, IObservedPlayer, IBeamableDisposableOrder, IDependencyNameProvider, IDependencyScopeNameProvider
 	{
 
 		#region Internal State
@@ -894,6 +894,7 @@ namespace Beamable
 
 		string IDependencyNameProvider.DependencyProviderName => PlayerCode;
 		string IDependencyScopeNameProvider.DependencyScopeName => PlayerId.ToString();
+		int IBeamableDisposableOrder.DisposeOrder => 100;
 	}
 
 	[Serializable]

--- a/client/Packages/com.beamable/Runtime/Connection/WebSocketConnection.cs
+++ b/client/Packages/com.beamable/Runtime/Connection/WebSocketConnection.cs
@@ -47,30 +47,17 @@ namespace Beamable.Connection
 			return _onConnectPromise;
 		}
 
-		public Promise Disconnect()
+		public async Promise Disconnect()
 		{
 			_disconnecting = true;
-#if !UNITY_WEBGL || UNITY_EDITOR
-			if (_dispatchMessagesRoutine != null)
-			{
-				_coroutineService.StopCoroutine(_dispatchMessagesRoutine);
-			}
-#endif
-			var p = new Promise();
-			_webSocket
-				.Close()
-				.ContinueWith(result =>
-				{
-					if (result.IsFaulted)
-					{
-						p.CompleteError(result.Exception);
-					}
-					else
-					{
-						p.CompleteSuccess();
-					}
-				});
-			return p;
+
+			await _webSocket.Close();
+			#if !UNITY_WEBGL || UNITY_EDITOR
+								if (_dispatchMessagesRoutine != null)
+								{
+									_coroutineService.StopCoroutine(_dispatchMessagesRoutine);
+								}
+			#endif
 		}
 
 		private Promise DoConnect()
@@ -97,7 +84,7 @@ namespace Beamable.Connection
 			{
 				if (state == UnityEditor.PlayModeStateChange.ExitingPlayMode)
 				{
-					Disconnect();
+					var _ = Disconnect();
 				}
 			};
 #endif

--- a/client/Packages/com.beamable/Runtime/Modules/Console/ConsoleFlow.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/Console/ConsoleFlow.cs
@@ -118,7 +118,6 @@ namespace Beamable.Console
 
 		private void Update()
 		{
-			var _ = BeamContext.ForPlayer(_playerCode).OnReady;
 			if (!_isInitialized) return;
 
 			if (_showNextTick)


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3776

# Brief Description

There were a few things going on here....

1. The `ContinueWith` logic wasn't working with the custom thread util thing- and instead of fixing it, I just made the method use `async/await`. 
2. The websocket needed to use our Coroutine service to dispatch callbacks back onto the main unity thread. However, the coroutine service was getting destroyed before everything else. To fix this, I added the `IBeamableDisposableOrder`, which allows a developer to control the relative ordering of their service shutdowns. Now, the `BeamContext` is the last thing to shutdown, which means the coroutine service is kicking around last- which means that the websocket can use it to shutdown. This meant that I had to refactor the dispose logic a bit in the dependency scope code. 
3. There was a line in the `Update` loop of the console that didn't seem to need to be there. I tested with/without it, and it works the same. 

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?
