### PR TITLE
fixes 3171 - usam project versioning

### DIFF
--- a/cli/cli/Commands/Project/ProjectVersionCommand.cs
+++ b/cli/cli/Commands/Project/ProjectVersionCommand.cs
@@ -37,15 +37,17 @@ public class ProjectVersionCommand : AtomicCommand<ProjectVersionCommandArgs, Pr
 		Log.Debug($"discovered {projectList.Count} projects...");
 		foreach (var project in projectList)
 		{
-			var solutionPath =
+			var solutionPathDir =
 				Directory.GetParent(Path.Combine(args.ConfigService.BaseDirectory, project.RelativeDockerfilePath));
+			var solutionPath = Path.ChangeExtension(solutionPathDir.FullName, ".sln");
+			var solutionDir = Path.GetDirectoryName(solutionPath);
 			Log.Debug($"sln=[{solutionPath}]");
 
 			var (_, buffer) =
-				await CliExtensions.RunWithOutput(args.AppContext.DotnetPath, $"sln list {solutionPath!.FullName}");
+				await CliExtensions.RunWithOutput(args.AppContext.DotnetPath, $"sln {solutionPath} list");
 
 			var projectsPaths = buffer.ToString().ReplaceLineEndings("\n").Split("\n").Where(s => s.EndsWith(".csproj"))
-				.Select(p => Directory.GetParent(Path.Combine(solutionPath.FullName, p))!.FullName).ToList();
+				.Select(p => Directory.GetParent(Path.Combine(solutionDir, p))!.FullName).ToList();
 			Log.Debug($"sln=[{solutionPath}] inner project reference count=[{projectsPaths.Count}]");
 
 			foreach (string projectPath in projectsPaths)

--- a/client/set-packages.sh
+++ b/client/set-packages.sh
@@ -28,7 +28,7 @@ dotnet pack Packages/com.beamable.server/SharedRuntime/ --configuration Release 
 dotnet pack ../microservice/beamable.tooling.common/  --configuration Release --include-source  -o $PROJECTS_DIR -p:PackageVersion=$VERSION -p:InformationalVersion=$VERSION_INFO
 dotnet pack ../microservice/  --configuration Release --include-source  -o $PROJECTS_DIR -p:PackageVersion=$VERSION -p:CombinedVersion=$VERSION -p:InformationalVersion=$VERSION_INFO
 dotnet pack ../microservice/unityEngineStubs/  --configuration Release --include-source  -o $PROJECTS_DIR -p:PackageVersion=$VERSION -p:InformationalVersion=$VERSION_INFO
-
+OUTPUT=$PROJECTS_DIR VERSION=$VERSION ../templates/build.sh
 
 if dotnet nuget list source | grep -q $SOURCE_NAME; then
     echo "Source already exists!"

--- a/templates/build.sh
+++ b/templates/build.sh
@@ -1,3 +1,6 @@
+VERSION=${VERSION-'0.0.0'}
+OUTPUT=${OUTPUT-'./artifacts/'}
+cd "$(dirname "$0")"
 # uninstall the old version if it exists...
 dotnet new -u Beamable.Templates
 
@@ -12,10 +15,9 @@ cp -R ./BeamStorage/ ./templates/Data/BeamStorage
 
 # produce a nuget package...
 # dotnet pack ./templates/templates.csproj -o ./artifacts/ --no-build --version-suffix=${SUFFIX-""} /p:VersionPrefix=$VERSION_PREFIX
-dotnet pack ./templates/templates.csproj -o ./artifacts/ /p:VersionPrefix=0.0.0
-
+dotnet pack ./templates/templates.csproj -o ${OUTPUT} -p:PackageVersion=$VERSION
 # clean the folder again...
 rm -rf ./templates/Data
 
 # install the latest version...
-dotnet new -i ./artifacts/Beamable.Templates.0.0.0.nupkg
+dotnet new -i ${OUTPUT}Beamable.Templates.${VERSION}.nupkg


### PR DESCRIPTION
a few things-

the `beam project version --requested-version` command wasn't doing what it should have been. It was loosing the `.sln` file path, and then silently failing. I believe I fixed it, and I was able to verify by creating a SAM, and then changing its nuget versions by doing `beam project version --requested-version 1.19.14`. 

Also, I removed the `_projectVersion` field and replaced it with a derived method that uses the SDK version number to come up with a nuget version number. For now, they are usually the same, except if we are developing, then we expect to use 0.0.123, which is our local nuget package, created via `set-packages.sh`. 

I made sure to have the local templates get installed through running `set-packages.sh` as well.