### PR TITLE
[BEAM-4007] Set manifest with updated information over deleted services

### DIFF
--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/CodeService.cs
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/CodeService.cs
@@ -642,7 +642,7 @@ namespace Beamable.Server.Editor.Usam
 				{
 					if (!Directory.Exists(sourcePath))
 					{
-						LogVerbose($"The file {name}.beamservice exists but there is no source code for it.");
+						LogVerbose($"The file {name}.beamstorage exists but there is no source code for it.");
 					}
 					continue;
 				}


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-4007

# Brief Description

When you delete both the source code and the signpost of the microservice/storage, that is updated in the local manifest.
If you only delete the source code but not the signpost file, then an error is going to happen.

# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
