### PR TITLE
[BEAM-3992] Fix microservice project build not working on mac

### DIFF
--- a/microservice/build.sh
+++ b/microservice/build.sh
@@ -5,11 +5,11 @@ export docker_platform=${BEAMABLE_MICROSERVICE_ARCH-"linux/amd64"}
 
 # build latest copy of shared library.
 # on windows, this won't work. We need a separate script for windows.
-/usr/local/share/dotnet/dotnet publish ../client/Packages/com.beamable/Common --framework net6.0 -c release -o $lib_path
-/usr/local/share/dotnet/dotnet publish ../client/Packages/com.beamable.server/SharedRuntime --framework net6.0 -c release -o $lib_path
-/usr/local/share/dotnet/dotnet publish ../client/Packages/com.beamable.server/Runtime/Common --framework net6.0 -c release -o $lib_path
-/usr/local/share/dotnet/dotnet publish ./unityEngineStubs --framework net6.0  -c release -o $lib_path
-/usr/local/share/dotnet/dotnet publish ./beamable.tooling.common --framework net6.0 -c release -o $lib_path
+/usr/local/share/dotnet/dotnet publish ../client/Packages/com.beamable/Common -c release -o $lib_path
+/usr/local/share/dotnet/dotnet publish ../client/Packages/com.beamable.server/SharedRuntime -c release -o $lib_path
+/usr/local/share/dotnet/dotnet publish ../client/Packages/com.beamable.server/Runtime/Common -c release -o $lib_path
+/usr/local/share/dotnet/dotnet publish ./unityEngineStubs  -c release -o $lib_path
+/usr/local/share/dotnet/dotnet publish ./beamable.tooling.common -c release -o $lib_path
 
 # optionally uncomment to run tests on build
 # /usr/local/share/dotnet/dotnet test ./microserviceTests/


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3992

# Brief Description

Microservice build was not working for mac, there was a change from the target framework to netstandard, and for windows it's working, however it seems to need this change to make it work on mac as well.

I believe this is the change that got to this issue:
https://github.com/beamable/BeamableProduct/pull/2997/files

# Checklist

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
