### PR TITLE
[BEAM-3936] beam project new-storage works only for root dir

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `project add` Dockerfile path fixes.
+- `project new-storage` path fixes.
 
 ## [1.19.7]
 

--- a/cli/cli/Commands/Project/NewStorageCommand.cs
+++ b/cli/cli/Commands/Project/NewStorageCommand.cs
@@ -108,8 +108,8 @@ public class NewStorageCommand : AppCommand<NewStorageCommandArgs>
 			var isDep = dependencies.Any(d => d == serviceFolder);
 			if (!isDep) continue;
 
-			dockerfilePath = Path.Combine(service.Value.DockerBuildContextPath, dockerfilePath);
-			var dockerfileText = File.ReadAllText(dockerfilePath);
+			dockerfilePath = args.ConfigService.GetFullPath(Path.Combine(service.Value.DockerBuildContextPath, dockerfilePath));
+			var dockerfileText = await File.ReadAllTextAsync(dockerfilePath);
 
 			const string search =
 				"# <BEAM-CLI-INSERT-FLAG:COPY> do not delete this line. It is used by the beam CLI to insert custom actions";
@@ -118,7 +118,7 @@ COPY {args.storageName}/. .
 {search}";
 			Log.Information($"Updating service=[{service.Key}] Dockerfile to include storage reference");
 			dockerfileText = dockerfileText.Replace(search, replacement);
-			File.WriteAllText(dockerfilePath, dockerfileText);
+			await File.WriteAllTextAsync(dockerfilePath, dockerfileText);
 		}
 
 		args.BeamoLocalSystem.SaveBeamoLocalManifest();


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3936

# Brief Description

> beam project new-storage called from folder different than folder containing beam config didn't work. Now it does.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?
