### PR TITLE
fixes 3175 - adds discovery status messaging to ps

### DIFF
--- a/cli/cli/Commands/Project/CheckStatusCommand.cs
+++ b/cli/cli/Commands/Project/CheckStatusCommand.cs
@@ -21,6 +21,7 @@ public class ServiceDiscoveryEvent
 	public bool isContainer;
 	public int healthPort;
 	public string containerId;
+	public string status;
 }
 
 public class CheckStatusCommand : StreamCommand<CheckStatusCommandArgs, ServiceDiscoveryEvent>
@@ -59,7 +60,26 @@ public class CheckStatusCommand : StreamCommand<CheckStatusCommandArgs, ServiceD
 			}
 			else
 			{
-				Log.Information($"{evt.service} is available prefix=[{evt.prefix}] docker=[{evt.isContainer}]");
+				if (DiscoveryStatusUtil.TryGetStatusFromString(evt.status, out var status))
+				{
+					switch (status)
+					{
+						case DiscoveryStatus.Starting:
+							Log.Information($"{evt.service} is starting at prefix=[{evt.prefix}] docker=[{evt.isContainer}]");
+							break;
+						case DiscoveryStatus.Stopping:
+							Log.Information($"{evt.service} is stopping at prefix=[{evt.prefix}] docker=[{evt.isContainer}]");
+							break;
+						case DiscoveryStatus.AcceptingTraffic:
+							Log.Information($"{evt.service} is accepting traffic at prefix=[{evt.prefix}] docker=[{evt.isContainer}]");
+							break;
+					}
+				}
+				else
+				{
+					Log.Information($"{evt.service} is broadcasing at prefix=[{evt.prefix}] docker=[{evt.isContainer}]");
+				}
+				
 			}
 			SendResults(evt);
 		}

--- a/cli/cli/Services/DiscoveryService.cs
+++ b/cli/cli/Services/DiscoveryService.cs
@@ -123,8 +123,14 @@ public class DiscoveryService
 				continue;
 			}
 
-			if (!nameToEntryWithTimestamp.ContainsKey(service.serviceName))
+			if (!nameToEntryWithTimestamp.TryGetValue(service.serviceName, out var existing))
 			{
+				// if it doesn't exist, enter it.
+				evtQueue.Enqueue(CreateEvent(service, true));
+
+			} else if (existing.Item2.status != service.status)
+			{
+				// or if the status has changed.
 				evtQueue.Enqueue(CreateEvent(service, true));
 			}
 
@@ -152,7 +158,8 @@ public class DiscoveryService
 			isRunning = isRunning,
 			isContainer = entry.isContainer,
 			containerId = entry.containerId,
-			healthPort = entry.healthPort
+			healthPort = entry.healthPort,
+			status = entry.status.GetDisplayString()
 		};
 	}
 

--- a/client/Packages/com.beamable.server/SharedRuntime/ServiceDiscoveryEntry.cs
+++ b/client/Packages/com.beamable.server/SharedRuntime/ServiceDiscoveryEntry.cs
@@ -12,5 +12,45 @@ namespace Beamable.Server
 		public int healthPort;
 		public bool isContainer;
 		public string containerId;
+		public DiscoveryStatus status;
+	}
+	
+	public enum DiscoveryStatus
+	{
+		Starting,
+		AcceptingTraffic,
+		Stopping
+	}
+
+	public static class DiscoveryStatusUtil
+	{
+		public static string GetDisplayString(this DiscoveryStatus status)
+		{
+			switch (status)
+			{
+				case DiscoveryStatus.Starting: return "starting";
+				case DiscoveryStatus.Stopping: return "stopping";
+				case DiscoveryStatus.AcceptingTraffic: return "accepting-traffic";
+				default: throw new ArgumentException();
+			}
+		}
+		public static bool TryGetStatusFromString(string statusString, out DiscoveryStatus status)
+		{
+			switch (statusString)
+			{
+				case "starting": 
+					status = DiscoveryStatus.Starting;
+					return true;
+				case "stopping": 
+					status = DiscoveryStatus.Stopping;
+					return true;
+				case "accepting-traffic": 
+					status = DiscoveryStatus.AcceptingTraffic;
+					return true;
+				default:
+					status = DiscoveryStatus.Starting;
+					return false;
+			}
+		}
 	}
 }

