### PR TITLE
beam 3917 - dll references should use file name, not suffix

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Microservices with `.dll` references will match based on filename, instead of first matching suffix. This fixes a common `Newtonsoft.Json` collision between Unity.Plastic and Unity.Newtonsoft.
+
 ### Added
 
 - `admin/metadata` route will return sdk version and other metadata about a running service.

--- a/client/Packages/com.beamable.server/Editor/DependencyResolver.cs
+++ b/client/Packages/com.beamable.server/Editor/DependencyResolver.cs
@@ -8,6 +8,7 @@ using MongoDB.Bson;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
@@ -490,7 +491,8 @@ namespace Beamable.Server
 			{
 				var importer = importers.FirstOrDefault(i =>
 				{
-					var isMatch = i.assetPath.EndsWith(dllReference);
+					var fileName = Path.GetFileName(i.assetPath);
+					var isMatch = dllReference == fileName;
 					return isMatch;
 				});
 				if (importer == null)


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3917

# Brief Description

We use the `PluginImporter.GetAllImporters()` function to get the list of available `.dll` files in Unity. Later, we use a `FirstOrDefault` check with an inner `EndsWith` predicate, meaning multiple entries in the `.dll` list _could_ match the `EndsWith` check, but the code would simply select the _first_ one. The order of the results from `GetAllImporters` is not enforced, so the `.dll` file that matched _first_ could be different, and by happenstance, incorrect. 

Instead of using `EndsWith`, this PR changes the code to do a proper file-name check. Previously, `Newtonsoft.Json.dll` was incorrectly matching with `Unity.Plastic.Newtonsoft.Json.dll`, but now with a full file name check, it will not.

# Checklist

* [X] Have you added appropriate text to the CHANGELOG.md files?
