### PR TITLE
[BEAM-3849] Update template to call the right Prepare function

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+ - Templates update with refactor to improve it receiving updates and fixes in the future.
+
 ## [1.19.1]
 
 no changes

--- a/templates/BeamService/BeamService.csproj
+++ b/templates/BeamService/BeamService.csproj
@@ -80,7 +80,7 @@
 
     <!-- Nuget references -->
     <ItemGroup>
-        <PackageReference Include="Beamable.Microservice.Runtime" Version="1.15.0-PREVIEW.RC1" />
+        <PackageReference Include="Beamable.Microservice.Runtime" Version="1.19.1" />
         
         <PackageReference Include="EmbedIO" Version="3.4.*" />
         <PackageReference Include="LoxSmoke.DocXml" Version="3.4.*" />

--- a/templates/BeamService/Program.cs
+++ b/templates/BeamService/Program.cs
@@ -15,7 +15,7 @@ namespace Beamable.BeamService
 		public static async Task Main()
 		{
 			// inject data from the CLI
-			await Prepare<BeamService>();
+			await MicroserviceBootstrapper.Prepare<BeamService>();
 			
 			// load environment variables from local file
 			LoadEnvironmentVariables();
@@ -39,34 +39,6 @@ namespace Beamable.BeamService
 					continue;
 
 				Environment.SetEnvironmentVariable(parts[0], parts[1]);
-			}
-		}
-		
-		static async Task Prepare<TMicroservice>() where TMicroservice : Microservice
-		{
-			var inDocker = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") == "true";
-			if (inDocker) return;
-			
-			MicroserviceAttribute attribute = typeof(TMicroservice).GetCustomAttribute<MicroserviceAttribute>();
-			var serviceName = attribute.MicroserviceName;
-			
-			using var process = new Process();
-
-			process.StartInfo.FileName = "beam";
-			process.StartInfo.Arguments = $"project generate-env {serviceName} . --auto-deploy";
-			process.StartInfo.RedirectStandardOutput = true;
-			process.StartInfo.RedirectStandardError = true;
-			process.StartInfo.CreateNoWindow = true;
-			process.StartInfo.UseShellExecute = false;
-
-			process.Start();
-			await process.WaitForExitAsync();
-			
-			var result = await process.StandardOutput.ReadToEndAsync();
-			// Console.WriteLine(result);
-			if (process.ExitCode != 0)
-			{
-				throw new Exception($"Failed to generate-env message=[{result}]");
 			}
 		}
 	}

--- a/wiki/features/BEAM-3849.md
+++ b/wiki/features/BEAM-3849.md
@@ -1,0 +1,20 @@
+### Why
+Updating the BeamService project template so it's using the updated version of the
+`Prepare<T>()` function, which now lives in the Beamable package instead of the template,
+making it easy to receive updates.
+
+### Configuration
+none
+
+### How
+When creating a new C#MS, the `Program.cs` file in it is going to come with the updated call
+to the `Prepare<T>()` function.
+
+### Prefab
+none
+
+### Editor
+none
+
+### Notes
+(Insert anything else that is important)


### PR DESCRIPTION

# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3849

# Brief Description

Updating the BeamService project template so it's using the updated version of the
`Prepare<T>()` function, which now lives in the Beamable package instead of the template,
making it easy to receive updates.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [x] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
