### PR TITLE
[beam-3852] Revert enum changes to content serialization

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+ - New enum serialization wasn't compatible with older versions of published content, so it was reverted.
+
 ## [1.19.0]
 
 ### Fixed

--- a/client/Packages/com.beamable/Common/Runtime/Content/ContentSerializer.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Content/ContentSerializer.cs
@@ -107,7 +107,7 @@ namespace Beamable.Common.Content
 
 				/* PRIMITIVE TYPES... */
 				case Enum e:
-					return Convert.ChangeType(arg, typeof(int)).ToString();
+					return Json.Serialize(arg.ToString(), new StringBuilder());
 				case bool b:
 				case long l:
 				case string s:
@@ -294,8 +294,10 @@ namespace Beamable.Common.Content
 					return contentRef;
 
 				/* PRIMITIVES TYPES */
-				case string enumValue when typeof(Enum).IsAssignableFrom(type):
-					return Enum.Parse(type, enumValue);
+				case string stringEnumValue when typeof(Enum).IsAssignableFrom(type):
+					return Enum.Parse(type, stringEnumValue);
+				case long longEnumValue when typeof(Enum).IsAssignableFrom(type):
+					return Enum.ToObject(type, (int)longEnumValue);
 				case string _:
 					return preParsedValue;
 				case float _:

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Content/Serialization/ClientContentSerializer/DeserializeTests.cs
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Content/Serialization/ClientContentSerializer/DeserializeTests.cs
@@ -939,6 +939,25 @@ namespace Beamable.Tests.Content.Serialization.ClientContentSerializationTests
 
 			Assert.AreEqual(TestEnum.B, o.e);
 		}
+		
+		[Test]
+		public void Enum_int()
+		{
+			var json = @"{
+   ""id"": ""test.nothing"",
+   ""version"": """",
+   ""properties"": {
+      ""e"": {
+         ""data"": 1
+      }
+   }
+}";
+
+			var s = new TestSerializer();
+			var o = s.Deserialize<EnumContent>(json);
+
+			Assert.AreEqual(TestEnum.B, o.e);
+		}
 
 		[Test]
 		public void CustomContentField_Works()

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Content/Serialization/ClientContentSerializer/SerializeTests.cs
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Content/Serialization/ClientContentSerializer/SerializeTests.cs
@@ -636,17 +636,13 @@ namespace Beamable.Tests.Content.Serialization.ClientContentSerializationTests
 		[Test]
 		public void Enum()
 		{
-			var c = new EnumContent
-			{
-				Id = "test.nothing",
-				e = TestEnum.B
-			};
+			var c = new EnumContent {Id = "test.nothing", e = TestEnum.B};
 			var expected = @"{
    ""id"": ""test.nothing"",
    ""version"": """",
    ""properties"": {
       ""e"": {
-         ""data"": 1
+         ""data"": ""B""
       }
    }
 }".Replace("\r\n", "").Replace("\n", "").Replace(" ", "");

--- a/wiki/features/BEAM-3852.md
+++ b/wiki/features/BEAM-3852.md
@@ -1,0 +1,21 @@
+### Why
+Reverting changes to content serialization in order to fix a previous issue and maintain compatibility.
+
+### Configuration
+none
+
+### How
+Serialization and deserialization of enums in content should work. So you can:
+ - Create a new content with a enum as a public field
+ - Publish this content
+ - Delete your local content
+ - Download your content with any Beamable SDK version and no errors should occur.
+
+### Prefab
+none
+
+### Editor
+none
+
+### Notes
+(Insert anything else that is important)


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3852

# Brief Description

Revert enum changes to content serialization.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [x] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
