### PR TITLE
fix automatic index creation

### DIFF
--- a/client/Packages/com.beamable.server/SharedRuntime/MongoIndexesReflectionCache.cs
+++ b/client/Packages/com.beamable.server/SharedRuntime/MongoIndexesReflectionCache.cs
@@ -125,9 +125,8 @@ namespace Beamable.Server
 
 					Promise promise = Convert(collectionGenericObject, mongoCollectionGenericType);
 					await promise;
-
-					MethodInfo resultFromPromiseMethod = GetType().GetMethod(nameof(GetResultFromPromise),
-						BindingFlags.Instance | BindingFlags.Public);
+					MethodInfo resultFromPromiseMethod = typeof(MongoIndexesReflectionCache).GetMethod(nameof(GetResultFromPromise),
+						BindingFlags.Static | BindingFlags.Public);
 					MethodInfo resultFromPromiseGeneric =
 						resultFromPromiseMethod?.MakeGenericMethod(mongoCollectionGenericType);
 					object collection = resultFromPromiseGeneric?.Invoke(null, new[] { collectionGenericObject });


### PR DESCRIPTION
little bug with the mongo index thing. The issue was that the generic method was `static`, so the existing code wouldn't find the method at all.