### PR TITLE
fixes #3155 - Leaderboard outlier null

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Listing content `activeFrom` field no longer resets every time it is viewed in the Inspector.
 - `Json.Serialize` will treat non `IDictionary` values of `IEnumerable` as json arrays.
 - Disabling Content inspectors no longer causes compiler errors.
+- Leaderboard `rankgt` field is not null when specifying outlier.
 
 ### Removed
 

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Modules/Leaderboards/LeaderboardViewSerializeTests.cs
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Modules/Leaderboards/LeaderboardViewSerializeTests.cs
@@ -1,0 +1,109 @@
+using Beamable.Common.Api.Leaderboards;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Beamable.Tests.Modules.Leaderboards
+{
+	public class LeaderboardViewSerializeTests
+	{
+		[Test]
+		public void LeaderBoardV2ViewResponse_RankgtGiven()
+		{
+			var instance = JsonUtility.FromJson<LeaderBoardV2ViewResponse>(LEADERBOARD_JSON_WITH_RANKGT);
+			Assert.That(instance.lb.rankgt, Is.Not.Null);
+			Assert.That(instance.lb.rankgt.gt, Is.EqualTo(1725855903908867L));
+		}
+		
+		[Test]
+		public void LeaderBoardV2ViewResponse_RankgtInferredFromUserId()
+		{
+			var instance = JsonUtility.FromJson<LeaderBoardV2ViewResponse>(LEADERBOARD_JSON_WITHOUT_RANKGT);
+			instance.lb.userId = 1715864498066877;
+			Assert.That(instance.lb.rankgt, Is.Not.Null);
+			Assert.That(instance.lb.rankgt.gt, Is.EqualTo(1715864498066877));
+		}
+
+		private const string LEADERBOARD_JSON_WITH_RANKGT = @"{
+  ""result"": ""ok"",
+  ""lb"": {
+    ""lbId"": ""leaderboards.issue"",
+    ""boardSize"": 5,
+    ""rankgt"": {
+      ""gt"": 1725855903908867,
+      ""rank"": 1,
+      ""columns"": {
+        ""score"": 5
+      },
+      ""score"": 5.0,
+      ""stats"": []
+    },
+    ""rankings"": [
+      {
+        ""gt"": 1725855903908867,
+        ""rank"": 1,
+        ""columns"": {
+          ""score"": 5
+        },
+        ""score"": 5.0,
+        ""stats"": []
+      },
+      {
+        ""gt"": 1725859500139527,
+        ""rank"": 2,
+        ""columns"": {
+          ""score"": 5
+        },
+        ""score"": 5.0,
+        ""stats"": []
+      },
+      {
+        ""gt"": 1715864498066877,
+        ""rank"": 3,
+        ""columns"": {
+          ""score"": 3
+        },
+        ""score"": 3.0,
+        ""stats"": []
+      }
+    ]
+  }
+}";
+		
+		private const string LEADERBOARD_JSON_WITHOUT_RANKGT = @"{
+  ""result"": ""ok"",
+  ""lb"": {
+    ""lbId"": ""leaderboards.issue"",
+    ""boardSize"": 5,
+    ""rankings"": [
+      {
+        ""gt"": 1725855903908867,
+        ""rank"": 1,
+        ""columns"": {
+          ""score"": 5
+        },
+        ""score"": 5.0,
+        ""stats"": []
+      },
+      {
+        ""gt"": 1725859500139527,
+        ""rank"": 2,
+        ""columns"": {
+          ""score"": 5
+        },
+        ""score"": 5.0,
+        ""stats"": []
+      },
+      {
+        ""gt"": 1715864498066877,
+        ""rank"": 3,
+        ""columns"": {
+          ""score"": 3
+        },
+        ""score"": 3.0,
+        ""stats"": []
+      }
+    ]
+  }
+}";
+	}
+}

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/Modules/Leaderboards/LeaderboardViewSerializeTests.cs.meta
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/Modules/Leaderboards/LeaderboardViewSerializeTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0c022e2155204c5da78dd1ac3ad33a4c
+timeCreated: 1710263943


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-4087

# Brief Description

Frustratingly, the `[FormerlySerializedAs]` attribute does not work when you're using `JsonUtility` directly. 
To not break field names or anything, I did something strange and created a base class, and used the `new` keyword on a field to get Unity to serialize the "rankgt" json field into the sub-class'd `rankgt` field. 

# Checklist

* [X] Have you added appropriate text to the CHANGELOG.md files?
