### PR TITLE
beam 4027 - error logs

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Commands will use `--raw` output automatically when piped to another process
 - Root commands with no action will automatically print `--help`
 - `docs`, `profile`, `generate-interface` and http commands are marked as `[INTERNAL]`
+- Commands automatically save the latest log to the temp path.
 
 ### Fixed
 

--- a/cli/cli/Utils/LogConfigData.cs
+++ b/cli/cli/Utils/LogConfigData.cs
@@ -1,0 +1,7 @@
+namespace cli.Utils;
+
+public class LogConfigData
+{
+	public bool shouldUseTempFile;
+	public string logFilePath;
+}

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCommand.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCommand.cs
@@ -329,6 +329,9 @@ namespace Beamable.Editor.BeamCli
 				_process.StartInfo.RedirectStandardError = CaptureStandardBuffers;
 				_process.StartInfo.CreateNoWindow = true;
 				_process.StartInfo.UseShellExecute = false;
+				
+				// prevent the beam CLI from saving any log information to file.
+				_process.StartInfo.Environment.Add("BEAM_CLI_NO_FILE_LOG", "1");
 
 				_status = new TaskCompletionSource<int>();
 				_standardOutComplete = new TaskCompletionSource<int>();


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-4027

# Brief Description

Now, when there is an exception, we'll print a little helpful message pointing to a log file that has all verbose logs.

for example, I rigged `beam me` to explode, 

```
chrishanna@Chriss-MacBook-Pro-2 cli % beam me
game over, man
   at cli.AccountMeCommand.GetResult(AccountMeCommandArgs args) in /Users/chrishanna/Documents/Github/BeamableProduct/cli/cli/Commands/AccountMeCommand.cs:line 42
   at cli.AtomicCommand`2.Handle(TArgs args) in /Users/chrishanna/Documents/Github/BeamableProduct/cli/cli/CommandContext.cs:line 112
   at System.CommandLine.Invocation.AnonymousCommandHandler.InvokeAsync(InvocationContext context)
   at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass4_0.<<BuildInvocationChain>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass18_0.<<UseParseErrorReporting>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass16_0.<<AddMiddleware>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass13_0.<<UseHelp>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass22_0.<<UseVersionOption>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass20_0.<<UseTypoCorrections>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass20_0.<<UseTypoCorrections>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<UseSuggestDirective>b__19_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<UseSuggestDirective>b__19_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass17_0.<<UseParseDirective>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<RegisterWithDotnetSuggest>b__6_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass9_0.<<UseExceptionHandler>b__0>d.MoveNext()
Logs at
  /var/folders/ys/949qmfy15r7bl8x36s6wmm000000gn/T/beamCliLog.txt
```

And then if you look at that file...

```
chrishanna@Chriss-MacBook-Pro-2 cli % cat /var/folders/ys/949qmfy15r7bl8x36s6wmm000000gn/T/beamCliLog.txt
2024-02-12 16:38:38.038 -05:00 [DBG] Trying to get option=ConfigDirOption from Env Vars! Value Found=
2024-02-12 16:38:38.126 -05:00 [DBG] Trying to get option=AccessTokenOption from Env Vars! Value Found=
2024-02-12 16:38:38.129 -05:00 [VRB] haha special verbose log
System.Exception: game over, man
   at cli.AccountMeCommand.GetResult(AccountMeCommandArgs args) in /Users/chrishanna/Documents/Github/BeamableProduct/cli/cli/Commands/AccountMeCommand.cs:line 42
   at cli.AtomicCommand`2.Handle(TArgs args) in /Users/chrishanna/Documents/Github/BeamableProduct/cli/cli/CommandContext.cs:line 112
   at System.CommandLine.Invocation.AnonymousCommandHandler.InvokeAsync(InvocationContext context)
   at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass4_0.<<BuildInvocationChain>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass18_0.<<UseParseErrorReporting>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass16_0.<<AddMiddleware>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass13_0.<<UseHelp>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass22_0.<<UseVersionOption>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass20_0.<<UseTypoCorrections>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass20_0.<<UseTypoCorrections>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<UseSuggestDirective>b__19_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<UseSuggestDirective>b__19_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass17_0.<<UseParseDirective>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<RegisterWithDotnetSuggest>b__6_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass9_0.<<UseExceptionHandler>b__0>d.MoveNext()%  
```

# Checklist

* [X] Have you added appropriate text to the CHANGELOG.md files?
