### PR TITLE
beam 3883 versioning - add version semantics

### DIFF
--- a/build/docker/image.microservice/docker-compose.yml
+++ b/build/docker/image.microservice/docker-compose.yml
@@ -7,4 +7,5 @@ services:
       dockerfile: build/docker/image.microservice/Dockerfile
     volumes:
       - ../../../:/Client
-    
+    environment:
+      VERSION: ${VERSION:-0.0.0}

--- a/build/docker/scripts/build-cli.sh
+++ b/build/docker/scripts/build-cli.sh
@@ -27,15 +27,15 @@ echo "running dotnet packs"
 
 if [ -z "$SUFFIX" ]
 then
-    dotnet pack ./cli/cli --configuration Release /p:VersionPrefix=$VERSION_PREFIX
-    dotnet pack ./client/Packages/com.beamable/Common --configuration Release --include-source --include-symbols /p:VersionPrefix=$VERSION_PREFIX
-    dotnet pack ./microservice/unityEngineStubs --configuration Release --include-source --include-symbols /p:VersionPrefix=$VERSION_PREFIX
-    dotnet pack ./microservice/microservice --configuration Release --include-source --include-symbols /p:NuspecFile=Microservice.nuspec /p:VersionPrefix=$VERSION_PREFIX /p:CombinedVersion=$VERSION
+    dotnet pack ./cli/cli --configuration Release /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
+    dotnet pack ./client/Packages/com.beamable/Common --configuration Release --include-source --include-symbols /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
+    dotnet pack ./microservice/unityEngineStubs --configuration Release --include-source --include-symbols /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
+    dotnet pack ./microservice/microservice --configuration Release --include-source --include-symbols /p:NuspecFile=Microservice.nuspec /p:VersionPrefix=$VERSION_PREFIX /p:CombinedVersion=$VERSION /p:InformationalVersion=$VERSION
 else
-    dotnet pack ./cli/cli --configuration Release --version-suffix=${SUFFIX-""} /p:VersionPrefix=$VERSION_PREFIX
-    dotnet pack ./client/Packages/com.beamable/Common --configuration Release --include-source --include-symbols --version-suffix=${SUFFIX-""} /p:VersionPrefix=$VERSION_PREFIX
-    dotnet pack ./microservice/unityEngineStubs --configuration Release --include-source --include-symbols --version-suffix=${SUFFIX-""} /p:VersionPrefix=$VERSION_PREFIX
-    dotnet pack ./microservice/microservice -c Release --include-source --include-symbols  --version-suffix=${SUFFIX-""} /p:NuspecFile=Microservice.nuspec /p:VersionPrefix=$VERSION_PREFIX /p:CombinedVersion=$VERSION
+    dotnet pack ./cli/cli --configuration Release --version-suffix=${SUFFIX-""} /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
+    dotnet pack ./client/Packages/com.beamable/Common --configuration Release --include-source --include-symbols --version-suffix=${SUFFIX-""} /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
+    dotnet pack ./microservice/unityEngineStubs --configuration Release --include-source --include-symbols --version-suffix=${SUFFIX-""} /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
+    dotnet pack ./microservice/microservice -c Release --include-source --include-symbols  --version-suffix=${SUFFIX-""} /p:NuspecFile=Microservice.nuspec /p:VersionPrefix=$VERSION_PREFIX /p:CombinedVersion=$VERSION /p:InformationalVersion=$VERSION
 fi
 
 echo "Installing built package..."

--- a/build/docker/scripts/build-microservice-deps.sh
+++ b/build/docker/scripts/build-microservice-deps.sh
@@ -5,13 +5,13 @@ export lib_path="../microservice/microservice/lib"
 echo "Building microserivce dependencies..."
 cd client
 echo "Building Common Library..."
-dotnet publish ../client/Packages/com.beamable/Common -c release -o $lib_path
+dotnet publish ../client/Packages/com.beamable/Common -c release -o $lib_path /p:InformationalVersion=$VERSION
 
 echo "Building Server Library..."
-dotnet publish ../client/Packages/com.beamable.server/SharedRuntime -c release -o $lib_path
+dotnet publish ../client/Packages/com.beamable.server/SharedRuntime -c release -o $lib_path /p:InformationalVersion=$VERSION
 
 echo "Building Stubs..."
-dotnet publish ../microservice/unityEngineStubs -c release -o $lib_path
+dotnet publish ../microservice/unityEngineStubs -c release -o $lib_path /p:InformationalVersion=$VERSION
 
 echo "Building Tools..."
-dotnet publish ../microservice/beamable.tooling.common -c release -o $lib_path
+dotnet publish ../microservice/beamable.tooling.common -c release -o $lib_path /p:InformationalVersion=$VERSION

--- a/client/Packages/com.beamable/Common/Runtime/Util/BeamAssemblyVersionUtil.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Util/BeamAssemblyVersionUtil.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Reflection;
+
+namespace Beamable.Common.Util
+{
+	public static class BeamAssemblyVersionUtil
+	{
+		/// <inheritdoc cref="GetVersion"/>
+		public static string GetVersion<T>() => GetVersion(typeof(T));
+		
+		/// <summary>
+		/// Get the version number of the Beamable assembly that provides the given type.
+		/// When Beamable assemblies are built, they use the <code> InformationalVersion </code> msbuild attribute
+		/// to set the full semantic version version.
+		/// <para>
+		/// This function should not be used from the Unity SDK. This function is only applicable when using Nuget to ingest
+		/// Beamable assemblies. 
+		/// </para>
+		/// </summary>
+		/// <param name="t"></param>
+		/// <returns></returns>
+		public static string GetVersion(Type t)
+		{
+			var attribute = t.Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+			return attribute.InformationalVersion;
+		}
+	}
+}


### PR DESCRIPTION
no part of a ticket, but we don't currently have a good way to get access to the version number of Beamable via a built nuget package. Ideally, we'd just use the `Assembly.GetName().Version` approach, _buuut_, our build strings don't fit neatly inside that format. Dotnet requires a 4 part semantic version with no wiggle room for suffixes, like our nightly&rc builds have.

Instead, there is a standard attribute to shove full version string information into- https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assemblyinformationalversionattribute?view=net-7.0

I modified our build scripts to use this property, and I added a helper function in Common to access the property.

I tested this by running this,
```
 dotnet publish -c release /p:InformationalVersion=1.19.5-PREVIEW.NIGHTLY-125 -f net6.0
```

And then in a separate project, using the utility function and printing out the version, and it works! 
```csharp
using Beamable.Common;
using Beamable.Common.Util;

var version = BeamAssemblyVersionUtil.GetVersion<Promise>();
Console.WriteLine(version);
```
<img width="720" alt="image" src="https://github.com/beamable/BeamableProduct/assets/3848374/91109a1e-2b8d-4222-b9a0-fbbefd2a9ddf">
