### PR TITLE
[BEAM-4077] Check if passed path is an unity project before asking more input

### DIFF
--- a/cli/cli/Commands/Project/AddUnityClientOutputCommand.cs
+++ b/cli/cli/Commands/Project/AddUnityClientOutputCommand.cs
@@ -33,16 +33,19 @@ public class AddUnityClientOutputCommand : AppCommand<AddProjectClientOutputComm
 		var startingDir = args.path;
 		var directory = args.path;
 
-		var expectedUnityParentDirectories = new[]
+		if (!unityProjectClient.IsValidProjectClientDirectory(ref directory) && !args.quiet)
 		{
-			".", // maybe the unity project a child of the current folder...
-			".." // or maybe the unity project is a sibling of the current folder...
-		}.Select(p => Path.Combine(startingDir, p)).ToArray();
+			var expectedUnityParentDirectories = new[]
+			{
+				".", // maybe the unity project a child of the current folder...
+				".." // or maybe the unity project is a sibling of the current folder...
+			}.Select(p => Path.Combine(startingDir, p)).ToArray();
 
-		var status = unityProjectClient.SuggestProjectClientTypeCandidates(expectedUnityParentDirectories, args);
-		if (status) return Task.CompletedTask;
+			var status = unityProjectClient.SuggestProjectClientTypeCandidates(expectedUnityParentDirectories, args);
+			if (status) return Task.CompletedTask;
 
-		unityProjectClient.FindProjectClientInDirectory(workingDir, ref directory);
+			unityProjectClient.FindProjectClientInDirectory(workingDir, ref directory);
+		}
 
 		directory = Path.GetRelativePath(args.ConfigService.BaseDirectory, directory);
 

--- a/cli/cli/Utils/ProjectClientHelper.cs
+++ b/cli/cli/Utils/ProjectClientHelper.cs
@@ -174,7 +174,7 @@ public class ProjectClientHelper<TProjectClient> where TProjectClient : IProject
 		}
 	}
 
-	private bool IsValidProjectClientDirectory(ref string path)
+	public bool IsValidProjectClientDirectory(ref string path)
 	{
 		try
 		{


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-4077

# Brief Description

When we first start the BeamCli in the Unity SDK, we link that project. However the CLI command that does this asks
for input in the command line, and that was failing when called from the SDK. This PR basically changes that to be: if you are passing a `--path` that is a valid Unity/Unreal project and it's also passing `--quiet=True`, then no prompt is going to happen, and that path is going to be used to link.

# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
