### PR TITLE
Issues 3181-3167

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `beam project run` command will run a dotnet project
 - `beam project stop` will stop running dotnet projects
 - `beam project build` will build a dotnet project
-- Unreal Microservice client generation now correctly generates non-primitives used in C#MS signatures
+- Unreal Microservice client generation now correctly generates non-primitives used in C#MS signatures, including containers and nested containers.
+- Unreal Microservice client generation now happens for all microservices at once and support shared code.
+This means Unreal now supports multiple microservices as well as shared libraries!
 
 ### Changed
 
@@ -28,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Commands will log single outputs as JSON by default.
 - Console logging no longer includes log level and timestamp.
 - Logs containing GUID based tokens will be masked and only the last 4 characters will be shown.
+- Unreal Microservice Client Code generation no longer appends the microservice name to serializable types. 
+This means that the game-maker is responsible for resolving name conflicts that stem from types used in any `Callable`'s signature.
+In most cases, this is as trivial as renaming the type inside the microservice to something that won't conflict.
 
 ### Fixed
 

--- a/cli/cli/Commands/Project/GenerateOapiCommand.cs
+++ b/cli/cli/Commands/Project/GenerateOapiCommand.cs
@@ -3,8 +3,6 @@ using Beamable.Server;
 using Beamable.Server.Editor;
 using Beamable.Tooling.Common.OpenAPI;
 using cli.Dotnet;
-using cli.Services;
-using CliWrap;
 using CliWrap.Buffered;
 using microservice.Common;
 using Microsoft.OpenApi;
@@ -12,7 +10,6 @@ using Microsoft.OpenApi.Extensions;
 using Serilog;
 using System.Reflection;
 using System.Runtime.Loader;
-using System.Text;
 
 namespace cli.Commands.Project;
 
@@ -46,7 +43,7 @@ public class GenerateOApiCommand : StreamCommand<GenerateOApiCommandArgs, Genera
 		var generator = new ServiceDocGenerator();
 		foreach (var service in args.services)
 		{
-			var result = await IsProjectBuilt(args, service);
+			var result = await ProjectCommand.IsProjectBuilt(args, service);
 			if (!result.isBuilt)
 			{
 				Log.Information($"service=[{service}] is not built.");
@@ -137,49 +134,5 @@ inner-type=[{ex.InnerException?.GetType().Name}]
 		};
 
 		return loadContext.LoadFromAssemblyPath(absolutePath);
-	}
-
-	static async Task<ProjectBuildStatusReport> IsProjectBuilt(CommandArgs args, string serviceName)
-	{
-		if (!args.BeamoLocalSystem.BeamoManifest.HttpMicroserviceLocalProtocols.TryGetValue(serviceName, out var service))
-		{
-			throw new CliException($"service does not exist, service=[{serviceName}]");
-		}
-		Log.Debug($"Found service definition, ctx=[{service.DockerBuildContextPath}] dockerfile=[{service.RelativeDockerfilePath}]");
-		var dockerfilePath = Path.Combine(args.ConfigService.GetRelativePath(service.DockerBuildContextPath), service.RelativeDockerfilePath);
-		var projectPath = Path.GetDirectoryName(dockerfilePath);
-		Log.Debug($"service path=[{projectPath}]");
-		var commandStr = $"msbuild {projectPath} -t:GetTargetPath -verbosity:diag";
-		Log.Debug($"running {args.AppContext.DotnetPath} {commandStr}");
-		var stdOutBuilder = new StringBuilder();
-		var result = await CliExtensions.GetDotnetCommand(args.AppContext.DotnetPath, commandStr)
-			.WithStandardOutputPipe(PipeTarget.ToStringBuilder(stdOutBuilder))
-			.WithValidation(CommandResultValidation.None)
-			.ExecuteAsync();
-		Log.Verbose("dotnet program exited with " + result.ExitCode);
-		var stdOut = stdOutBuilder.ToString();
-		var lines = stdOut.Split(Environment.NewLine);
-		Log.Verbose("msbuild logs\n" + stdOut);
-		var outputPathLine = lines.Select(l => l.ToLowerInvariant().Trim()).FirstOrDefault(l => l.StartsWith("finaloutputpath") && l.EndsWith(".dll"));
-
-		if (string.IsNullOrEmpty(outputPathLine))
-			throw new CliException(
-				$"service could not identify output path. service=[{serviceName}] command=[{commandStr}]");
-
-		var report = new ProjectBuildStatusReport
-		{
-			path = outputPathLine.Substring("finaloutputpath = ".Length).Trim(),
-		};
-		report.isBuilt = File.Exists(report.path);
-
-		Log.Debug($"found output path, path=[{report.path}] exists=[{report.isBuilt}]");
-
-		return report;
-	}
-
-	public struct ProjectBuildStatusReport
-	{
-		public bool isBuilt;
-		public string path;
 	}
 }

