### PR TITLE
[BEAM-3814] Fixed ContentRef property drawer on Unity 2021 LTS

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Websocket connection authentication in WebGL builds.
+- Fixed ContentRef property drawer on Unity 2021 LTS.
 
 ## [1.18.0]
 

--- a/client/Packages/com.beamable/Editor/Modules/Content/ContentPropertyDrawer.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/ContentPropertyDrawer.cs
@@ -299,18 +299,14 @@ namespace Beamable.Editor.Content
 
 			GUI.SetNextControlName(SearchControlName);
 
-#if UNITY_2022_1_OR_NEWER
-			// hey wow, they fixed the typo!!
-			const string styleName = "ToolbarSearchTextField";
-#else
 			// SIC. The "ToolbarSeachTextField" is on purpose. It's a Unity typo.
-			const string styleName = "ToolbarSeachTextField";
-#endif
+			// hey wow, they fixed the typo, at least for most versions
+			var skin = GUI.skin.FindStyle("ToolbarSearchTextField") ?? GUI.skin.FindStyle("ToolbarSeachTextField");
 
-			_searchString = GUILayout.TextField(_searchString, GUI.skin.FindStyle(styleName));
+			_searchString = GUILayout.TextField(_searchString, skin);
 			GUI.FocusControl(SearchControlName);
 
-			if (GUILayout.Button("", GUI.skin.FindStyle(styleName)))
+			if (GUILayout.Button("", skin))
 			{
 				// Remove focus if cleared
 				_searchString = "";


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3814

# Brief Description

> Fixed ContentRef property drawer on Unity 2021 LTS.
