### PR TITLE
Bugfix/beam 3829 payment provider id windows

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Added "windows" and "macos" to the set of possible `PaymentService.ProviderId` values.
 - Changed the unknown `PaymentService.ProviderId` value from "bogus" to "unknown".
+- Payment ProviderId can be changed by injecting a custom `IPaymentServiceOptions` into the Beam Context scope.
 
 ## [1.18.1]
 

--- a/client/Packages/com.beamable/Runtime/Beam.cs
+++ b/client/Packages/com.beamable/Runtime/Beam.cs
@@ -197,6 +197,7 @@ namespace Beamable
 			DependencyBuilder.AddSingleton<ICloudDataApi>(provider => provider.GetService<CloudDataService>());
 			DependencyBuilder.AddSingleton<CloudDataApi>(provider => provider.GetService<CloudDataService>());
 			DependencyBuilder.AddSingleton<PaymentService>();
+			DependencyBuilder.AddSingleton<IPaymentServiceOptions, DefaultPaymentServiceOptions>();
 			DependencyBuilder.AddSingleton<GroupsService>();
 			DependencyBuilder.AddSingleton<EventsService>();
 			DependencyBuilder.AddSingleton<ITournamentApi>(p => p.GetService<TournamentService>());

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Payments/IPaymentServiceOptions.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Payments/IPaymentServiceOptions.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+namespace Beamable.Api.Payments
+{
+	public interface IPaymentServiceOptions
+	{
+		/// <summary>
+		/// The <see cref="ProviderId"/> is used to signal which storefront is being used.
+		/// </summary>
+		string ProviderId { get; }
+	}
+
+	public class DefaultPaymentServiceOptions : IPaymentServiceOptions
+	{
+		public string ProviderId
+		{
+			get
+			{
+				switch (Application.platform)
+				{
+					case RuntimePlatform.IPhonePlayer:
+						return "itunes";
+					case RuntimePlatform.Android:
+						return "googleplay";
+					default:
+#if UNITY_EDITOR
+						return "test";
+#elif USE_STEAMWORKS
+						return "steam";
+#else
+						return "unknown";
+#endif
+				}
+			}
+		}
+
+	}
+}

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Payments/IPaymentServiceOptions.cs.meta
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Payments/IPaymentServiceOptions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c79a4ab482f74d72885487407621fed6
+timeCreated: 1695065266

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Payments/PaymentService.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Payments/PaymentService.cs
@@ -28,41 +28,17 @@ namespace Beamable.Api.Payments
 	public class PaymentService : PaymentsApi
 	{
 		private IPlatformService _platform;
+		private readonly IPaymentServiceOptions _options;
 
-		public PaymentService(IPlatformService platform, IPlatformRequester requester) : base(requester)
+		public PaymentService(IPlatformService platform, IPlatformRequester requester, IPaymentServiceOptions options) : base(requester)
 		{
 			_platform = platform;
+			_options = options;
 			_requester = requester;
 			platform.Notification.Subscribe("commerce.coupons_updated", payload =>
 			{
 				RefreshCoupons();
 			});
-		}
-
-		private static string ProviderId
-		{
-			get
-			{
-				switch (Application.platform)
-				{
-					case RuntimePlatform.IPhonePlayer:
-						return "itunes";
-					case RuntimePlatform.Android:
-						return "googleplay";
-					case RuntimePlatform.WindowsPlayer:
-						return "windows";
-					case RuntimePlatform.OSXPlayer:
-						return "windows";  // We return "windows" instead of "macos" because the backend API supports "windows" as an ID but does not support "macos" and we do not want this to trickle through to the "unknown" case.
-					default:
-#if UNITY_EDITOR
-						return "test";
-#elif USE_STEAMWORKS
-						return "steam";
-#else
-						return "unknown";
-#endif
-				}
-			}
 		}
 
 		/// <summary>
@@ -74,7 +50,7 @@ namespace Beamable.Api.Payments
 		{
 			return _requester.Request<EmptyResponse>(
 			   Method.POST,
-			   $"/basic/payments/{ProviderId}/purchase/track",
+			   $"/basic/payments/{_options.ProviderId}/purchase/track",
 			   trackPurchaseRequest
 			);
 		}
@@ -87,7 +63,7 @@ namespace Beamable.Api.Payments
 		{
 			return _requester.Request<PurchaseResponse>(
 			   Method.POST,
-			   $"/basic/payments/{ProviderId}/purchase/begin",
+			   $"/basic/payments/{_options.ProviderId}/purchase/begin",
 			   new BeginPurchaseRequest(purchaseId)
 			);
 		}
@@ -101,7 +77,7 @@ namespace Beamable.Api.Payments
 		{
 			return _requester.Request<EmptyResponse>(
 			   Method.POST,
-			   $"/basic/payments/{ProviderId}/purchase/complete",
+			   $"/basic/payments/{_options.ProviderId}/purchase/complete",
 			   new CompleteTransactionRequest(transaction)
 			);
 		}
@@ -114,7 +90,7 @@ namespace Beamable.Api.Payments
 		{
 			return _requester.Request<EmptyResponse>(
 			   Method.POST,
-			   $"/basic/payments/{ProviderId}/purchase/cancel",
+			   $"/basic/payments/{_options.ProviderId}/purchase/cancel",
 			   new CancelPurchaseRequest(txid)
 			);
 		}
@@ -128,7 +104,7 @@ namespace Beamable.Api.Payments
 		{
 			return _requester.Request<EmptyResponse>(
 			   Method.POST,
-			   $"/basic/payments/{ProviderId}/purchase/fail",
+			   $"/basic/payments/{_options.ProviderId}/purchase/fail",
 			   new FailPurchaseRequest(txid, reason)
 			);
 		}


### PR DESCRIPTION
# Ticket BEAM-3829

https://disruptorbeam.atlassian.net/browse/BEAM-3829

# Brief Description

Our PaymentService `ProviderId` static function has a hard coded set of strings it can return, currently limited to "itunes", "googleplay", "steam", "test", and "bogus". This poses two problems:

1. The word "bogus" should never show up in real production code. It should be reserved for tests and examples, as it is in the same category as "foo", "tuna", and "lorem ipsum".
2. Game Makers should be able to implement custom purchasing on top of our code, and having some platforms (notably Windows) simply not represented prevents them from doing that. In specific, Marco at Hashbang is using "windows" for his custom implementation of purchasing using Wax blockchain assets.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)

* Hard-coded provider IDs are problematic to begin with, so adding more of them is exacerbating the problem.