### PR TITLE
Fix/BEAM-3815 - Switching accounts too fast throw error with HeartBeat

### DIFF
--- a/client/Packages/com.beamable/Common/Runtime/Api/IBeamState.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/IBeamState.cs
@@ -1,0 +1,7 @@
+namespace Beamable.Common.Api
+{
+	public interface IBeamState
+	{
+		Promise<Unit> OnPlayerReady { get; }
+	}
+}

--- a/client/Packages/com.beamable/Common/Runtime/Api/IBeamState.cs.meta
+++ b/client/Packages/com.beamable/Common/Runtime/Api/IBeamState.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6f9f77a39b564fd2a7e2fb41ad9fe16b
+timeCreated: 1697826728

--- a/client/Packages/com.beamable/Runtime/Beam.cs
+++ b/client/Packages/com.beamable/Runtime/Beam.cs
@@ -209,7 +209,8 @@ namespace Beamable
 			DependencyBuilder.AddScoped<IPresenceApi>(provider => new PresenceService(
 				// the presence service needs a special instance of the beamable api requester
 				provider.GetService<IBeamableApiRequester>(),
-				provider.GetService<IUserContext>()));
+				provider.GetService<IUserContext>(),
+				provider.GetService<IBeamState>()));
 			DependencyBuilder.AddSingleton<AnalyticsTracker>(provider =>
 																 new AnalyticsTracker(
 																	 provider.GetService<IPlatformService>(),

--- a/wiki/features/BEAM-3815.md
+++ b/wiki/features/BEAM-3815.md
@@ -1,0 +1,20 @@
+### Why
+If you change users fast enough and while the SDK is sending a HeartBeat to the server, it's possible to get
+an error where it complains that the user being sent by the HeartBeat is not the actual user.
+
+### Configuration
+none
+
+### How
+Now we are waiting for an user change to happen before sending the heartbeat. The error still might occur in
+the case that, for some weird reason not found yet, the heartbeat was send before the user start changing, and
+somehow the change happens before the heartbeat finishs.
+
+### Prefab
+none
+
+### Editor
+none
+
+### Notes
+(Insert anything else that is important)


### PR DESCRIPTION
Attempt to fix issue with heartbeat erroring while users are being changed

# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3815

# Brief Description

If you change users fast enough and while the SDK is sending a HeartBeat to the server, it's possible to get
an error where it complains that the user being sent by the HeartBeat is not the actual user.

Now we are waiting for an user change to happen before sending the heartbeat. The error still might occur in
the case that, for some weird reason not found yet, the heartbeat was send before the user start changing, and
somehow the change happens before the heartbeat finishs.

# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [x] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
