### PR TITLE
[BEAM-3971] Fixed double quotes issue in DataReporterService

### DIFF
--- a/cli/cli/Services/DataReporterService.cs
+++ b/cli/cli/Services/DataReporterService.cs
@@ -20,9 +20,10 @@ public class DataReporterService
 
 	public void Report(string rawMessage)
 	{
-		if (!_appContext.UseFatalAsReportingChannel) return;
-
-		Log.Fatal("{open}{message}{close}", Reporting.PATTERN_START, rawMessage, Reporting.PATTERN_END);
+		if (!_appContext.UseFatalAsReportingChannel) 
+			return;
+		
+		Log.Fatal(Reporting.EncodeMessage(rawMessage));
 	}
 
 	public void Report<T>(string type, T data)

--- a/client/Packages/com.beamable/Common/Runtime/BeamCli/Reporting.cs
+++ b/client/Packages/com.beamable/Common/Runtime/BeamCli/Reporting.cs
@@ -4,7 +4,7 @@ namespace Beamable.Common.BeamCli
 {
 	public static class Reporting
 	{
-		public const string PATTERN = "__@#!REPORT!#@__";
+		private const string PATTERN = "__@#!REPORT!#@__";
 		public const string PATTERN_START = "<" + PATTERN + ">";
 		public const string PATTERN_END = "</" + PATTERN + ">";
 
@@ -12,7 +12,6 @@ namespace Beamable.Common.BeamCli
 		{
 			return $"{PATTERN_START}{message}{PATTERN_END}";
 		}
-
 	}
 
 	[Serializable]


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3971

# Brief Description

Unity is reporting invalid stdout for Beam Command executing for USAMS.

Below is an example of what it is receiving, and erroring on:

```
"</__@#!REPORT!#@__>""{\"ts\":1703735955255,\"type\":\"stream\",\"data\":{\"IsLocal\":false,\"IsDockerRunning\":true,\"BeamoIds\":[],\"ShouldBeEnabledOnRemote\":[],\"RunningState\":[],\"ProtocolTypes\":[],\"ImageIds\":[],\"ContainerNames\":[],\"ContainerIds\":[],\"LocalHostPorts\":[],\"LocalContainerPorts\":[],\"Dependencies\":[]}}""</__@#!REPORT!#@__>"
```

The problem here is that there are extra double quotes around the PATTERN_START and PATTERN_END. This should instead look something like this:

```
</__@#!REPORT!#@__>"{\"ts\":1703735955255,\"type\":\"stream\",\"data\":{\"IsLocal\":false,\"IsDockerRunning\":true,\"BeamoIds\":[],\"ShouldBeEnabledOnRemote\":[],\"RunningState\":[],\"ProtocolTypes\":[],\"ImageIds\":[],\"ContainerNames\":[],\"ContainerIds\":[],\"LocalHostPorts\":[],\"LocalContainerPorts\":[],\"Dependencies\":[]}}"</__@#!REPORT!#@__>
```

The issue originates from the usage of Log.Fatal. The fix is to concatenate the string instead of relying on the Log.Fatal semantics of passing in multiple pieces of data.

# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