--- a/microservice/microservice/dbmicroservice/BeamableMicroService.cs
+++ b/microservice/microservice/dbmicroservice/BeamableMicroService.cs
@@ -28,6 +28,7 @@ using Beamable.Common.Api.Realms;
 using Beamable.Common.Reflection;
 using Beamable.Server.Api.Usage;
 using microservice.Common;
+using microservice.dbmicroservice;
 using Newtonsoft.Json;
 using Serilog;
 using Microsoft.Extensions.DependencyInjection;
@@ -195,6 +196,8 @@ namespace Beamable.Server
          }
 
          await SetupWebsocket(socket, _serviceAttribute.EnableEagerContentLoading);
+         
+         Provider.GetService<IDiscoveryService>().SetStatus(DiscoveryStatus.AcceptingTraffic);
          if (!_serviceAttribute.EnableEagerContentLoading)
          {
 	         var _ = contentService.Init();
@@ -228,6 +231,7 @@ namespace Beamable.Server
 
          // need to wait for all tasks to complete...
          Log.Debug("Shutdown started... {runningTaskCount} tasks running.", _runningTaskTable.Count);
+         Provider.GetService<IDiscoveryService>().SetStatus(DiscoveryStatus.Stopping);
 
          var sw = new System.Diagnostics.Stopwatch();
          sw.Start();

--- a/microservice/microservice/dbmicroservice/DiscoveryService.cs
+++ b/microservice/microservice/dbmicroservice/DiscoveryService.cs
@@ -1,0 +1,68 @@
+using Beamable.Common;
+using Beamable.Common.Dependencies;
+using Beamable.Server;
+using Beamable.Server.Common;
+using NetMQ;
+using Newtonsoft.Json;
+using Serilog;
+using System;
+
+namespace microservice.dbmicroservice;
+
+public interface IDiscoveryService
+{
+	void SetStatus(DiscoveryStatus status);
+}
+
+public class NoDiscoveryService : IDiscoveryService
+{
+	public void SetStatus(DiscoveryStatus _)
+	{
+		// no-op
+	}
+}
+
+public static class DiscoveryExtensions
+{
+	public static IDiscoveryService GetDiscoveryService(this IDependencyProvider provider)
+	{
+		return provider.GetService<IDiscoveryService>();
+	}
+}
+
+
+public class DiscoveryService : IDiscoveryService
+{
+	private readonly NetMQBeacon _beacon;
+	private readonly int _port;
+	private readonly ServiceDiscoveryEntry _heartBeatMsg;
+
+	public DiscoveryService(IMicroserviceArgs args, MicroserviceAttribute attribute)
+	{
+		_beacon = new NetMQBeacon();
+		_port = Constants.Features.Services.DISCOVERY_PORT;
+		_beacon.Configure(_port);
+		_heartBeatMsg = new ServiceDiscoveryEntry
+		{
+			cid = args.CustomerID,
+			pid = args.ProjectName,
+			prefix = args.NamePrefix,
+			serviceName = attribute.MicroserviceName,
+			healthPort = args.HealthPort,
+			status = DiscoveryStatus.Starting
+		};
+	}
+
+
+	public void SetStatus(DiscoveryStatus status)
+	{
+		_heartBeatMsg.status = status;
+		_beacon.Silence();
+		
+		var json = HeartBeatMessageJson;
+		Log.Verbose("setting discovery json : " + json);
+		_beacon.Publish(json, TimeSpan.FromMilliseconds(Constants.Features.Services.DISCOVERY_BROADCAST_PERIOD_MS));
+	}
+
+	string HeartBeatMessageJson => JsonConvert.SerializeObject(_heartBeatMsg, UnitySerializationSettings.Instance);
+}


### PR DESCRIPTION
still in progress, but now when you do a `beam project ps -w`, you'll see messages for a service either starting, accepting-traffic, or stopping. 