### PR TITLE
beam 4060 - support ienumerable types in json serialize

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 502 and 504 requests containing HTML are received as `RequesterExceptions`.
 - Content alphabetizes fields on checksum calculation as well as publication.
 - Listing content `activeFrom` field no longer resets every time it is viewed in the Inspector.
+- `Json.Serialize` will treat non `IDictionary` values of `IEnumerable` as json arrays.
 
 ### Removed
 

--- a/client/Packages/com.beamable/Common/Runtime/SmallerJSON/SmallerJSON.cs
+++ b/client/Packages/com.beamable/Common/Runtime/SmallerJSON/SmallerJSON.cs
@@ -763,6 +763,7 @@ namespace Beamable.Serialization.SmallerJSON
 				IList asList;
 				IDictionary asDict;
 				string asStr;
+				IEnumerable asEnumerable;
 
 				if (value == null)
 				{
@@ -785,6 +786,7 @@ namespace Beamable.Serialization.SmallerJSON
 
 					SerializeArray(asList, builder);
 				}
+				
 				else if ((asDict = value as IDictionary) != null)
 				{
 					if (value is ISerializationCallbackReceiver receiver)
@@ -797,6 +799,15 @@ namespace Beamable.Serialization.SmallerJSON
 				else if (value is char)
 				{
 					SerializeString(new string((char)value, 1), builder);
+				}
+				else if ((asEnumerable = value as IEnumerable) != null)
+				{
+					if (value is ISerializationCallbackReceiver receiver)
+					{
+						receiver.OnBeforeSerialize();
+					}
+
+					SerializeEnumerable(asEnumerable, builder);
 				}
 				else
 				{
@@ -831,6 +842,28 @@ namespace Beamable.Serialization.SmallerJSON
 				}
 
 				builder.Append('}');
+			}
+
+			private static void SerializeEnumerable(IEnumerable enumerable, StringBuilder builder)
+			{
+				builder.Append('[');
+
+				bool first = true;
+
+				foreach (var value in enumerable)
+				{
+					object obj = value;
+					if (!first)
+					{
+						builder.Append(',');
+					}
+
+					SerializeValue(obj, builder);
+
+					first = false;
+				}
+
+				builder.Append(']');
 			}
 
 			private static void SerializeArray(IList anArray, StringBuilder builder)

--- a/client/Packages/com.beamable/Tests/Editor/SmallerJSON/JsonSerializeTest.cs
+++ b/client/Packages/com.beamable/Tests/Editor/SmallerJSON/JsonSerializeTest.cs
@@ -1,6 +1,7 @@
 ﻿using Beamable.Serialization.SmallerJSON;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
 
@@ -30,6 +31,59 @@ namespace Beamable.Editor.Tests.SmallerJson
 			var jsonSerializedUnity = JsonUtility.ToJson(instance);
 			var smallerJsonSerialized = Json.Serialize(instance, new StringBuilder());
 			Assert.AreEqual(jsonSerializedUnity, smallerJsonSerialized);
+		}
+
+		[Test]
+		public void DictionaryWithHashSet_Long()
+		{
+			var dict = new Dictionary<string, object>
+			{
+				["fish"] = new HashSet<long>
+				{
+					1,2,3,1,2,3
+				}
+			};
+			var json = Json.Serialize(dict, new StringBuilder());
+			var expected = @"{
+""fish"":[1,2,3]
+}".Trim().Replace("\r\n", "").Replace("\n", "");
+			Assert.That(json, Is.EqualTo(expected));
+		}
+		
+		
+		[Test]
+		public void DictionaryWithHashSet_Ints()
+		{
+			var dict = new Dictionary<string, object>
+			{
+				["fish"] = new HashSet<int>
+				{
+					1,2,3,1,2,3
+				}
+			};
+			var json = Json.Serialize(dict, new StringBuilder());
+			var expected = @"{
+""fish"":[1,2,3]
+}".Trim().Replace("\r\n", "").Replace("\n", "");
+			Assert.That(json, Is.EqualTo(expected));
+		}
+		
+		
+		[Test]
+		public void DictionaryWithHashSet_Strings()
+		{
+			var dict = new Dictionary<string, object>
+			{
+				["fish"] = new HashSet<string>
+				{
+					"tuna", "salmon", "tuna"
+				}
+			};
+			var json = Json.Serialize(dict, new StringBuilder());
+			var expected = @"{
+""fish"":[""tuna"",""salmon""]
+}".Trim().Replace("\r\n", "").Replace("\n", "");
+			Assert.That(json, Is.EqualTo(expected));
 		}
 
 


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-4060

# Brief Description

When that fateful serialization change happened where our Unity SDK uses object representation to invoke C#MS, instead of array representation- we _also_ (in addition to a growing list of things) broke support for stuff like `HashSet`. That is because we started using `Json.Serialize` on a dictionary, instead of recursing through the structure ourselves. 

This PR adds support for general `IEnumerable` types to the `Json.Serialize` method. **CRITICALLY**, the base `IEnumerable` is handled after the the dictionary support.... However, the _risk_ in this PR is that some enterprising developer out there in the void is sending a DTO that implements `IEnumerable`, but that they _want_ the default object form representation of the object.... If this is happening, this PR would shoot that developer in the face. 

I very much _doubt_ that is happening. I hope it isn't.... Put differently; I'll roll those dice.

# Checklist

* [X] Have you added appropriate text to the CHANGELOG.md files?
