### PR TITLE
[BEAM-4000][BEAM-4005] Fix logs not appearing correctly and rider not recognizing MS files

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -9,10 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Better validation and error messages for add-unreal-project command code-path;
-- Unreal Microservice client generation now correctly identifies whether or not the OSS UE Plugin is there and, if so, it'll add the microservices code to that module instead.
-- Unreal Microservice client generation now checks whether or not the linked project is using the OnlineSubsystemBeamable plugin and, if so, checks if it is configured correctly. This catches the case where people add the OSS after the Microservice was already added to the project modules;
-- CLI will now check if its necessary to run Unreal's Generate VS Project Files command after generating client code and, if so, will run and wait for it as part of the generate-client command (it is needed when new client callables are added/removed);
 - `--raw` option will output commands in machine readable JSON format
 - `beam listen player` command monitors notifications sent to the logged in CLI user
 - `beam listen server` command monitors server events
@@ -27,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `project add` Dockerfile path fixes.
 - `project new-storage` path fixes.
+
+## [1.19.12]
+
+### Added
+- Better validation and error messages for add-unreal-project command code-path;
+- Unreal Microservice client generation now correctly identifies whether or not the OSS UE Plugin is there and, if so, it'll add the microservices code to that module instead.
+- Unreal Microservice client generation now checks whether or not the linked project is using the OnlineSubsystemBeamable plugin and, if so, checks if it is configured correctly. This catches the case where people add the OSS after the Microservice was already added to the project modules;
+- CLI will now check if its necessary to run Unreal's Generate VS Project Files command after generating client code and, if so, will run and wait for it as part of the generate-client command (it is needed when new client callables are added/removed);
+
+### Fixed
 - Fixed issue that caused paths not to be stored relative to the `.beamable` folder correctly
 - Fixed issue that caused incorrect `\\` to be used instead of `/`
 - Fixed serializer generation to correctly use `TCHAR` as opposed to `wchar_t`

--- a/cli/cli/Services/ProjectService.cs
+++ b/cli/cli/Services/ProjectService.cs
@@ -369,9 +369,9 @@ public class ProjectService
 
 	public async Task CreateNewStorage(string slnFilePath, string storageName)
 	{
-		var slnDirectory = Path.GetDirectoryName(slnFilePath);
+		var slnDirectory = Path.GetDirectoryName(slnFilePath)!;
 		var rootServicesPath = Path.Combine(slnDirectory, "services");
-		var storagePath = Path.Combine(rootServicesPath, storageName);
+		var storagePath = _configService.GetRelativePath(Path.Combine(rootServicesPath, storageName));
 
 		if (Directory.Exists(storagePath))
 		{

--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## [Unreleased]
 
 ### Fixed
@@ -13,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `admin/metadata` route will return sdk version and other metadata about a running service.
+
+
+## [1.19.12]
+
+no changes
 
 ## [1.19.11]
 

--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Marked `EventView` `endTime` field as obsolete, suggest using `GetEndTime` method instead.
 
+## [1.19.12]
+
+no changes
+
 ## [1.19.11]
 
 ### Fixed


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-4000
https://disruptorbeam.atlassian.net/browse/BEAM-4005

# Brief Description

The first problem was that we were using a list of strings as a buffer for the logs messages sink. That was making logs
getting lost and being showed in wrong orders. Changing to use `ConcurrentQueue` fixed that!

The second problem was that in the `SolutionPostProcessor` we were pointing the main solution file to the wrong `csproj` files of the standalone microservices.

# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
