### PR TITLE
3879 - use correct windows default path

### DIFF
--- a/client/Packages/com.beamable/Editor/Dotnet/DotnetUtil.cs
+++ b/client/Packages/com.beamable/Editor/Dotnet/DotnetUtil.cs
@@ -14,8 +14,11 @@ namespace Beamable.Editor.Dotnet
 		private const string ENV_VAR_DOTNET_LOCATION = "BEAMABLE_DOTNET_PATH";
 		private const string DOTNET_LIBRARY_PATH = "Library/BeamableEditor/Dotnet";
 		
+#if UNITY_EDITOR_WIN
+		public static readonly string DOTNET_GLOBAL_PATH = "C:\\Program Files\\dotnet";
+#else
 		public static readonly string DOTNET_GLOBAL_PATH = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile), ".dotnet");
-		
+#endif
 		
 		/// <summary>
 		/// this list is in order precedence 


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3879

# Brief Description

I had the wrong default path for dotnet on a windows machine

# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