--- a/cli/cli/Commands/Project/NewStorageCommand.cs
+++ b/cli/cli/Commands/Project/NewStorageCommand.cs
@@ -108,7 +108,7 @@ public class NewStorageCommand : AppCommand<NewStorageCommandArgs>, IEmptyResult
 		}
 		else if (args.linkedServices != null)
 		{
-			dependencies = GetDependencieFromName(args.BeamoLocalSystem, args.linkedServices);
+			dependencies = GetDependenciesFromName(args.BeamoLocalSystem, args.linkedServices);
 		}
 
 		// add the project itself
@@ -128,7 +128,7 @@ public class NewStorageCommand : AppCommand<NewStorageCommandArgs>, IEmptyResult
 		}
 	}
 
-	private string[] GetDependencieFromName(BeamoLocalSystem localSystem, List<string> dependencies)
+	private string[] GetDependenciesFromName(BeamoLocalSystem localSystem, List<string> dependencies)
 	{
 		if (dependencies == null)
 		{

--- a/cli/cli/Commands/Project/ProjectCommand.cs
+++ b/cli/cli/Commands/Project/ProjectCommand.cs
@@ -1,6 +1,8 @@
-
+using cli.Services;
+using CliWrap;
 using Serilog;
 using System.CommandLine;
+using System.Text;
 
 namespace cli.Dotnet;
 
@@ -51,5 +53,46 @@ public class ProjectCommand : CommandGroup
 		}
 
 		Log.Debug("using services " + string.Join(",", services));
+	}
+
+	public static async Task<ProjectBuildStatusReport> IsProjectBuilt(CommandArgs args, string beamoServiceId)
+	{
+		if (!args.BeamoLocalSystem.BeamoManifest.HttpMicroserviceLocalProtocols.TryGetValue(beamoServiceId, out var service))
+		{
+			throw new CliException($"service does not exist, service=[{beamoServiceId}]");
+		}
+
+		var deps = await args.BeamoLocalSystem.GetDependencies(beamoServiceId);
+		Log.Debug("Found service definition, ctx=[{ServiceDockerBuildContextPath}] dockerfile=[{ServiceRelativeDockerfilePath}] deps=[{Dependencies}]", service.DockerBuildContextPath, service.RelativeDockerfilePath, string.Join(",", deps));
+		var dockerfilePath = Path.Combine(args.ConfigService.GetRelativePath(service.DockerBuildContextPath), service.RelativeDockerfilePath);
+		var projectPath = Path.GetDirectoryName(dockerfilePath);
+		Log.Debug("service path=[{ProjectPath}]", projectPath);
+		var commandStr = $"msbuild {projectPath} -t:GetTargetPath -verbosity:diag";
+		Log.Debug("running {AppContextDotnetPath} {CommandStr}", args.AppContext.DotnetPath, commandStr);
+		var stdOutBuilder = new StringBuilder();
+		var result = await CliExtensions.GetDotnetCommand(args.AppContext.DotnetPath, commandStr)
+			.WithStandardOutputPipe(PipeTarget.ToStringBuilder(stdOutBuilder))
+			.WithValidation(CommandResultValidation.None)
+			.ExecuteAsync();
+		Log.Verbose("dotnet program exited with {ResultExitCode}", result.ExitCode);
+		var stdOut = stdOutBuilder.ToString();
+		var lines = stdOut.Split(Environment.NewLine);
+		Log.Verbose("msbuild logs\\n{StdOut}", stdOut);
+		var outputPathLine = lines.Select(l => l.ToLowerInvariant().Trim()).FirstOrDefault(l => l.StartsWith("finaloutputpath") && l.EndsWith(".dll"));
+
+		if (string.IsNullOrEmpty(outputPathLine))
+			throw new CliException(
+				$"service could not identify output path. service=[{beamoServiceId}] command=[{commandStr}]");
+
+		var report = new ProjectBuildStatusReport { path = outputPathLine.Substring("finaloutputpath = ".Length).Trim(), };
+		report.isBuilt = File.Exists(report.path);
+		Log.Debug("found output path, path=[{ReportPath}] exists=[{ReportIsBuilt}]", report.path, report.isBuilt);
+		return report;
+	}
+
+	public struct ProjectBuildStatusReport
+	{
+		public bool isBuilt;
+		public string path;
 	}
 }

