### PR TITLE
Typo fix in previousStageChange conversion

### DIFF
--- a/client/Packages/com.beamable/Common/Runtime/Api/Tournaments/ITournamentApi.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Api/Tournaments/ITournamentApi.cs
@@ -317,7 +317,7 @@ namespace Beamable.Common.Api.Tournaments
 				tier = entry.tier,
 				stage = entry.stage,
 				nextStageChange = entry.nextStageChange.GetOrElse(null),
-				previousStageChange = entry.nextStageChange.GetOrElse(null),
+				previousStageChange = entry.previousStageChange.GetOrElse(null),
 				currencyRewards = entry.currencyRewards.Select(TournamentRewardCurrency.FromOpenApi).ToList(),
 			};
 		}


### PR DESCRIPTION
TournamentEntry.FromOpenApi was using the value of nextStageChange in place of previousStageChange.

# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3951

# Brief Description

> Put description here

# Checklist

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
