### PR TITLE
backport- only use cli if it matches version exactly

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.15]
+
+### Changed
+- CLI is only used if the global CLI matches the exact SDK version.
+
 ## [1.19.14]
 
 ### Fixed

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCli.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCli.cs
@@ -2,6 +2,7 @@ using Beamable.Common;
 using Beamable.Common.Api;
 using Beamable.Common.Dependencies;
 using Beamable.Editor.BeamCli.Commands;
+using UnityEngine;
 
 namespace Beamable.Editor.BeamCli
 {
@@ -24,7 +25,26 @@ namespace Beamable.Editor.BeamCli
 			try
 			{
 				await comm.Run();
+				
+#if BEAMABLE_DEVELOPER
+				// if we are developers, then we should always use the latest beam version
 				return true;
+#else
+				// but if we are not developers, then the global version must match the SDK version.
+				var buffer = comm.GetMessageBuffer();
+				if (!PackageVersion.TryFromSemanticVersionString(buffer, out var version))
+				{
+					return false;
+				}
+				
+				if (BeamableEnvironment.SdkVersion != version)
+				{
+					return false;
+				}
+				
+				Debug.Log("Using CLI");
+				return true;
+#endif
 			}
 			catch
 			{

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCommand.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCommand.cs
@@ -193,6 +193,8 @@ namespace Beamable.Editor.BeamCli
 			return this;
 		}
 
+		public string GetMessageBuffer() => messageBuffer;
+		
 		private void ProcessStandardOut(string message)
 		{
 			if (message == null) return;


### PR DESCRIPTION
Going forward, I'd like to release a CLI 2.0.0-PREVIEW-BETA, but if we do that, then old versions of the SDK will try and use it if its installed globally- but the syntax has changed so much, the old SDKs will break....


To fix that- I think we can reasonably give our customers 2 choices, either
1. you must not use the global CLI beta, or
2. you must not use a version of the SDK prior to 1.19.15

this change will first check the version number of the CLI and make sure it matches exactly the SDK version number before saying, "oh hey, we have access to the CLI!" In 1.19.x, the CLI interop is more, "if its available, use it, otherwise, don't", where-as the new 2.0 stuff _requires_ it exist. 