--- a/cli/cli/Services/BeamoLocalSystem.cs
+++ b/cli/cli/Services/BeamoLocalSystem.cs
@@ -15,8 +15,6 @@ public partial class BeamoLocalSystem
 	/// </summary>
 	public readonly BeamoLocalManifest BeamoManifest;
 
-	public readonly Dictionary<BeamoServiceDefinition, List<string>> ServicesDependencies = new();
-
 	/// <summary>
 	/// The current local state of containers, associated with the <see cref="BeamoLocalManifest.ServiceDefinitions"/>, keept in sync with the <see cref="_beamoLocalRuntimeFile"/> json file.
 	/// </summary>
@@ -96,6 +94,7 @@ public partial class BeamoLocalSystem
 	/// Persists the current state of <see cref="BeamoManifest"/> out to disk. TODO: Make this persistence part agnostic of where this is running so we can use it in Unity as well, maybe?
 	/// </summary>
 	public void SaveBeamoLocalManifest() => _configService.SaveDataFile(Constants.BEAMO_LOCAL_MANIFEST_FILE_NAME, BeamoManifest);
+
 	public void SaveBeamoLocalRuntime() => _configService.SaveDataFile(Constants.BEAMO_LOCAL_RUNTIME_FILE_NAME, BeamoRuntime);
 
 	/// <summary>
@@ -108,15 +107,21 @@ public partial class BeamoLocalSystem
 	/// Get list of <see cref="BeamoId"/>s that this service depends on.
 	/// </summary>
 	/// <param name="beamoServiceId">The identifier of the Beamo service.</param>
-	/// <param name="projectExtension">The extension of the project files. Default is "csproj".</param>
 	/// <returns>Returns a list of <see cref="BeamoId"/>s that this service depends on.</returns>
-	public async Task<List<string>> GetDependencies(string beamoServiceId, string projectExtension = "csproj")
+	public async Task<List<string>> GetDependencies(string beamoServiceId)
 	{
 		var serviceDefinition = BeamoManifest.ServiceDefinitions.FirstOrDefault(s => s.BeamoId == beamoServiceId);
 		if (string.IsNullOrWhiteSpace(serviceDefinition?.ProjectDirectory))
 		{
 			return new List<string>();
 		}
+
+		var projectExtension = serviceDefinition.Language switch
+		{
+			BeamoServiceDefinition.ProjectLanguage.CSharpDotnet => "csproj",
+			_ => throw new ArgumentOutOfRangeException()
+		};
+
 		var path = _configService.GetRelativePath(serviceDefinition!.ProjectDirectory);
 		path = Path.Combine(path, $"{beamoServiceId}.{projectExtension}");
 		var (cmd, builder) = await CliExtensions.RunWithOutput(_ctx.DotnetPath, $"list {path} reference");
@@ -124,6 +129,7 @@ public partial class BeamoLocalSystem
 		{
 			throw new CliException($"Getting service dependencies failed, command output: {builder}");
 		}
+
 		// TODO improve it, for now it is naive, if there is related project with same name as one of the services it will treat it as it is connected
 		var withExtension = builder.ToString().Split(Environment.NewLine);
 
@@ -139,11 +145,12 @@ public partial class BeamoLocalSystem
 	public async Task AddProjectDependency(BeamoServiceDefinition project, BeamoServiceDefinition dependency)
 	{
 		if (project.Protocol != BeamoProtocolType.HttpMicroservice ||
-			dependency.Protocol != BeamoProtocolType.EmbeddedMongoDb)
+		    dependency.Protocol != BeamoProtocolType.EmbeddedMongoDb)
 		{
 			throw new CliException(
 				$"Currently the only supported dependencies are {nameof(BeamoProtocolType.HttpMicroservice)} depending on {nameof(BeamoProtocolType.EmbeddedMongoDb)}");
 		}
+
 		var projectPath = _configService.GetRelativePath(project.ProjectDirectory);
 		var dependencyPath = _configService.GetRelativePath(dependency.ProjectDirectory);
 		var command = $"add {projectPath} reference {dependencyPath}";
@@ -169,7 +176,6 @@ COPY {dependency.BeamoId}/. .";
 			dockerfileText = dockerfileText.Replace(search, replacement);
 			await File.WriteAllTextAsync(dockerfilePath, dockerfileText);
 		}
