### PR TITLE
[BEAM-3905] Create generate properties command and execute it in USAM

### DIFF
--- a/cli/cli/App.cs
+++ b/cli/cli/App.cs
@@ -215,6 +215,7 @@ public class App
 		Commands.AddSubCommand<GenerateEnvFileCommand, GenerateEnvFileCommandArgs, ProjectCommand>();
 		Commands.AddSubCommand<GenerateIgnoreFileCommand, GenerateIgnoreFileCommandArgs, ProjectCommand>();
 		Commands.AddSubCommand<GenerateClientFileCommand, GenerateClientFileCommandArgs, ProjectCommand>();
+		Commands.AddSubCommand<GeneratePropertiesFileCommand, GeneratePropertiesFileCommandArgs, ProjectCommand>();
 		Commands.AddSubCommand<OpenSwaggerCommand, OpenSwaggerCommandArgs, ProjectCommand>();
 		Commands.AddSubCommand<TailLogsCommand, TailLogsCommandArgs, ProjectCommand>();
 		Commands.AddSubCommand<OpenMongoExpressCommand, OpenMongoExpressCommandArgs, ProjectCommand>();

--- a/cli/cli/Commands/Project/GeneratePropertiesFileCommand.cs
+++ b/cli/cli/Commands/Project/GeneratePropertiesFileCommand.cs
@@ -42,7 +42,7 @@ public class GeneratePropertiesFileCommand : AppCommand<GeneratePropertiesFileCo
 		string fileContents = @$"
 <Project>
  <PropertyGroup>
-     <SolutionDir Condition=""$(SolutionDir) == ''$\"">{args.SolutionDir}</SolutionDir>
+     <SolutionDir Condition=""'$(SolutionDir)' == ''"">{args.SolutionDir}</SolutionDir>
      <BeamableTool>{args.BeamPath}</BeamableTool>
  </PropertyGroup>
 </Project>";

--- a/cli/cli/Commands/Project/GeneratePropertiesFileCommand.cs
+++ b/cli/cli/Commands/Project/GeneratePropertiesFileCommand.cs
@@ -1,0 +1,54 @@
+using System.CommandLine;
+
+namespace cli.Dotnet;
+
+public class GeneratePropertiesFileCommandArgs : CommandArgs
+{
+	public string OutputPath;
+	public string BeamPath;
+	public string SolutionDir;
+}
+
+public class GeneratePropertiesFileCommand : AppCommand<GeneratePropertiesFileCommandArgs>, IEmptyResult
+{
+	
+	
+	public GeneratePropertiesFileCommand() : base("generate-properties", "Generates a Directory.Build.props file with the beam path and solution dir")
+	{
+	}
+
+	public override void Configure()
+	{
+		AddArgument(new Argument<string>("output", description: "Where the file will be created"),
+			(args, i) => args.OutputPath = i);
+		AddArgument(new Argument<string>("beam-path", description: "Beam path to be used"),
+			(args, i) => args.BeamPath = i);
+		AddArgument(new Argument<string>("solution-dir", description: "The solution path to be used"),
+			(args, i) => args.SolutionDir = i);
+	}
+
+	public override Task Handle(GeneratePropertiesFileCommandArgs args)
+	{
+		if (!Directory.Exists(args.OutputPath))
+		{
+			throw new CliException("Output path argument passed does not exist.");
+		}
+		
+		if (!Directory.Exists(args.SolutionDir))
+		{
+			throw new CliException("SolutionDir path must exist.");
+		}
+		
+		string fileContents = @$"
+<Project>
+ <PropertyGroup>
+     <SolutionDir Condition=""$(SolutionDir) == ''$\"">{args.SolutionDir}</SolutionDir>
+     <BeamableTool>{args.BeamPath}</BeamableTool>
+ </PropertyGroup>
+</Project>";
+		var path = Path.Combine(args.OutputPath, "Directory.Build.props");
+		File.WriteAllText(path, fileContents);
+		
+		return Task.CompletedTask;
+	}
+}

--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/CodeService.cs
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/CodeService.cs
@@ -77,6 +77,9 @@ namespace Beamable.Server.Editor.Usam
 			SetSolution(_services, _storages);
 			LogVerbose("Solution set done");
 
+			LogVerbose("Setting properties file");
+			await SetPropertiesFile();
+
 			LogVerbose("Set manifest start");
 			await SetManifest(_cli, _services, _storages);
 			LogVerbose("set manifest ended");
@@ -478,6 +481,17 @@ namespace Beamable.Server.Editor.Usam
 			}
 
 			return null;
+		}
+
+		private async Promise SetPropertiesFile()
+		{
+			var command = _cli.ProjectGenerateProperties(new ProjectGeneratePropertiesArgs()
+			{
+				output = ".",
+				beamPath = BeamCliUtil.CLI_PATH.Replace(".dll", ""),
+				solutionDir = Path.GetFullPath(".")
+			});
+			await command.Run();
 		}
 
 		/// <summary>

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateProperties.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateProperties.cs
@@ -1,0 +1,58 @@
+
+namespace Beamable.Editor.BeamCli.Commands
+{
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectGeneratePropertiesArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Where the file will be created</summary>
+        public string output;
+        /// <summary>Beam path to be used</summary>
+        public string beamPath;
+        /// <summary>The solution path to be used</summary>
+        public string solutionDir;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // Add the output value to the list of args.
+            genBeamCommandArgs.Add(this.output);
+            // Add the beamPath value to the list of args.
+            genBeamCommandArgs.Add(this.beamPath);
+            // Add the solutionDir value to the list of args.
+            genBeamCommandArgs.Add(this.solutionDir);
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectGeneratePropertiesWrapper ProjectGenerateProperties(ProjectGeneratePropertiesArgs generatePropertiesArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("generate-properties");
+            genBeamCommandArgs.Add(generatePropertiesArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectGeneratePropertiesWrapper genBeamCommandWrapper = new ProjectGeneratePropertiesWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectGeneratePropertiesWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
+}

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateProperties.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateProperties.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c48d1d6627496421a97a51742fd43ca0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-3905

# Brief Description

This PR creates a command in the CLI for generating a `Directory.Build.props` file with both the 
`beam` path and the solution directory path. 

# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
