### PR TITLE
1.19.4 -- CLI logging fix

### DIFF
--- a/cli/cli/App.cs
+++ b/cli/cli/App.cs
@@ -51,9 +51,10 @@ public class App
 
 		// https://github.com/serilog/serilog/wiki/Configuration-Basics
 		// configureLogger ??= config => config.WriteTo.Console()
-		configureLogger ??= config => config.WriteTo.Spectre("{Timestamp:HH:mm:ss} [{Level:u4}] {Message:lj}{NewLine}{Exception}")
-			.MinimumLevel.ControlledBy(LogLevel)
-			.CreateLogger();
+		configureLogger ??= config =>
+			config.WriteTo.Console(outputTemplate:"{Timestamp:HH:mm:ss} [{Level:u4}] {Message:l}{NewLine}{Exception}")
+				.MinimumLevel.ControlledBy(LogLevel)
+				.CreateLogger();
 		Log.Logger = configureLogger(new LoggerConfiguration());
 
 		BeamableLogProvider.Provider = new CliSerilogProvider();

--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.4]
+
+### Fixed
+- `--reporter-use-fatal` channel supports JSON strings
+
 ## [1.19.3]
 
 no changes

--- a/cli/cli/Services/DataReporterService.cs
+++ b/cli/cli/Services/DataReporterService.cs
@@ -19,8 +19,7 @@ public class DataReporterService
 	{
 		if (!_appContext.UseFatalAsReportingChannel) return;
 
-		var encoded = Reporting.EncodeMessage(rawMessage);
-		Log.Fatal(encoded);
+		Log.Fatal("{open}{message}{close}", Reporting.PATTERN_START, rawMessage, Reporting.PATTERN_END);
 	}
 
 	public void Report<T>(string type, T data)

--- a/cli/cli/cli.csproj
+++ b/cli/cli/cli.csproj
@@ -52,7 +52,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.2.0-dev-00918" />
 <!--    <PackageReference Include="Serilog.Sinks.SpectreConsole" Version="0.3.3" />-->
     <PackageReference Include="Serilog.Sinks.Spectre" Version="0.4.1" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />

--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.4]
+
+no changes
+
 ## [1.19.3]
 
 ### Fixed

--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.4]
+
+no changes
+
 ## [1.19.3]
 
 no changes


### PR DESCRIPTION
While working on something on `main`, I discovered that the CLI-->Engine `.SendResults` function wasn't working.
It was broken because at some point, we updated our serilog sink version (because that package is cursed for many many reasons), and there is a bug where it doesn't log JSON strings correctly. 


Honestly, the bug feels like a bug with Serilog, _not_ with us. I feel pretty let down by Serilog, supposedly one of the most popular logging solutions for dotnet. Rrrrg.... 

Anyway, this pulls out the changes required to fix the logging issue and puts them into a PR against production-1-19-4, hopefully slated for a production release later this week.