-		ServicesDependencies.Clear();
 	}
 
 	/// <summary>
@@ -179,17 +185,17 @@ COPY {dependency.BeamoId}/. .";
 	/// <returns>A dictionary where the key is a BeamoServiceDefinition and the value is a list of its dependencies.</returns>
 	public async Task<Dictionary<BeamoServiceDefinition, List<string>>> GetAllBeamoIdsDependencies(string projectExtension = "csproj")
 	{
-
+		var allBeamoIdsDependencies = new Dictionary<BeamoServiceDefinition, List<string>>();
 		foreach (var definition in BeamoManifest.ServiceDefinitions)
 		{
-			if (!ServicesDependencies.ContainsKey(definition))
+			if (!allBeamoIdsDependencies.ContainsKey(definition))
 			{
-				var entry = await GetDependencies(definition.BeamoId, projectExtension);
-				ServicesDependencies.Add(definition, entry);
+				var entry = await GetDependencies(definition.BeamoId);
+				allBeamoIdsDependencies.Add(definition, entry);
 			}
 		}
 
-		return ServicesDependencies;
+		return allBeamoIdsDependencies;
 	}
 
 	/// <summary>
@@ -272,6 +278,7 @@ COPY {dependency.BeamoId}/. .";
 		{
 			BeamoId = beamoId,
 			Protocol = type,
+			Language = BeamoServiceDefinition.ProjectLanguage.CSharpDotnet,
 			ImageId = string.Empty,
 			ShouldBeEnabledOnRemote = shouldServiceBeEnabled,
 		};
@@ -387,7 +394,6 @@ COPY {dependency.BeamoId}/. .";
 	}
 }
 
-
 /// <summary>
 /// A function that takes in the <see cref="BeamoServiceDefinition"/> plus it's associated Local Protocol so that it can make changes to the protocol instance.
 /// </summary>
@@ -399,7 +405,6 @@ public delegate Task LocalProtocolModifier<in TLocal>(BeamoServiceDefinition own
 /// </summary>
 /// <typeparam name="TRemote">The type of <see cref="IBeamoRemoteProtocol"/> associated with the given <see cref="BeamoServiceDefinition.Protocol"/>.</typeparam>
 public delegate Task RemoteProtocolModifier<in TRemote>(BeamoServiceDefinition owner, TRemote protocol) where TRemote : IBeamoRemoteProtocol;
-
 
 /// <summary>
 /// A "typedef" around a <see cref="string"/> to <see cref="IBeamoLocalProtocol"/> <see cref="Dictionary{TKey,TValue}"/>.
@@ -473,10 +478,18 @@ public class BeamoLocalManifest
 
 public class BeamoServiceDefinition
 {
+	public enum ProjectLanguage { CSharpDotnet, }
+
 	/// <summary>
 	/// The id that this service will be know, both locally and remotely.
 	/// </summary>
 	public string BeamoId;
+
+	/// <summary>
+	/// The type of the project for this --- for now, can only be <see cref="ProjectLanguage.CSharpDotnet"/>, in the future, we might have different flavor MSs.
+	/// TODO: When we start supporting different languages for microservices, this will be allowed to change --- for now, it is always <see cref="ProjectLanguage.CSharpDotnet"/>.
+	/// </summary>
+	public ProjectLanguage Language = ProjectLanguage.CSharpDotnet;
 
 	/// <summary>
 	/// The protocol this service respects.
@@ -621,7 +634,6 @@ public struct DockerEnvironmentVariable
 	public string VariableName;
 	public string Value;
 }
-
 
 /// <summary>
 /// The type of protocol a <see cref="BeamoServiceDefinition.Protocol"/> was created with. Conceptually, a protocol is just a set of algorithms and data that solve the problem of:

--- a/cli/cli/Services/BeamoLocalSystem.cs
+++ b/cli/cli/Services/BeamoLocalSystem.cs
@@ -116,11 +116,7 @@ public partial class BeamoLocalSystem
 			return new List<string>();
 		}
 
-		var projectExtension = serviceDefinition.Language switch
-		{
-			BeamoServiceDefinition.ProjectLanguage.CSharpDotnet => "csproj",
-			_ => throw new ArgumentOutOfRangeException()
-		};
+		var projectExtension = serviceDefinition.ProjectExtension;
 
 		var path = _configService.GetRelativePath(serviceDefinition!.ProjectDirectory);
 		path = Path.Combine(path, $"{beamoServiceId}.{projectExtension}");
@@ -571,6 +567,34 @@ public class BeamoServiceDefinition
 			return $"{bm.LocalPath}:{bm.InContainerPath}{options}";
 		}));
 	}
+
+	/// <summary>
+	/// <inheritdoc cref="GetProjectExtension"/>
+	/// </summary>
+	public string ProjectExtension => GetProjectExtension(Language);
+
+	/// <summary>
+	/// Given a project language, will return an individual project/module file extension ("csproj" for dotnet, "mod" for go, etc...)
+	/// </summary>
+	public static string GetProjectExtension(ProjectLanguage language) => language switch
+	{
+		ProjectLanguage.CSharpDotnet => "csproj",
+		_ => throw new ArgumentOutOfRangeException()
+	};
+
+	/// <summary>
+	/// <inheritdoc cref="GetSolutionExtension"/>
+	/// </summary>
+	public string SolutionExtension => GetSolutionExtension(Language);
+
+	/// <summary>
+	/// Given a language, return a "group of project" file extension ("sln" for dotnet, "work" for go, etc...)
+	/// </summary>
+	public static string GetSolutionExtension(ProjectLanguage language) => language switch
+	{
+		ProjectLanguage.CSharpDotnet => "sln",
+		_ => throw new ArgumentOutOfRangeException()
+	};
 }
 
 /// <summary>

--- a/cli/cli/Services/BeamoLocalSystem_HttpMicroservice.cs
+++ b/cli/cli/Services/BeamoLocalSystem_HttpMicroservice.cs
@@ -260,36 +260,6 @@ public class HttpMicroserviceLocalProtocol : IBeamoLocalProtocol
 	/// This is for local and development things
 	/// </summary>
 	public string RelativeDockerfilePath;
-	//
-	// [JsonIgnore]
-	// public string CID;
-	//
-	// [JsonIgnore]
-	// public string PID;
-	//
-	// /// <summary>
-	// /// TODO: We should add secret storage/resolution to Beam-O...
-	// /// </summary>
-	// [JsonIgnore]
-	// public string RealmSecret;
-	//
-	// /// <summary>
-	// /// TODO: Discuss with Drazen how to step out of this problem by leveraging the Http Service Discovery thing.
-	// /// </summary>
-	// [JsonIgnore]
-	// public string WebSocketHost;
-	//
-	// [JsonIgnore]
-	// public string LogLevel;
-	//
-	// [JsonIgnore]
-	// public string Prefix;
-	//
-	// [JsonIgnore]
-	// public string HealthCheckEndpoint;
-	//
-	// [JsonIgnore]
-	// public string HealthCheckInternalPort;
 
 	public DockerBindMount BindSrcForHotReloading;
 	public string HotReloadEnabledEndpoint;


### PR DESCRIPTION
# Ticket

https://github.com/beamable/BeamableProduct/issues/3181
https://github.com/beamable/BeamableProduct/issues/3167

# Brief Description

Added Single Pass Client Code-generation for UE SAMS Client-Code Gen.

- Removed commented data from HttpMicroserviceLocalProtocol
- Since service dependencies are now implicitly tracked by the SAMS ".csproj" file, we removed the ServiceDependency data field from the manifest
- Added ProjectLanguage enum and field to ServiceDefinition ---- defaults to CSharpDotnet ---- this is used to inform our various algorithms of where to look for service configuration.
- BeamoLocalSystem.GetDependencies no longer takes an an extension. Instead, this is determined by the ServiceDefinition's Language.
- Unreal Source Generator's SAMS Client Code-gen now supports returning containers and nested containers (resolves https://github.com/beamable/BeamableProduct/issues/3167).
- Unreal Source Generator no longer automatically appends the Microservice name to JsonSerializable declarations (it still applies it to RequestsArgs and Subsystem and endpoint definitions). Resolves https://github.com/beamable/BeamableProduct/issues/3181.
- Moved IsProjectBuilt static function into ProjectCommand so various commands can find the project and its output path.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
