### PR TITLE
[Issue/3178] List non beamo references of services and add those to Unity sln

### DIFF
--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/LibrariesPaths.cs
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/LibrariesPaths.cs
@@ -1,0 +1,12 @@
+using Beamable.Editor.BeamCli.Commands;
+using System;
+using System.Collections.Generic;
+
+namespace Beamable.Server.Editor.Usam
+{
+	[Serializable]
+	public class LibrariesPaths
+	{
+		public List<BeamDependencyData> libraries;
+	}
+}

--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/LibrariesPaths.cs.meta
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/LibrariesPaths.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8843d6d7a1b8410f8ce53d07bddb78df
+timeCreated: 1711485933

--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/SolutionPostProcessor.cs
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/SolutionPostProcessor.cs
@@ -54,6 +54,12 @@ EndProject";
 				content = InjectProject(content, signpost.name, signpost.CsprojFilePath);
 			}
 
+			var librariesPaths = CodeService.GetLibrariesPaths();
+			foreach (var lib in librariesPaths.libraries)
+			{
+				content = InjectProject(content, lib.name, lib.projPath);
+			}
+
 			foreach (var reference in AssemblyUtil.ReferencedAssemblies)
 			{
 				var referenceName = reference.name;

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/Beam.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/Beam.cs
@@ -1,148 +1,148 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class BeamArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Should any networking happen?</summary>
-		public bool dryrun;
-		/// <summary>Cid to use; will default to whatever is in the file system</summary>
-		public string cid;
-		/// <summary>Pid to use; will default to whatever is in the file system</summary>
-		public string pid;
-		/// <summary>When true, skip input waiting and use defaults</summary>
-		public bool quiet;
-		/// <summary>The host endpoint for beamable</summary>
-		public string host;
-		/// <summary>Refresh token to use for the requests</summary>
-		public string refreshToken;
-		/// <summary>Extra logs gets printed out</summary>
-		public string log;
-		/// <summary>Directory to use for configuration</summary>
-		public string dir;
-		/// <summary>Output raw JSON to standard out. This happens by default when the command is being piped</summary>
-		public bool raw;
-		/// <summary>Output syntax highlighted box text. This happens by default when the command is not piped</summary>
-		public bool pretty;
-		/// <summary>skips the check for commands that require beam config directories.</summary>
-		public bool skipStandaloneValidation;
-		/// <summary>a custom location for dotnet</summary>
-		public string dotnetPath;
-		/// <summary>Show version information</summary>
-		public bool version;
-		/// <summary>Show help and usage information</summary>
-		public bool help;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the dryrun value was not default, then add it to the list of args.
-			if ((this.dryrun != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--dryrun=" + this.dryrun));
-			}
-			// If the cid value was not default, then add it to the list of args.
-			if ((this.cid != default(string)))
-			{
-				genBeamCommandArgs.Add((("--cid=\"" + this.cid)
-								+ "\""));
-			}
-			// If the pid value was not default, then add it to the list of args.
-			if ((this.pid != default(string)))
-			{
-				genBeamCommandArgs.Add((("--pid=\"" + this.pid)
-								+ "\""));
-			}
-			// If the quiet value was not default, then add it to the list of args.
-			if ((this.quiet != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--quiet=" + this.quiet));
-			}
-			// If the host value was not default, then add it to the list of args.
-			if ((this.host != default(string)))
-			{
-				genBeamCommandArgs.Add((("--host=\"" + this.host)
-								+ "\""));
-			}
-			// If the refreshToken value was not default, then add it to the list of args.
-			if ((this.refreshToken != default(string)))
-			{
-				genBeamCommandArgs.Add((("--refresh-token=\"" + this.refreshToken)
-								+ "\""));
-			}
-			// If the log value was not default, then add it to the list of args.
-			if ((this.log != default(string)))
-			{
-				genBeamCommandArgs.Add((("--log=\"" + this.log)
-								+ "\""));
-			}
-			// If the dir value was not default, then add it to the list of args.
-			if ((this.dir != default(string)))
-			{
-				genBeamCommandArgs.Add((("--dir=\"" + this.dir)
-								+ "\""));
-			}
-			// If the raw value was not default, then add it to the list of args.
-			if ((this.raw != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--raw=" + this.raw));
-			}
-			// If the pretty value was not default, then add it to the list of args.
-			if ((this.pretty != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--pretty=" + this.pretty));
-			}
-			// If the skipStandaloneValidation value was not default, then add it to the list of args.
-			if ((this.skipStandaloneValidation != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--skip-standalone-validation=" + this.skipStandaloneValidation));
-			}
-			// If the dotnetPath value was not default, then add it to the list of args.
-			if ((this.dotnetPath != default(string)))
-			{
-				genBeamCommandArgs.Add((("--dotnet-path=\"" + this.dotnetPath)
-								+ "\""));
-			}
-			// If the version value was not default, then add it to the list of args.
-			if ((this.version != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--version=" + this.version));
-			}
-			// If the help value was not default, then add it to the list of args.
-			if ((this.help != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--help=" + this.help));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual BeamWrapper Beam()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			BeamWrapper genBeamCommandWrapper = new BeamWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class BeamWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class BeamArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Should any networking happen?</summary>
+        public bool dryrun;
+        /// <summary>Cid to use; will default to whatever is in the file system</summary>
+        public string cid;
+        /// <summary>Pid to use; will default to whatever is in the file system</summary>
+        public string pid;
+        /// <summary>When true, skip input waiting and use defaults</summary>
+        public bool quiet;
+        /// <summary>The host endpoint for beamable</summary>
+        public string host;
+        /// <summary>Refresh token to use for the requests</summary>
+        public string refreshToken;
+        /// <summary>Extra logs gets printed out</summary>
+        public string log;
+        /// <summary>Directory to use for configuration</summary>
+        public string dir;
+        /// <summary>Output raw JSON to standard out. This happens by default when the command is being piped</summary>
+        public bool raw;
+        /// <summary>Output syntax highlighted box text. This happens by default when the command is not piped</summary>
+        public bool pretty;
+        /// <summary>skips the check for commands that require beam config directories.</summary>
+        public bool skipStandaloneValidation;
+        /// <summary>a custom location for dotnet</summary>
+        public string dotnetPath;
+        /// <summary>Show version information</summary>
+        public bool version;
+        /// <summary>Show help and usage information</summary>
+        public bool help;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the dryrun value was not default, then add it to the list of args.
+            if ((this.dryrun != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--dryrun=" + this.dryrun));
+            }
+            // If the cid value was not default, then add it to the list of args.
+            if ((this.cid != default(string)))
+            {
+                genBeamCommandArgs.Add((("--cid=\"" + this.cid) 
+                                + "\""));
+            }
+            // If the pid value was not default, then add it to the list of args.
+            if ((this.pid != default(string)))
+            {
+                genBeamCommandArgs.Add((("--pid=\"" + this.pid) 
+                                + "\""));
+            }
+            // If the quiet value was not default, then add it to the list of args.
+            if ((this.quiet != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--quiet=" + this.quiet));
+            }
+            // If the host value was not default, then add it to the list of args.
+            if ((this.host != default(string)))
+            {
+                genBeamCommandArgs.Add((("--host=\"" + this.host) 
+                                + "\""));
+            }
+            // If the refreshToken value was not default, then add it to the list of args.
+            if ((this.refreshToken != default(string)))
+            {
+                genBeamCommandArgs.Add((("--refresh-token=\"" + this.refreshToken) 
+                                + "\""));
+            }
+            // If the log value was not default, then add it to the list of args.
+            if ((this.log != default(string)))
+            {
+                genBeamCommandArgs.Add((("--log=\"" + this.log) 
+                                + "\""));
+            }
+            // If the dir value was not default, then add it to the list of args.
+            if ((this.dir != default(string)))
+            {
+                genBeamCommandArgs.Add((("--dir=\"" + this.dir) 
+                                + "\""));
+            }
+            // If the raw value was not default, then add it to the list of args.
+            if ((this.raw != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--raw=" + this.raw));
+            }
+            // If the pretty value was not default, then add it to the list of args.
+            if ((this.pretty != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--pretty=" + this.pretty));
+            }
+            // If the skipStandaloneValidation value was not default, then add it to the list of args.
+            if ((this.skipStandaloneValidation != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--skip-standalone-validation=" + this.skipStandaloneValidation));
+            }
+            // If the dotnetPath value was not default, then add it to the list of args.
+            if ((this.dotnetPath != default(string)))
+            {
+                genBeamCommandArgs.Add((("--dotnet-path=\"" + this.dotnetPath) 
+                                + "\""));
+            }
+            // If the version value was not default, then add it to the list of args.
+            if ((this.version != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--version=" + this.version));
+            }
+            // If the help value was not default, then add it to the list of args.
+            if ((this.help != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--help=" + this.help));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual BeamWrapper Beam()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            BeamWrapper genBeamCommandWrapper = new BeamWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class BeamWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamAccountMeCommandOutput.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamAccountMeCommandOutput.cs
@@ -1,18 +1,18 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamAccountMeCommandOutput
-	{
-		public long id;
-		public string email;
-		public string language;
-		public System.Collections.Generic.List<string> scopes;
-		public System.Collections.Generic.List<string> thirdPartyAppAssociations;
-		public System.Collections.Generic.List<string> deviceIds;
-		public System.Collections.Generic.List<BeamAccountMeExternalIdentity> external;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamAccountMeCommandOutput
+    {
+        public long id;
+        public string email;
+        public string language;
+        public System.Collections.Generic.List<string> scopes;
+        public System.Collections.Generic.List<string> thirdPartyAppAssociations;
+        public System.Collections.Generic.List<string> deviceIds;
+        public System.Collections.Generic.List<BeamAccountMeExternalIdentity> external;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamAccountMeExternalIdentity.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamAccountMeExternalIdentity.cs
@@ -1,14 +1,14 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamAccountMeExternalIdentity
-	{
-		public string providerNamespace;
-		public string providerService;
-		public string userId;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamAccountMeExternalIdentity
+    {
+        public string providerNamespace;
+        public string providerService;
+        public string userId;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamBuildProjectCommandOutput.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamBuildProjectCommandOutput.cs
@@ -1,13 +1,13 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamBuildProjectCommandOutput
-	{
-		public string service;
-		public BeamProjectErrorReport report;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamBuildProjectCommandOutput
+    {
+        public string service;
+        public BeamProjectErrorReport report;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCheckPerfCommandOutput.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCheckPerfCommandOutput.cs
@@ -1,12 +1,12 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamCheckPerfCommandOutput
-	{
-		public string message;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamCheckPerfCommandOutput
+    {
+        public string message;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceComponent.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceComponent.cs
@@ -1,12 +1,12 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamCliServiceComponent
-	{
-		public string name;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamCliServiceComponent
+    {
+        public string name;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceDependency.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceDependency.cs
@@ -1,13 +1,13 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamCliServiceDependency
-	{
-		public string storageType;
-		public string id;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamCliServiceDependency
+    {
+        public string storageType;
+        public string id;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceManifest.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceManifest.cs
@@ -1,17 +1,17 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamCliServiceManifest
-	{
-		public string id;
-		public long created;
-		public System.Collections.Generic.List<BeamCliServiceReference> manifest;
-		public System.Collections.Generic.List<BeamCliServiceStorageReference> storageReference;
-		public long createdByAccountId;
-		public string comments;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamCliServiceManifest
+    {
+        public string id;
+        public long created;
+        public System.Collections.Generic.List<BeamCliServiceReference> manifest;
+        public System.Collections.Generic.List<BeamCliServiceStorageReference> storageReference;
+        public long createdByAccountId;
+        public string comments;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceReference.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceReference.cs
@@ -1,20 +1,20 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamCliServiceReference
-	{
-		public string serviceName;
-		public string checksum;
-		public bool enabled;
-		public string imageId;
-		public string templateId;
-		public string comments;
-		public System.Collections.Generic.List<BeamCliServiceDependency> dependencies;
-		public long containerHealthCheckPort;
-		public System.Collections.Generic.List<BeamCliServiceComponent> components;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamCliServiceReference
+    {
+        public string serviceName;
+        public string checksum;
+        public bool enabled;
+        public string imageId;
+        public string templateId;
+        public string comments;
+        public System.Collections.Generic.List<BeamCliServiceDependency> dependencies;
+        public long containerHealthCheckPort;
+        public System.Collections.Generic.List<BeamCliServiceComponent> components;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceStorageReference.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceStorageReference.cs
@@ -1,16 +1,16 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamCliServiceStorageReference
-	{
-		public string id;
-		public string storageType;
-		public bool enabled;
-		public string templateId;
-		public string checksum;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamCliServiceStorageReference
+    {
+        public string id;
+        public string storageType;
+        public bool enabled;
+        public string templateId;
+        public string checksum;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfig.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfig.cs
@@ -1,49 +1,49 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ConfigArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ConfigWrapper Config()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("config");
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ConfigWrapper genBeamCommandWrapper = new ConfigWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ConfigWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ConfigWrapper OnStreamConfigCommandResult(System.Action<ReportDataPoint<BeamConfigCommandResult>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ConfigArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ConfigWrapper Config()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("config");
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ConfigWrapper genBeamCommandWrapper = new ConfigWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ConfigWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ConfigWrapper OnStreamConfigCommandResult(System.Action<ReportDataPoint<BeamConfigCommandResult>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfigCommandResult.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfigCommandResult.cs
@@ -1,15 +1,15 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamConfigCommandResult
-	{
-		public string host;
-		public string cid;
-		public string pid;
-		public string configPath;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamConfigCommandResult
+    {
+        public string host;
+        public string cid;
+        public string pid;
+        public string configPath;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfigRealm.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfigRealm.cs
@@ -1,62 +1,62 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ConfigRealmArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>A list of realm config namespaces to filter</summary>
-		public string[] namespaces;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the namespaces value was not default, then add it to the list of args.
-			if ((this.namespaces != default(string[])))
-			{
-				for (int i = 0; (i < this.namespaces.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--namespaces=" + this.namespaces[i]));
-				}
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ConfigRealmWrapper ConfigRealm(ConfigRealmArgs realmArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("config");
-			genBeamCommandArgs.Add("realm");
-			genBeamCommandArgs.Add(realmArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ConfigRealmWrapper genBeamCommandWrapper = new ConfigRealmWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ConfigRealmWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ConfigRealmWrapper OnStreamRealmConfigOutput(System.Action<ReportDataPoint<BeamRealmConfigOutput>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ConfigRealmArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>A list of realm config namespaces to filter</summary>
+        public string[] namespaces;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the namespaces value was not default, then add it to the list of args.
+            if ((this.namespaces != default(string[])))
+            {
+                for (int i = 0; (i < this.namespaces.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--namespaces=" + this.namespaces[i]));
+                }
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ConfigRealmWrapper ConfigRealm(ConfigRealmArgs realmArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("config");
+            genBeamCommandArgs.Add("realm");
+            genBeamCommandArgs.Add(realmArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ConfigRealmWrapper genBeamCommandWrapper = new ConfigRealmWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ConfigRealmWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ConfigRealmWrapper OnStreamRealmConfigOutput(System.Action<ReportDataPoint<BeamRealmConfigOutput>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfigRealmRemove.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfigRealmRemove.cs
@@ -1,64 +1,64 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ConfigRealmRemoveArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>A list of realm config keys in a namespace|key format</summary>
-		public string[] keys;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the keys value was not default, then add it to the list of args.
-			if ((this.keys != default(string[])))
-			{
-				for (int i = 0; (i < this.keys.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--keys=" + this.keys[i]));
-				}
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ConfigRealmRemoveWrapper ConfigRealmRemove(ConfigRealmArgs realmArgs, ConfigRealmRemoveArgs removeArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("config");
-			genBeamCommandArgs.Add("realm");
-			genBeamCommandArgs.Add(realmArgs.Serialize());
-			genBeamCommandArgs.Add("remove");
-			genBeamCommandArgs.Add(removeArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ConfigRealmRemoveWrapper genBeamCommandWrapper = new ConfigRealmRemoveWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ConfigRealmRemoveWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ConfigRealmRemoveWrapper OnStreamRealmConfigOutput(System.Action<ReportDataPoint<BeamRealmConfigOutput>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ConfigRealmRemoveArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>A list of realm config keys in a namespace|key format</summary>
+        public string[] keys;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the keys value was not default, then add it to the list of args.
+            if ((this.keys != default(string[])))
+            {
+                for (int i = 0; (i < this.keys.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--keys=" + this.keys[i]));
+                }
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ConfigRealmRemoveWrapper ConfigRealmRemove(ConfigRealmArgs realmArgs, ConfigRealmRemoveArgs removeArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("config");
+            genBeamCommandArgs.Add("realm");
+            genBeamCommandArgs.Add(realmArgs.Serialize());
+            genBeamCommandArgs.Add("remove");
+            genBeamCommandArgs.Add(removeArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ConfigRealmRemoveWrapper genBeamCommandWrapper = new ConfigRealmRemoveWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ConfigRealmRemoveWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ConfigRealmRemoveWrapper OnStreamRealmConfigOutput(System.Action<ReportDataPoint<BeamRealmConfigOutput>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfigRealmSet.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfigRealmSet.cs
@@ -1,64 +1,64 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ConfigRealmSetArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>A list of realm config key/value pairs in a 'namespace|key::value' format</summary>
-		public string[] keyValues;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the keyValues value was not default, then add it to the list of args.
-			if ((this.keyValues != default(string[])))
-			{
-				for (int i = 0; (i < this.keyValues.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--key-values=" + this.keyValues[i]));
-				}
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ConfigRealmSetWrapper ConfigRealmSet(ConfigRealmArgs realmArgs, ConfigRealmSetArgs setArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("config");
-			genBeamCommandArgs.Add("realm");
-			genBeamCommandArgs.Add(realmArgs.Serialize());
-			genBeamCommandArgs.Add("set");
-			genBeamCommandArgs.Add(setArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ConfigRealmSetWrapper genBeamCommandWrapper = new ConfigRealmSetWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ConfigRealmSetWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ConfigRealmSetWrapper OnStreamRealmConfigOutput(System.Action<ReportDataPoint<BeamRealmConfigOutput>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ConfigRealmSetArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>A list of realm config key/value pairs in a 'namespace|key::value' format</summary>
+        public string[] keyValues;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the keyValues value was not default, then add it to the list of args.
+            if ((this.keyValues != default(string[])))
+            {
+                for (int i = 0; (i < this.keyValues.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--key-values=" + this.keyValues[i]));
+                }
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ConfigRealmSetWrapper ConfigRealmSet(ConfigRealmArgs realmArgs, ConfigRealmSetArgs setArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("config");
+            genBeamCommandArgs.Add("realm");
+            genBeamCommandArgs.Add(realmArgs.Serialize());
+            genBeamCommandArgs.Add("set");
+            genBeamCommandArgs.Add(setArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ConfigRealmSetWrapper genBeamCommandWrapper = new ConfigRealmSetWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ConfigRealmSetWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ConfigRealmSetWrapper OnStreamRealmConfigOutput(System.Action<ReportDataPoint<BeamRealmConfigOutput>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConstructVersionOutput.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConstructVersionOutput.cs
@@ -1,15 +1,15 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamConstructVersionOutput
-	{
-		public string versionString;
-		public string versionPrefix;
-		public string versionSuffix;
-		public bool exists;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamConstructVersionOutput
+    {
+        public string versionString;
+        public string versionPrefix;
+        public string versionSuffix;
+        public bool exists;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamDependencyData.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamDependencyData.cs
@@ -1,15 +1,15 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamDependencyData
-	{
-		public string name;
-		public string projPath;
-		public string dllName;
-		public string type;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamDependencyData
+    {
+        public string name;
+        public string projPath;
+        public string dllName;
+        public string type;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamGenerateOApiCommandOutput.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamGenerateOApiCommandOutput.cs
@@ -1,14 +1,14 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamGenerateOApiCommandOutput
-	{
-		public string service;
-		public bool isBuilt;
-		public string openApi;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamGenerateOApiCommandOutput
+    {
+        public string service;
+        public bool isBuilt;
+        public string openApi;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamGetLogsUrlHeader.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamGetLogsUrlHeader.cs
@@ -1,13 +1,13 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamGetLogsUrlHeader
-	{
-		public string key;
-		public string value;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamGetLogsUrlHeader
+    {
+        public string key;
+        public string value;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamGetSignedUrlResponse.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamGetSignedUrlResponse.cs
@@ -1,15 +1,15 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamGetSignedUrlResponse
-	{
-		public System.Collections.Generic.List<BeamGetLogsUrlHeader> headers;
-		public string url;
-		public string body;
-		public string method;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamGetSignedUrlResponse
+    {
+        public System.Collections.Generic.List<BeamGetLogsUrlHeader> headers;
+        public string url;
+        public string body;
+        public string method;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamInit.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamInit.cs
@@ -1,126 +1,126 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class InitArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Specify user name</summary>
-		public string username;
-		/// <summary>User password</summary>
-		public string password;
-		/// <summary>The host endpoint for beamable</summary>
-		public string host;
-		/// <summary>Cid to use; will default to whatever is in the file system</summary>
-		public string cid;
-		/// <summary>Pid to use; will default to whatever is in the file system</summary>
-		public string pid;
-		/// <summary>Refresh token to use for the requests</summary>
-		public string refreshToken;
-		/// <summary>Save login refresh token to environment variable</summary>
-		public bool saveToEnvironment;
-		/// <summary>Save login refresh token to file</summary>
-		public bool saveToFile;
-		/// <summary>Make request customer scoped instead of product only</summary>
-		public bool customerScoped;
-		/// <summary>Prints out login request response to console</summary>
-		public bool printToConsole;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the username value was not default, then add it to the list of args.
-			if ((this.username != default(string)))
-			{
-				genBeamCommandArgs.Add((("--username=\"" + this.username)
-								+ "\""));
-			}
-			// If the password value was not default, then add it to the list of args.
-			if ((this.password != default(string)))
-			{
-				genBeamCommandArgs.Add((("--password=\"" + this.password)
-								+ "\""));
-			}
-			// If the host value was not default, then add it to the list of args.
-			if ((this.host != default(string)))
-			{
-				genBeamCommandArgs.Add((("--host=\"" + this.host)
-								+ "\""));
-			}
-			// If the cid value was not default, then add it to the list of args.
-			if ((this.cid != default(string)))
-			{
-				genBeamCommandArgs.Add((("--cid=\"" + this.cid)
-								+ "\""));
-			}
-			// If the pid value was not default, then add it to the list of args.
-			if ((this.pid != default(string)))
-			{
-				genBeamCommandArgs.Add((("--pid=\"" + this.pid)
-								+ "\""));
-			}
-			// If the refreshToken value was not default, then add it to the list of args.
-			if ((this.refreshToken != default(string)))
-			{
-				genBeamCommandArgs.Add((("--refresh-token=\"" + this.refreshToken)
-								+ "\""));
-			}
-			// If the saveToEnvironment value was not default, then add it to the list of args.
-			if ((this.saveToEnvironment != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--save-to-environment=" + this.saveToEnvironment));
-			}
-			// If the saveToFile value was not default, then add it to the list of args.
-			if ((this.saveToFile != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--save-to-file=" + this.saveToFile));
-			}
-			// If the customerScoped value was not default, then add it to the list of args.
-			if ((this.customerScoped != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--customer-scoped=" + this.customerScoped));
-			}
-			// If the printToConsole value was not default, then add it to the list of args.
-			if ((this.printToConsole != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--print-to-console=" + this.printToConsole));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual InitWrapper Init(InitArgs initArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("init");
-			genBeamCommandArgs.Add(initArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			InitWrapper genBeamCommandWrapper = new InitWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class InitWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual InitWrapper OnStreamInitCommandResult(System.Action<ReportDataPoint<BeamInitCommandResult>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class InitArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Specify user name</summary>
+        public string username;
+        /// <summary>User password</summary>
+        public string password;
+        /// <summary>The host endpoint for beamable</summary>
+        public string host;
+        /// <summary>Cid to use; will default to whatever is in the file system</summary>
+        public string cid;
+        /// <summary>Pid to use; will default to whatever is in the file system</summary>
+        public string pid;
+        /// <summary>Refresh token to use for the requests</summary>
+        public string refreshToken;
+        /// <summary>Save login refresh token to environment variable</summary>
+        public bool saveToEnvironment;
+        /// <summary>Save login refresh token to file</summary>
+        public bool saveToFile;
+        /// <summary>Make request customer scoped instead of product only</summary>
+        public bool customerScoped;
+        /// <summary>Prints out login request response to console</summary>
+        public bool printToConsole;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the username value was not default, then add it to the list of args.
+            if ((this.username != default(string)))
+            {
+                genBeamCommandArgs.Add((("--username=\"" + this.username) 
+                                + "\""));
+            }
+            // If the password value was not default, then add it to the list of args.
+            if ((this.password != default(string)))
+            {
+                genBeamCommandArgs.Add((("--password=\"" + this.password) 
+                                + "\""));
+            }
+            // If the host value was not default, then add it to the list of args.
+            if ((this.host != default(string)))
+            {
+                genBeamCommandArgs.Add((("--host=\"" + this.host) 
+                                + "\""));
+            }
+            // If the cid value was not default, then add it to the list of args.
+            if ((this.cid != default(string)))
+            {
+                genBeamCommandArgs.Add((("--cid=\"" + this.cid) 
+                                + "\""));
+            }
+            // If the pid value was not default, then add it to the list of args.
+            if ((this.pid != default(string)))
+            {
+                genBeamCommandArgs.Add((("--pid=\"" + this.pid) 
+                                + "\""));
+            }
+            // If the refreshToken value was not default, then add it to the list of args.
+            if ((this.refreshToken != default(string)))
+            {
+                genBeamCommandArgs.Add((("--refresh-token=\"" + this.refreshToken) 
+                                + "\""));
+            }
+            // If the saveToEnvironment value was not default, then add it to the list of args.
+            if ((this.saveToEnvironment != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--save-to-environment=" + this.saveToEnvironment));
+            }
+            // If the saveToFile value was not default, then add it to the list of args.
+            if ((this.saveToFile != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--save-to-file=" + this.saveToFile));
+            }
+            // If the customerScoped value was not default, then add it to the list of args.
+            if ((this.customerScoped != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--customer-scoped=" + this.customerScoped));
+            }
+            // If the printToConsole value was not default, then add it to the list of args.
+            if ((this.printToConsole != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--print-to-console=" + this.printToConsole));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual InitWrapper Init(InitArgs initArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("init");
+            genBeamCommandArgs.Add(initArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            InitWrapper genBeamCommandWrapper = new InitWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class InitWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual InitWrapper OnStreamInitCommandResult(System.Action<ReportDataPoint<BeamInitCommandResult>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamInitCommandResult.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamInitCommandResult.cs
@@ -1,14 +1,14 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamInitCommandResult
-	{
-		public string host;
-		public string cid;
-		public string pid;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamInitCommandResult
+    {
+        public string host;
+        public string cid;
+        public string pid;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListCommandResult.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListCommandResult.cs
@@ -1,13 +1,13 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamListCommandResult
-	{
-		public System.Collections.Generic.List<Beamable.Common.BeamCli.Contracts.ServiceInfo> localServices;
-		public System.Collections.Generic.List<Beamable.Common.BeamCli.Contracts.ServiceInfo> localStorages;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamListCommandResult
+    {
+        public System.Collections.Generic.List<Beamable.Common.BeamCli.Contracts.ServiceInfo> localServices;
+        public System.Collections.Generic.List<Beamable.Common.BeamCli.Contracts.ServiceInfo> localStorages;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListDepsCommandResults.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListDepsCommandResults.cs
@@ -1,12 +1,12 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamListDepsCommandResults
-	{
-		public System.Collections.Generic.List<BeamServiceDependenciesPair> Services;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamListDepsCommandResults
+    {
+        public System.Collections.Generic.List<BeamServiceDependenciesPair> Services;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListenPlayer.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListenPlayer.cs
@@ -1,59 +1,59 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ListenPlayerArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>A regex to filter for notification channels</summary>
-		public string context;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the context value was not default, then add it to the list of args.
-			if ((this.context != default(string)))
-			{
-				genBeamCommandArgs.Add((("--context=\"" + this.context)
-								+ "\""));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ListenPlayerWrapper ListenPlayer(ListenPlayerArgs playerArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("listen");
-			genBeamCommandArgs.Add("player");
-			genBeamCommandArgs.Add(playerArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ListenPlayerWrapper genBeamCommandWrapper = new ListenPlayerWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ListenPlayerWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ListenPlayerWrapper OnStreamNotificationPlayerOutput(System.Action<ReportDataPoint<BeamNotificationPlayerOutput>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ListenPlayerArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>A regex to filter for notification channels</summary>
+        public string context;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the context value was not default, then add it to the list of args.
+            if ((this.context != default(string)))
+            {
+                genBeamCommandArgs.Add((("--context=\"" + this.context) 
+                                + "\""));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ListenPlayerWrapper ListenPlayer(ListenPlayerArgs playerArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("listen");
+            genBeamCommandArgs.Add("player");
+            genBeamCommandArgs.Add(playerArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ListenPlayerWrapper genBeamCommandWrapper = new ListenPlayerWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ListenPlayerWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ListenPlayerWrapper OnStreamNotificationPlayerOutput(System.Action<ReportDataPoint<BeamNotificationPlayerOutput>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListenServer.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListenServer.cs
@@ -1,50 +1,50 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ListenServerArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ListenServerWrapper ListenServer()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("listen");
-			genBeamCommandArgs.Add("server");
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ListenServerWrapper genBeamCommandWrapper = new ListenServerWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ListenServerWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ListenServerWrapper OnStreamNotificationServerOutput(System.Action<ReportDataPoint<BeamNotificationServerOutput>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ListenServerArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ListenServerWrapper ListenServer()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("listen");
+            genBeamCommandArgs.Add("server");
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ListenServerWrapper genBeamCommandWrapper = new ListenServerWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ListenServerWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ListenServerWrapper OnStreamNotificationServerOutput(System.Action<ReportDataPoint<BeamNotificationServerOutput>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamManifestChecksum.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamManifestChecksum.cs
@@ -1,14 +1,14 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamManifestChecksum
-	{
-		public string id;
-		public string checksum;
-		public long createdAt;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamManifestChecksum
+    {
+        public string id;
+        public string checksum;
+        public long createdAt;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamManifestChecksums.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamManifestChecksums.cs
@@ -1,12 +1,12 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamManifestChecksums
-	{
-		public System.Collections.Generic.List<BeamManifestChecksum> manifests;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamManifestChecksums
+    {
+        public System.Collections.Generic.List<BeamManifestChecksum> manifests;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamMe.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamMe.cs
@@ -1,49 +1,49 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class MeArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual MeWrapper Me()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("me");
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			MeWrapper genBeamCommandWrapper = new MeWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class MeWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual MeWrapper OnStreamAccountMeCommandOutput(System.Action<ReportDataPoint<BeamAccountMeCommandOutput>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class MeArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual MeWrapper Me()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("me");
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            MeWrapper genBeamCommandWrapper = new MeWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class MeWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual MeWrapper OnStreamAccountMeCommandOutput(System.Action<ReportDataPoint<BeamAccountMeCommandOutput>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamNotificationPlayerOutput.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamNotificationPlayerOutput.cs
@@ -1,13 +1,13 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamNotificationPlayerOutput
-	{
-		public string context;
-		public string payload;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamNotificationPlayerOutput
+    {
+        public string context;
+        public string payload;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamNotificationServerOutput.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamNotificationServerOutput.cs
@@ -1,13 +1,13 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamNotificationServerOutput
-	{
-		public string path;
-		public string body;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamNotificationServerOutput
+    {
+        public string path;
+        public string body;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamOapiDownload.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamOapiDownload.cs
@@ -1,62 +1,62 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class OapiDownloadArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>When null or empty, the generated code will be sent to standard-out. When there is a output value, the file or files will be written to the path</summary>
-		public string output;
-		/// <summary>Filter which open apis to generate. An empty string matches everything</summary>
-		public string filter;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the output value was not default, then add it to the list of args.
-			if ((this.output != default(string)))
-			{
-				genBeamCommandArgs.Add((("--output=\"" + this.output)
-								+ "\""));
-			}
-			// If the filter value was not default, then add it to the list of args.
-			if ((this.filter != default(string)))
-			{
-				genBeamCommandArgs.Add((("--filter=\"" + this.filter)
-								+ "\""));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual OapiDownloadWrapper OapiDownload(OapiDownloadArgs downloadArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("oapi");
-			genBeamCommandArgs.Add("download");
-			genBeamCommandArgs.Add(downloadArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			OapiDownloadWrapper genBeamCommandWrapper = new OapiDownloadWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class OapiDownloadWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class OapiDownloadArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>When null or empty, the generated code will be sent to standard-out. When there is a output value, the file or files will be written to the path</summary>
+        public string output;
+        /// <summary>Filter which open apis to generate. An empty string matches everything</summary>
+        public string filter;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the output value was not default, then add it to the list of args.
+            if ((this.output != default(string)))
+            {
+                genBeamCommandArgs.Add((("--output=\"" + this.output) 
+                                + "\""));
+            }
+            // If the filter value was not default, then add it to the list of args.
+            if ((this.filter != default(string)))
+            {
+                genBeamCommandArgs.Add((("--filter=\"" + this.filter) 
+                                + "\""));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual OapiDownloadWrapper OapiDownload(OapiDownloadArgs downloadArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("oapi");
+            genBeamCommandArgs.Add("download");
+            genBeamCommandArgs.Add(downloadArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            OapiDownloadWrapper genBeamCommandWrapper = new OapiDownloadWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class OapiDownloadWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProfileCheckCounters.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProfileCheckCounters.cs
@@ -1,69 +1,69 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProfileCheckCountersArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>The path to the dotnet-counters output json file</summary>
-		public string countersFilePath;
-		/// <summary>The max cpu spike limit %</summary>
-		public double cpuLimit;
-		/// <summary>The max mem spike limit MB</summary>
-		public double memLimit;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// Add the countersFilePath value to the list of args.
-			genBeamCommandArgs.Add(this.countersFilePath.ToString());
-			// If the cpuLimit value was not default, then add it to the list of args.
-			if ((this.cpuLimit != default(double)))
-			{
-				genBeamCommandArgs.Add(("--cpu-limit=" + this.cpuLimit));
-			}
-			// If the memLimit value was not default, then add it to the list of args.
-			if ((this.memLimit != default(double)))
-			{
-				genBeamCommandArgs.Add(("--mem-limit=" + this.memLimit));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProfileCheckCountersWrapper ProfileCheckCounters(ProfileCheckCountersArgs checkCountersArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("profile");
-			genBeamCommandArgs.Add("check-counters");
-			genBeamCommandArgs.Add(checkCountersArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProfileCheckCountersWrapper genBeamCommandWrapper = new ProfileCheckCountersWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProfileCheckCountersWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ProfileCheckCountersWrapper OnStreamCheckPerfCommandOutput(System.Action<ReportDataPoint<BeamCheckPerfCommandOutput>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProfileCheckCountersArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>The path to the dotnet-counters output json file</summary>
+        public string countersFilePath;
+        /// <summary>The max cpu spike limit %</summary>
+        public double cpuLimit;
+        /// <summary>The max mem spike limit MB</summary>
+        public double memLimit;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // Add the countersFilePath value to the list of args.
+            genBeamCommandArgs.Add(this.countersFilePath.ToString());
+            // If the cpuLimit value was not default, then add it to the list of args.
+            if ((this.cpuLimit != default(double)))
+            {
+                genBeamCommandArgs.Add(("--cpu-limit=" + this.cpuLimit));
+            }
+            // If the memLimit value was not default, then add it to the list of args.
+            if ((this.memLimit != default(double)))
+            {
+                genBeamCommandArgs.Add(("--mem-limit=" + this.memLimit));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProfileCheckCountersWrapper ProfileCheckCounters(ProfileCheckCountersArgs checkCountersArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("profile");
+            genBeamCommandArgs.Add("check-counters");
+            genBeamCommandArgs.Add(checkCountersArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProfileCheckCountersWrapper genBeamCommandWrapper = new ProfileCheckCountersWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProfileCheckCountersWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ProfileCheckCountersWrapper OnStreamCheckPerfCommandOutput(System.Action<ReportDataPoint<BeamCheckPerfCommandOutput>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProfileCheckNbomber.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProfileCheckNbomber.cs
@@ -1,69 +1,69 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProfileCheckNbomberArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>The path to the nbomber output csv file</summary>
-		public string nbomberFilePath;
-		/// <summary>The max number of failed requests</summary>
-		public double failLimit;
-		/// <summary>The max p95 in ms</summary>
-		public double p95Limit;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// Add the nbomberFilePath value to the list of args.
-			genBeamCommandArgs.Add(this.nbomberFilePath.ToString());
-			// If the failLimit value was not default, then add it to the list of args.
-			if ((this.failLimit != default(double)))
-			{
-				genBeamCommandArgs.Add(("--fail-limit=" + this.failLimit));
-			}
-			// If the p95Limit value was not default, then add it to the list of args.
-			if ((this.p95Limit != default(double)))
-			{
-				genBeamCommandArgs.Add(("--p95-limit=" + this.p95Limit));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProfileCheckNbomberWrapper ProfileCheckNbomber(ProfileCheckNbomberArgs checkNbomberArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("profile");
-			genBeamCommandArgs.Add("check-nbomber");
-			genBeamCommandArgs.Add(checkNbomberArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProfileCheckNbomberWrapper genBeamCommandWrapper = new ProfileCheckNbomberWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProfileCheckNbomberWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ProfileCheckNbomberWrapper OnStreamCheckPerfCommandOutput(System.Action<ReportDataPoint<BeamCheckPerfCommandOutput>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProfileCheckNbomberArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>The path to the nbomber output csv file</summary>
+        public string nbomberFilePath;
+        /// <summary>The max number of failed requests</summary>
+        public double failLimit;
+        /// <summary>The max p95 in ms</summary>
+        public double p95Limit;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // Add the nbomberFilePath value to the list of args.
+            genBeamCommandArgs.Add(this.nbomberFilePath.ToString());
+            // If the failLimit value was not default, then add it to the list of args.
+            if ((this.failLimit != default(double)))
+            {
+                genBeamCommandArgs.Add(("--fail-limit=" + this.failLimit));
+            }
+            // If the p95Limit value was not default, then add it to the list of args.
+            if ((this.p95Limit != default(double)))
+            {
+                genBeamCommandArgs.Add(("--p95-limit=" + this.p95Limit));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProfileCheckNbomberWrapper ProfileCheckNbomber(ProfileCheckNbomberArgs checkNbomberArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("profile");
+            genBeamCommandArgs.Add("check-nbomber");
+            genBeamCommandArgs.Add(checkNbomberArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProfileCheckNbomberWrapper genBeamCommandWrapper = new ProfileCheckNbomberWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProfileCheckNbomberWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ProfileCheckNbomberWrapper OnStreamCheckPerfCommandOutput(System.Action<ReportDataPoint<BeamCheckPerfCommandOutput>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectAddUnityProject.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectAddUnityProject.cs
@@ -1,50 +1,50 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectAddUnityProjectArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Relative path to the Unity project</summary>
-		public string path;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// Add the path value to the list of args.
-			genBeamCommandArgs.Add(this.path.ToString());
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectAddUnityProjectWrapper ProjectAddUnityProject(ProjectAddUnityProjectArgs addUnityProjectArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("add-unity-project");
-			genBeamCommandArgs.Add(addUnityProjectArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectAddUnityProjectWrapper genBeamCommandWrapper = new ProjectAddUnityProjectWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectAddUnityProjectWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectAddUnityProjectArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Relative path to the Unity project</summary>
+        public string path;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // Add the path value to the list of args.
+            genBeamCommandArgs.Add(this.path.ToString());
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectAddUnityProjectWrapper ProjectAddUnityProject(ProjectAddUnityProjectArgs addUnityProjectArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("add-unity-project");
+            genBeamCommandArgs.Add(addUnityProjectArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectAddUnityProjectWrapper genBeamCommandWrapper = new ProjectAddUnityProjectWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectAddUnityProjectWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectBuild.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectBuild.cs
@@ -1,69 +1,69 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectBuildArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>When true, the command will run forever and watch the state of the program</summary>
-		public bool watch;
-		/// <summary>The list of services to build, defaults to all local services</summary>
-		public string[] ids;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the watch value was not default, then add it to the list of args.
-			if ((this.watch != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--watch=" + this.watch));
-			}
-			// If the ids value was not default, then add it to the list of args.
-			if ((this.ids != default(string[])))
-			{
-				for (int i = 0; (i < this.ids.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--ids=" + this.ids[i]));
-				}
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectBuildWrapper ProjectBuild(ProjectBuildArgs buildArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("build");
-			genBeamCommandArgs.Add(buildArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectBuildWrapper genBeamCommandWrapper = new ProjectBuildWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectBuildWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ProjectBuildWrapper OnStreamBuildProjectCommandOutput(System.Action<ReportDataPoint<BeamBuildProjectCommandOutput>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectBuildArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>When true, the command will run forever and watch the state of the program</summary>
+        public bool watch;
+        /// <summary>The list of services to build, defaults to all local services</summary>
+        public string[] ids;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the watch value was not default, then add it to the list of args.
+            if ((this.watch != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--watch=" + this.watch));
+            }
+            // If the ids value was not default, then add it to the list of args.
+            if ((this.ids != default(string[])))
+            {
+                for (int i = 0; (i < this.ids.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--ids=" + this.ids[i]));
+                }
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectBuildWrapper ProjectBuild(ProjectBuildArgs buildArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("build");
+            genBeamCommandArgs.Add(buildArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectBuildWrapper genBeamCommandWrapper = new ProjectBuildWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectBuildWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ProjectBuildWrapper OnStreamBuildProjectCommandOutput(System.Action<ReportDataPoint<BeamBuildProjectCommandOutput>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDeps.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDeps.cs
@@ -1,45 +1,45 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectDepsArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectDepsWrapper ProjectDeps()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("deps");
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectDepsWrapper genBeamCommandWrapper = new ProjectDepsWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectDepsWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectDepsArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectDepsWrapper ProjectDeps()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("deps");
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectDepsWrapper genBeamCommandWrapper = new ProjectDepsWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectDepsWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDepsAdd.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDepsAdd.cs
@@ -1,55 +1,55 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectDepsAddArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>The microservice name that the dependency will be added to</summary>
-		public string microservice;
-		/// <summary>The storage that will be a dependency of the given microservice</summary>
-		public string dependency;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// Add the microservice value to the list of args.
-			genBeamCommandArgs.Add(this.microservice.ToString());
-			// Add the dependency value to the list of args.
-			genBeamCommandArgs.Add(this.dependency.ToString());
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectDepsAddWrapper ProjectDepsAdd(ProjectDepsAddArgs addArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("deps");
-			genBeamCommandArgs.Add("add");
-			genBeamCommandArgs.Add(addArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectDepsAddWrapper genBeamCommandWrapper = new ProjectDepsAddWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectDepsAddWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectDepsAddArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>The microservice name that the dependency will be added to</summary>
+        public string microservice;
+        /// <summary>The storage that will be a dependency of the given microservice</summary>
+        public string dependency;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // Add the microservice value to the list of args.
+            genBeamCommandArgs.Add(this.microservice.ToString());
+            // Add the dependency value to the list of args.
+            genBeamCommandArgs.Add(this.dependency.ToString());
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectDepsAddWrapper ProjectDepsAdd(ProjectDepsAddArgs addArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("deps");
+            genBeamCommandArgs.Add("add");
+            genBeamCommandArgs.Add(addArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectDepsAddWrapper genBeamCommandWrapper = new ProjectDepsAddWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectDepsAddWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDepsList.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDepsList.cs
@@ -1,67 +1,74 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectDepsListArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>The name of the service to list the dependencies of</summary>
-		public string service;
-		/// <summary>If this is passed and set to True, then all references of the service will be listed</summary>
-		public bool all;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the service value was not default, then add it to the list of args.
-			if ((this.service != default(string)))
-			{
-				genBeamCommandArgs.Add((("--service=\"" + this.service)
-								+ "\""));
-			}
-			// If the all value was not default, then add it to the list of args.
-			if ((this.all != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--all=" + this.all));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectDepsListWrapper ProjectDepsList(ProjectDepsListArgs listArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("deps");
-			genBeamCommandArgs.Add("list");
-			genBeamCommandArgs.Add(listArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectDepsListWrapper genBeamCommandWrapper = new ProjectDepsListWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectDepsListWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ProjectDepsListWrapper OnStreamListDepsCommandResults(System.Action<ReportDataPoint<BeamListDepsCommandResults>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectDepsListArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>The name of the service to list the dependencies of</summary>
+        public string service;
+        /// <summary>If this is passed and set to True, then all references of the service will be listed</summary>
+        public bool all;
+        /// <summary>If this is passed and set to True, then all references that are not storages or microservices will be listed</summary>
+        public bool nonBeamo;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the service value was not default, then add it to the list of args.
+            if ((this.service != default(string)))
+            {
+                genBeamCommandArgs.Add((("--service=\"" + this.service) 
+                                + "\""));
+            }
+            // If the all value was not default, then add it to the list of args.
+            if ((this.all != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--all=" + this.all));
+            }
+            // If the nonBeamo value was not default, then add it to the list of args.
+            if ((this.nonBeamo != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--non-beamo=" + this.nonBeamo));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectDepsListWrapper ProjectDepsList(ProjectDepsListArgs listArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("deps");
+            genBeamCommandArgs.Add("list");
+            genBeamCommandArgs.Add(listArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectDepsListWrapper genBeamCommandWrapper = new ProjectDepsListWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectDepsListWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ProjectDepsListWrapper OnStreamListDepsCommandResults(System.Action<ReportDataPoint<BeamListDepsCommandResults>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDepsRemove.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDepsRemove.cs
@@ -1,55 +1,55 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectDepsRemoveArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>The microservice name that the dependency will be removed from</summary>
-		public string microservice;
-		/// <summary>The dependency that will be removed from that service</summary>
-		public string dependency;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// Add the microservice value to the list of args.
-			genBeamCommandArgs.Add(this.microservice.ToString());
-			// Add the dependency value to the list of args.
-			genBeamCommandArgs.Add(this.dependency.ToString());
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectDepsRemoveWrapper ProjectDepsRemove(ProjectDepsRemoveArgs removeArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("deps");
-			genBeamCommandArgs.Add("remove");
-			genBeamCommandArgs.Add(removeArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectDepsRemoveWrapper genBeamCommandWrapper = new ProjectDepsRemoveWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectDepsRemoveWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectDepsRemoveArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>The microservice name that the dependency will be removed from</summary>
+        public string microservice;
+        /// <summary>The dependency that will be removed from that service</summary>
+        public string dependency;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // Add the microservice value to the list of args.
+            genBeamCommandArgs.Add(this.microservice.ToString());
+            // Add the dependency value to the list of args.
+            genBeamCommandArgs.Add(this.dependency.ToString());
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectDepsRemoveWrapper ProjectDepsRemove(ProjectDepsRemoveArgs removeArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("deps");
+            genBeamCommandArgs.Add("remove");
+            genBeamCommandArgs.Add(removeArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectDepsRemoveWrapper genBeamCommandWrapper = new ProjectDepsRemoveWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectDepsRemoveWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectErrorReport.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectErrorReport.cs
@@ -1,13 +1,13 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamProjectErrorReport
-	{
-		public bool isSuccess;
-		public System.Collections.Generic.List<BeamProjectErrorResult> errors;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamProjectErrorReport
+    {
+        public bool isSuccess;
+        public System.Collections.Generic.List<BeamProjectErrorResult> errors;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectErrorResult.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectErrorResult.cs
@@ -1,16 +1,16 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamProjectErrorResult
-	{
-		public string level;
-		public string formattedMessage;
-		public string uri;
-		public int line;
-		public int column;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamProjectErrorResult
+    {
+        public string level;
+        public string formattedMessage;
+        public string uri;
+        public int line;
+        public int column;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateClient.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateClient.cs
@@ -1,65 +1,65 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectGenerateClientArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>The .dll filepath for the built microservice</summary>
-		public string source;
-		/// <summary>Directory to write the output client at</summary>
-		public string outputDir;
-		/// <summary>When true, generate the source client files to all associated projects</summary>
-		public bool outputLinks;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// Add the source value to the list of args.
-			genBeamCommandArgs.Add(this.source.ToString());
-			// If the outputDir value was not default, then add it to the list of args.
-			if ((this.outputDir != default(string)))
-			{
-				genBeamCommandArgs.Add((("--output-dir=\"" + this.outputDir)
-								+ "\""));
-			}
-			// If the outputLinks value was not default, then add it to the list of args.
-			if ((this.outputLinks != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--output-links=" + this.outputLinks));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectGenerateClientWrapper ProjectGenerateClient(ProjectGenerateClientArgs generateClientArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("generate-client");
-			genBeamCommandArgs.Add(generateClientArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectGenerateClientWrapper genBeamCommandWrapper = new ProjectGenerateClientWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectGenerateClientWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectGenerateClientArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>The .dll filepath for the built microservice</summary>
+        public string source;
+        /// <summary>Directory to write the output client at</summary>
+        public string outputDir;
+        /// <summary>When true, generate the source client files to all associated projects</summary>
+        public bool outputLinks;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // Add the source value to the list of args.
+            genBeamCommandArgs.Add(this.source.ToString());
+            // If the outputDir value was not default, then add it to the list of args.
+            if ((this.outputDir != default(string)))
+            {
+                genBeamCommandArgs.Add((("--output-dir=\"" + this.outputDir) 
+                                + "\""));
+            }
+            // If the outputLinks value was not default, then add it to the list of args.
+            if ((this.outputLinks != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--output-links=" + this.outputLinks));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectGenerateClientWrapper ProjectGenerateClient(ProjectGenerateClientArgs generateClientArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("generate-client");
+            genBeamCommandArgs.Add(generateClientArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectGenerateClientWrapper genBeamCommandWrapper = new ProjectGenerateClientWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectGenerateClientWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateProperties.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateProperties.cs
@@ -1,66 +1,66 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectGeneratePropertiesArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Where the file will be created</summary>
-		public string output;
-		/// <summary>Beam path to be used</summary>
-		public string beamPath;
-		/// <summary>The solution path to be used</summary>
-		public string solutionDir;
-		/// <summary>A path relative to the given solution directory, that will be used to store the projects /bin and /obj directories. Note: the given path will have the project's assembly name and the bin or obj folder appended</summary>
-		public string buildDir;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// Add the output value to the list of args.
-			genBeamCommandArgs.Add(this.output.ToString());
-			// Add the beamPath value to the list of args.
-			genBeamCommandArgs.Add(this.beamPath.ToString());
-			// Add the solutionDir value to the list of args.
-			genBeamCommandArgs.Add(this.solutionDir.ToString());
-			// If the buildDir value was not default, then add it to the list of args.
-			if ((this.buildDir != default(string)))
-			{
-				genBeamCommandArgs.Add((("--build-dir=\"" + this.buildDir)
-								+ "\""));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectGeneratePropertiesWrapper ProjectGenerateProperties(ProjectGeneratePropertiesArgs generatePropertiesArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("generate-properties");
-			genBeamCommandArgs.Add(generatePropertiesArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectGeneratePropertiesWrapper genBeamCommandWrapper = new ProjectGeneratePropertiesWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectGeneratePropertiesWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectGeneratePropertiesArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Where the file will be created</summary>
+        public string output;
+        /// <summary>Beam path to be used</summary>
+        public string beamPath;
+        /// <summary>The solution path to be used</summary>
+        public string solutionDir;
+        /// <summary>A path relative to the given solution directory, that will be used to store the projects /bin and /obj directories. Note: the given path will have the project's assembly name and the bin or obj folder appended</summary>
+        public string buildDir;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // Add the output value to the list of args.
+            genBeamCommandArgs.Add(this.output.ToString());
+            // Add the beamPath value to the list of args.
+            genBeamCommandArgs.Add(this.beamPath.ToString());
+            // Add the solutionDir value to the list of args.
+            genBeamCommandArgs.Add(this.solutionDir.ToString());
+            // If the buildDir value was not default, then add it to the list of args.
+            if ((this.buildDir != default(string)))
+            {
+                genBeamCommandArgs.Add((("--build-dir=\"" + this.buildDir) 
+                                + "\""));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectGeneratePropertiesWrapper ProjectGenerateProperties(ProjectGeneratePropertiesArgs generatePropertiesArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("generate-properties");
+            genBeamCommandArgs.Add(generatePropertiesArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectGeneratePropertiesWrapper genBeamCommandWrapper = new ProjectGeneratePropertiesWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectGeneratePropertiesWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectList.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectList.cs
@@ -1,50 +1,50 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectListArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectListWrapper ProjectList()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("list");
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectListWrapper genBeamCommandWrapper = new ProjectListWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectListWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ProjectListWrapper OnStreamListCommandResult(System.Action<ReportDataPoint<BeamListCommandResult>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectListArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectListWrapper ProjectList()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("list");
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectListWrapper genBeamCommandWrapper = new ProjectListWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectListWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ProjectListWrapper OnStreamListCommandResult(System.Action<ReportDataPoint<BeamListCommandResult>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectLogs.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectLogs.cs
@@ -1,62 +1,62 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectLogsArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>The name of the service to view logs for</summary>
-		public Beamable.Common.Semantics.ServiceName service;
-		/// <summary>If the service stops, and reconnect is enabled, then the logs command will wait for the service to restart and then reattach to logs</summary>
-		public bool reconnect;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// Add the service value to the list of args.
-			genBeamCommandArgs.Add(this.service.ToString());
-			// If the reconnect value was not default, then add it to the list of args.
-			if ((this.reconnect != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--reconnect=" + this.reconnect));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectLogsWrapper ProjectLogs(ProjectLogsArgs logsArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("logs");
-			genBeamCommandArgs.Add(logsArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectLogsWrapper genBeamCommandWrapper = new ProjectLogsWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectLogsWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ProjectLogsWrapper OnStreamTailLogMessageForClient(System.Action<ReportDataPoint<BeamTailLogMessageForClient>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectLogsArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>The name of the service to view logs for</summary>
+        public Beamable.Common.Semantics.ServiceName service;
+        /// <summary>If the service stops, and reconnect is enabled, then the logs command will wait for the service to restart and then reattach to logs</summary>
+        public bool reconnect;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // Add the service value to the list of args.
+            genBeamCommandArgs.Add(this.service.ToString());
+            // If the reconnect value was not default, then add it to the list of args.
+            if ((this.reconnect != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--reconnect=" + this.reconnect));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectLogsWrapper ProjectLogs(ProjectLogsArgs logsArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("logs");
+            genBeamCommandArgs.Add(logsArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectLogsWrapper genBeamCommandWrapper = new ProjectLogsWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectLogsWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ProjectLogsWrapper OnStreamTailLogMessageForClient(System.Action<ReportDataPoint<BeamTailLogMessageForClient>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewCommonLib.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewCommonLib.cs
@@ -1,82 +1,82 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectNewCommonLibArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>The name of the new library project</summary>
-		public Beamable.Common.Semantics.ServiceName name;
-		/// <summary>Automatically create a .beamable folder context if no context exists</summary>
-		public bool init;
-		/// <summary>Relative path to the .sln file to use for the new project. If the .sln file does not exist, it will be created. By default, when no value is provided, the .sln path will be <name>/<name>.sln</summary>
-		public string sln;
-		/// <summary>Specifies version of Beamable project dependencies</summary>
-		public string version;
-		/// <summary>The path where the project is going to be created</summary>
-		public string outputPath;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// Add the name value to the list of args.
-			genBeamCommandArgs.Add(this.name.ToString());
-			// If the init value was not default, then add it to the list of args.
-			if ((this.init != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--init=" + this.init));
-			}
-			// If the sln value was not default, then add it to the list of args.
-			if ((this.sln != default(string)))
-			{
-				genBeamCommandArgs.Add((("--sln=\"" + this.sln)
-								+ "\""));
-			}
-			// If the version value was not default, then add it to the list of args.
-			if ((this.version != default(string)))
-			{
-				genBeamCommandArgs.Add((("--version=\"" + this.version)
-								+ "\""));
-			}
-			// If the outputPath value was not default, then add it to the list of args.
-			if ((this.outputPath != default(string)))
-			{
-				genBeamCommandArgs.Add((("--output-path=\"" + this.outputPath)
-								+ "\""));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectNewCommonLibWrapper ProjectNewCommonLib(ProjectNewCommonLibArgs commonLibArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("new");
-			genBeamCommandArgs.Add("common-lib");
-			genBeamCommandArgs.Add(commonLibArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectNewCommonLibWrapper genBeamCommandWrapper = new ProjectNewCommonLibWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectNewCommonLibWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectNewCommonLibArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>The name of the new library project</summary>
+        public Beamable.Common.Semantics.ServiceName name;
+        /// <summary>Automatically create a .beamable folder context if no context exists</summary>
+        public bool init;
+        /// <summary>Relative path to the .sln file to use for the new project. If the .sln file does not exist, it will be created. By default, when no value is provided, the .sln path will be <name>/<name>.sln</summary>
+        public string sln;
+        /// <summary>Specifies version of Beamable project dependencies</summary>
+        public string version;
+        /// <summary>The path where the project is going to be created</summary>
+        public string outputPath;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // Add the name value to the list of args.
+            genBeamCommandArgs.Add(this.name.ToString());
+            // If the init value was not default, then add it to the list of args.
+            if ((this.init != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--init=" + this.init));
+            }
+            // If the sln value was not default, then add it to the list of args.
+            if ((this.sln != default(string)))
+            {
+                genBeamCommandArgs.Add((("--sln=\"" + this.sln) 
+                                + "\""));
+            }
+            // If the version value was not default, then add it to the list of args.
+            if ((this.version != default(string)))
+            {
+                genBeamCommandArgs.Add((("--version=\"" + this.version) 
+                                + "\""));
+            }
+            // If the outputPath value was not default, then add it to the list of args.
+            if ((this.outputPath != default(string)))
+            {
+                genBeamCommandArgs.Add((("--output-path=\"" + this.outputPath) 
+                                + "\""));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectNewCommonLibWrapper ProjectNewCommonLib(ProjectNewCommonLibArgs commonLibArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("new");
+            genBeamCommandArgs.Add("common-lib");
+            genBeamCommandArgs.Add(commonLibArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectNewCommonLibWrapper genBeamCommandWrapper = new ProjectNewCommonLibWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectNewCommonLibWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewService.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewService.cs
@@ -1,89 +1,89 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectNewServiceArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Name of the new project</summary>
-		public Beamable.Common.Semantics.ServiceName name;
-		/// <summary>Automatically create a .beamable folder context if no context exists</summary>
-		public bool init;
-		/// <summary>Relative path to the .sln file to use for the new project. If the .sln file does not exist, it will be created. By default, when no value is provided, the .sln path will be <name>/<name>.sln</summary>
-		public string sln;
-		/// <summary>Relative path to directory where project should be created. Defaults to "SOLUTION_DIR/services"</summary>
-		public string serviceDirectory;
-		/// <summary>Specifies version of Beamable project dependencies</summary>
-		public string version;
-		/// <summary>Created service by default would not be published</summary>
-		public bool disable;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// Add the name value to the list of args.
-			genBeamCommandArgs.Add(this.name.ToString());
-			// If the init value was not default, then add it to the list of args.
-			if ((this.init != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--init=" + this.init));
-			}
-			// If the sln value was not default, then add it to the list of args.
-			if ((this.sln != default(string)))
-			{
-				genBeamCommandArgs.Add((("--sln=\"" + this.sln)
-								+ "\""));
-			}
-			// If the serviceDirectory value was not default, then add it to the list of args.
-			if ((this.serviceDirectory != default(string)))
-			{
-				genBeamCommandArgs.Add((("--service-directory=\"" + this.serviceDirectory)
-								+ "\""));
-			}
-			// If the version value was not default, then add it to the list of args.
-			if ((this.version != default(string)))
-			{
-				genBeamCommandArgs.Add((("--version=\"" + this.version)
-								+ "\""));
-			}
-			// If the disable value was not default, then add it to the list of args.
-			if ((this.disable != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--disable=" + this.disable));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectNewServiceWrapper ProjectNewService(ProjectNewServiceArgs serviceArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("new");
-			genBeamCommandArgs.Add("service");
-			genBeamCommandArgs.Add(serviceArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectNewServiceWrapper genBeamCommandWrapper = new ProjectNewServiceWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectNewServiceWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectNewServiceArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Name of the new project</summary>
+        public Beamable.Common.Semantics.ServiceName name;
+        /// <summary>Automatically create a .beamable folder context if no context exists</summary>
+        public bool init;
+        /// <summary>Relative path to the .sln file to use for the new project. If the .sln file does not exist, it will be created. By default, when no value is provided, the .sln path will be <name>/<name>.sln</summary>
+        public string sln;
+        /// <summary>Relative path to directory where project should be created. Defaults to "SOLUTION_DIR/services"</summary>
+        public string serviceDirectory;
+        /// <summary>Specifies version of Beamable project dependencies</summary>
+        public string version;
+        /// <summary>Created service by default would not be published</summary>
+        public bool disable;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // Add the name value to the list of args.
+            genBeamCommandArgs.Add(this.name.ToString());
+            // If the init value was not default, then add it to the list of args.
+            if ((this.init != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--init=" + this.init));
+            }
+            // If the sln value was not default, then add it to the list of args.
+            if ((this.sln != default(string)))
+            {
+                genBeamCommandArgs.Add((("--sln=\"" + this.sln) 
+                                + "\""));
+            }
+            // If the serviceDirectory value was not default, then add it to the list of args.
+            if ((this.serviceDirectory != default(string)))
+            {
+                genBeamCommandArgs.Add((("--service-directory=\"" + this.serviceDirectory) 
+                                + "\""));
+            }
+            // If the version value was not default, then add it to the list of args.
+            if ((this.version != default(string)))
+            {
+                genBeamCommandArgs.Add((("--version=\"" + this.version) 
+                                + "\""));
+            }
+            // If the disable value was not default, then add it to the list of args.
+            if ((this.disable != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--disable=" + this.disable));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectNewServiceWrapper ProjectNewService(ProjectNewServiceArgs serviceArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("new");
+            genBeamCommandArgs.Add("service");
+            genBeamCommandArgs.Add(serviceArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectNewServiceWrapper genBeamCommandWrapper = new ProjectNewServiceWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectNewServiceWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewStorage.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewStorage.cs
@@ -1,100 +1,100 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectNewStorageArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Name of the new project</summary>
-		public Beamable.Common.Semantics.ServiceName name;
-		/// <summary>Automatically create a .beamable folder context if no context exists</summary>
-		public bool init;
-		/// <summary>Relative path to the .sln file to use for the new project. If the .sln file does not exist, it will be created. By default, when no value is provided, the .sln path will be <name>/<name>.sln</summary>
-		public string sln;
-		/// <summary>Relative path to directory where project should be created. Defaults to "SOLUTION_DIR/services"</summary>
-		public string serviceDirectory;
-		/// <summary>Specifies version of Beamable project dependencies</summary>
-		public string version;
-		/// <summary>Created service by default would not be published</summary>
-		public bool disable;
-		/// <summary>The name of the project to link this storage to</summary>
-		public string[] linkTo;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// Add the name value to the list of args.
-			genBeamCommandArgs.Add(this.name.ToString());
-			// If the init value was not default, then add it to the list of args.
-			if ((this.init != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--init=" + this.init));
-			}
-			// If the sln value was not default, then add it to the list of args.
-			if ((this.sln != default(string)))
-			{
-				genBeamCommandArgs.Add((("--sln=\"" + this.sln)
-								+ "\""));
-			}
-			// If the serviceDirectory value was not default, then add it to the list of args.
-			if ((this.serviceDirectory != default(string)))
-			{
-				genBeamCommandArgs.Add((("--service-directory=\"" + this.serviceDirectory)
-								+ "\""));
-			}
-			// If the version value was not default, then add it to the list of args.
-			if ((this.version != default(string)))
-			{
-				genBeamCommandArgs.Add((("--version=\"" + this.version)
-								+ "\""));
-			}
-			// If the disable value was not default, then add it to the list of args.
-			if ((this.disable != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--disable=" + this.disable));
-			}
-			// If the linkTo value was not default, then add it to the list of args.
-			if ((this.linkTo != default(string[])))
-			{
-				for (int i = 0; (i < this.linkTo.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--link-to=" + this.linkTo[i]));
-				}
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectNewStorageWrapper ProjectNewStorage(ProjectNewStorageArgs storageArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("new");
-			genBeamCommandArgs.Add("storage");
-			genBeamCommandArgs.Add(storageArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectNewStorageWrapper genBeamCommandWrapper = new ProjectNewStorageWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectNewStorageWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectNewStorageArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Name of the new project</summary>
+        public Beamable.Common.Semantics.ServiceName name;
+        /// <summary>Automatically create a .beamable folder context if no context exists</summary>
+        public bool init;
+        /// <summary>Relative path to the .sln file to use for the new project. If the .sln file does not exist, it will be created. By default, when no value is provided, the .sln path will be <name>/<name>.sln</summary>
+        public string sln;
+        /// <summary>Relative path to directory where project should be created. Defaults to "SOLUTION_DIR/services"</summary>
+        public string serviceDirectory;
+        /// <summary>Specifies version of Beamable project dependencies</summary>
+        public string version;
+        /// <summary>Created service by default would not be published</summary>
+        public bool disable;
+        /// <summary>The name of the project to link this storage to</summary>
+        public string[] linkTo;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // Add the name value to the list of args.
+            genBeamCommandArgs.Add(this.name.ToString());
+            // If the init value was not default, then add it to the list of args.
+            if ((this.init != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--init=" + this.init));
+            }
+            // If the sln value was not default, then add it to the list of args.
+            if ((this.sln != default(string)))
+            {
+                genBeamCommandArgs.Add((("--sln=\"" + this.sln) 
+                                + "\""));
+            }
+            // If the serviceDirectory value was not default, then add it to the list of args.
+            if ((this.serviceDirectory != default(string)))
+            {
+                genBeamCommandArgs.Add((("--service-directory=\"" + this.serviceDirectory) 
+                                + "\""));
+            }
+            // If the version value was not default, then add it to the list of args.
+            if ((this.version != default(string)))
+            {
+                genBeamCommandArgs.Add((("--version=\"" + this.version) 
+                                + "\""));
+            }
+            // If the disable value was not default, then add it to the list of args.
+            if ((this.disable != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--disable=" + this.disable));
+            }
+            // If the linkTo value was not default, then add it to the list of args.
+            if ((this.linkTo != default(string[])))
+            {
+                for (int i = 0; (i < this.linkTo.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--link-to=" + this.linkTo[i]));
+                }
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectNewStorageWrapper ProjectNewStorage(ProjectNewStorageArgs storageArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("new");
+            genBeamCommandArgs.Add("storage");
+            genBeamCommandArgs.Add(storageArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectNewStorageWrapper genBeamCommandWrapper = new ProjectNewStorageWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectNewStorageWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectOapi.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectOapi.cs
@@ -1,62 +1,62 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectOapiArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>The list of services to build, defaults to all local services</summary>
-		public string[] ids;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the ids value was not default, then add it to the list of args.
-			if ((this.ids != default(string[])))
-			{
-				for (int i = 0; (i < this.ids.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--ids=" + this.ids[i]));
-				}
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectOapiWrapper ProjectOapi(ProjectOapiArgs oapiArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("oapi");
-			genBeamCommandArgs.Add(oapiArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectOapiWrapper genBeamCommandWrapper = new ProjectOapiWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectOapiWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ProjectOapiWrapper OnStreamGenerateOApiCommandOutput(System.Action<ReportDataPoint<BeamGenerateOApiCommandOutput>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectOapiArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>The list of services to build, defaults to all local services</summary>
+        public string[] ids;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the ids value was not default, then add it to the list of args.
+            if ((this.ids != default(string[])))
+            {
+                for (int i = 0; (i < this.ids.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--ids=" + this.ids[i]));
+                }
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectOapiWrapper ProjectOapi(ProjectOapiArgs oapiArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("oapi");
+            genBeamCommandArgs.Add(oapiArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectOapiWrapper genBeamCommandWrapper = new ProjectOapiWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectOapiWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ProjectOapiWrapper OnStreamGenerateOApiCommandOutput(System.Action<ReportDataPoint<BeamGenerateOApiCommandOutput>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectOpenSwagger.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectOpenSwagger.cs
@@ -1,60 +1,60 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectOpenSwaggerArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Name of the service to open swagger to</summary>
-		public Beamable.Common.Semantics.ServiceName serviceName;
-		/// <summary>If passed, swagger will open to the remote version of this service. Otherwise, it will try and use the local version</summary>
-		public bool remote;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the serviceName value was not default, then add it to the list of args.
-			if ((this.serviceName != default(Beamable.Common.Semantics.ServiceName)))
-			{
-				genBeamCommandArgs.Add(this.serviceName.ToString());
-			}
-			// If the remote value was not default, then add it to the list of args.
-			if ((this.remote != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--remote=" + this.remote));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectOpenSwaggerWrapper ProjectOpenSwagger(ProjectOpenSwaggerArgs openSwaggerArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("open-swagger");
-			genBeamCommandArgs.Add(openSwaggerArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectOpenSwaggerWrapper genBeamCommandWrapper = new ProjectOpenSwaggerWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectOpenSwaggerWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectOpenSwaggerArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Name of the service to open swagger to</summary>
+        public Beamable.Common.Semantics.ServiceName serviceName;
+        /// <summary>If passed, swagger will open to the remote version of this service. Otherwise, it will try and use the local version</summary>
+        public bool remote;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the serviceName value was not default, then add it to the list of args.
+            if ((this.serviceName != default(Beamable.Common.Semantics.ServiceName)))
+            {
+                genBeamCommandArgs.Add(this.serviceName.ToString());
+            }
+            // If the remote value was not default, then add it to the list of args.
+            if ((this.remote != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--remote=" + this.remote));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectOpenSwaggerWrapper ProjectOpenSwagger(ProjectOpenSwaggerArgs openSwaggerArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("open-swagger");
+            genBeamCommandArgs.Add(openSwaggerArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectOpenSwaggerWrapper genBeamCommandWrapper = new ProjectOpenSwaggerWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectOpenSwaggerWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectPs.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectPs.cs
@@ -1,58 +1,58 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectPsArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>When true, the command will run forever and watch the state of the program</summary>
-		public bool watch;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the watch value was not default, then add it to the list of args.
-			if ((this.watch != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--watch=" + this.watch));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectPsWrapper ProjectPs(ProjectPsArgs psArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("ps");
-			genBeamCommandArgs.Add(psArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectPsWrapper genBeamCommandWrapper = new ProjectPsWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectPsWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ProjectPsWrapper OnStreamServiceDiscoveryEvent(System.Action<ReportDataPoint<BeamServiceDiscoveryEvent>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectPsArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>When true, the command will run forever and watch the state of the program</summary>
+        public bool watch;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the watch value was not default, then add it to the list of args.
+            if ((this.watch != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--watch=" + this.watch));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectPsWrapper ProjectPs(ProjectPsArgs psArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("ps");
+            genBeamCommandArgs.Add(psArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectPsWrapper genBeamCommandWrapper = new ProjectPsWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectPsWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ProjectPsWrapper OnStreamServiceDiscoveryEvent(System.Action<ReportDataPoint<BeamServiceDiscoveryEvent>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectRegenerate.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectRegenerate.cs
@@ -1,80 +1,80 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectRegenerateArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Name of the new project</summary>
-		public Beamable.Common.Semantics.ServiceName name;
-		/// <summary>Where the temp project will be created</summary>
-		public string output;
-		/// <summary>The path to where the files will be copied to</summary>
-		public string copyPath;
-		/// <summary>Specifies version of Beamable project dependencies</summary>
-		public string version;
-		/// <summary>Relative path to the .sln file to use for the new project. If the .sln file does not exist, it will be created. By default, when no value is provided, the .sln path will be <name>/<name>.sln</summary>
-		public string sln;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// Add the name value to the list of args.
-			genBeamCommandArgs.Add(this.name.ToString());
-			// If the output value was not default, then add it to the list of args.
-			if ((this.output != default(string)))
-			{
-				genBeamCommandArgs.Add(this.output.ToString());
-			}
-			// If the copyPath value was not default, then add it to the list of args.
-			if ((this.copyPath != default(string)))
-			{
-				genBeamCommandArgs.Add(this.copyPath.ToString());
-			}
-			// If the version value was not default, then add it to the list of args.
-			if ((this.version != default(string)))
-			{
-				genBeamCommandArgs.Add((("--version=\"" + this.version)
-								+ "\""));
-			}
-			// If the sln value was not default, then add it to the list of args.
-			if ((this.sln != default(string)))
-			{
-				genBeamCommandArgs.Add((("--sln=\"" + this.sln)
-								+ "\""));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectRegenerateWrapper ProjectRegenerate(ProjectRegenerateArgs regenerateArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("regenerate");
-			genBeamCommandArgs.Add(regenerateArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectRegenerateWrapper genBeamCommandWrapper = new ProjectRegenerateWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectRegenerateWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectRegenerateArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Name of the new project</summary>
+        public Beamable.Common.Semantics.ServiceName name;
+        /// <summary>Where the temp project will be created</summary>
+        public string output;
+        /// <summary>The path to where the files will be copied to</summary>
+        public string copyPath;
+        /// <summary>Specifies version of Beamable project dependencies</summary>
+        public string version;
+        /// <summary>Relative path to the .sln file to use for the new project. If the .sln file does not exist, it will be created. By default, when no value is provided, the .sln path will be <name>/<name>.sln</summary>
+        public string sln;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // Add the name value to the list of args.
+            genBeamCommandArgs.Add(this.name.ToString());
+            // If the output value was not default, then add it to the list of args.
+            if ((this.output != default(string)))
+            {
+                genBeamCommandArgs.Add(this.output.ToString());
+            }
+            // If the copyPath value was not default, then add it to the list of args.
+            if ((this.copyPath != default(string)))
+            {
+                genBeamCommandArgs.Add(this.copyPath.ToString());
+            }
+            // If the version value was not default, then add it to the list of args.
+            if ((this.version != default(string)))
+            {
+                genBeamCommandArgs.Add((("--version=\"" + this.version) 
+                                + "\""));
+            }
+            // If the sln value was not default, then add it to the list of args.
+            if ((this.sln != default(string)))
+            {
+                genBeamCommandArgs.Add((("--sln=\"" + this.sln) 
+                                + "\""));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectRegenerateWrapper ProjectRegenerate(ProjectRegenerateArgs regenerateArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("regenerate");
+            genBeamCommandArgs.Add(regenerateArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectRegenerateWrapper genBeamCommandWrapper = new ProjectRegenerateWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectRegenerateWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectRun.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectRun.cs
@@ -1,64 +1,64 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectRunArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>When true, the command will run forever and watch the state of the program</summary>
-		public bool watch;
-		/// <summary>The list of services to build, defaults to all local services</summary>
-		public string[] ids;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the watch value was not default, then add it to the list of args.
-			if ((this.watch != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--watch=" + this.watch));
-			}
-			// If the ids value was not default, then add it to the list of args.
-			if ((this.ids != default(string[])))
-			{
-				for (int i = 0; (i < this.ids.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--ids=" + this.ids[i]));
-				}
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectRunWrapper ProjectRun(ProjectRunArgs runArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("run");
-			genBeamCommandArgs.Add(runArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectRunWrapper genBeamCommandWrapper = new ProjectRunWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectRunWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectRunArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>When true, the command will run forever and watch the state of the program</summary>
+        public bool watch;
+        /// <summary>The list of services to build, defaults to all local services</summary>
+        public string[] ids;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the watch value was not default, then add it to the list of args.
+            if ((this.watch != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--watch=" + this.watch));
+            }
+            // If the ids value was not default, then add it to the list of args.
+            if ((this.ids != default(string[])))
+            {
+                for (int i = 0; (i < this.ids.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--ids=" + this.ids[i]));
+                }
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectRunWrapper ProjectRun(ProjectRunArgs runArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("run");
+            genBeamCommandArgs.Add(runArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectRunWrapper genBeamCommandWrapper = new ProjectRunWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectRunWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectStop.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectStop.cs
@@ -1,62 +1,62 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectStopArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>The list of services to build, defaults to all local services</summary>
-		public string[] ids;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the ids value was not default, then add it to the list of args.
-			if ((this.ids != default(string[])))
-			{
-				for (int i = 0; (i < this.ids.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--ids=" + this.ids[i]));
-				}
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectStopWrapper ProjectStop(ProjectStopArgs stopArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("stop");
-			genBeamCommandArgs.Add(stopArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectStopWrapper genBeamCommandWrapper = new ProjectStopWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectStopWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ProjectStopWrapper OnStreamStopProjectCommandOutput(System.Action<ReportDataPoint<BeamStopProjectCommandOutput>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectStopArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>The list of services to build, defaults to all local services</summary>
+        public string[] ids;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the ids value was not default, then add it to the list of args.
+            if ((this.ids != default(string[])))
+            {
+                for (int i = 0; (i < this.ids.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--ids=" + this.ids[i]));
+                }
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectStopWrapper ProjectStop(ProjectStopArgs stopArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("stop");
+            genBeamCommandArgs.Add(stopArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectStopWrapper genBeamCommandWrapper = new ProjectStopWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectStopWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ProjectStopWrapper OnStreamStopProjectCommandOutput(System.Action<ReportDataPoint<BeamStopProjectCommandOutput>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectVersion.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectVersion.cs
@@ -1,59 +1,59 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ProjectVersionArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Request specific version of Beamable packages</summary>
-		public string requestedVersion;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the requestedVersion value was not default, then add it to the list of args.
-			if ((this.requestedVersion != default(string)))
-			{
-				genBeamCommandArgs.Add((("--requested-version=\"" + this.requestedVersion)
-								+ "\""));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ProjectVersionWrapper ProjectVersion(ProjectVersionArgs versionArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("project");
-			genBeamCommandArgs.Add("version");
-			genBeamCommandArgs.Add(versionArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ProjectVersionWrapper genBeamCommandWrapper = new ProjectVersionWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ProjectVersionWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ProjectVersionWrapper OnStreamProjectVersionCommandResult(System.Action<ReportDataPoint<BeamProjectVersionCommandResult>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ProjectVersionArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Request specific version of Beamable packages</summary>
+        public string requestedVersion;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the requestedVersion value was not default, then add it to the list of args.
+            if ((this.requestedVersion != default(string)))
+            {
+                genBeamCommandArgs.Add((("--requested-version=\"" + this.requestedVersion) 
+                                + "\""));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ProjectVersionWrapper ProjectVersion(ProjectVersionArgs versionArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("project");
+            genBeamCommandArgs.Add("version");
+            genBeamCommandArgs.Add(versionArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ProjectVersionWrapper genBeamCommandWrapper = new ProjectVersionWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ProjectVersionWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ProjectVersionWrapper OnStreamProjectVersionCommandResult(System.Action<ReportDataPoint<BeamProjectVersionCommandResult>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectVersionCommandResult.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectVersionCommandResult.cs
@@ -1,14 +1,14 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamProjectVersionCommandResult
-	{
-		public string[] projectPaths;
-		public string[] packageNames;
-		public string[] packageVersions;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamProjectVersionCommandResult
+    {
+        public string[] projectPaths;
+        public string[] packageNames;
+        public string[] packageVersions;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamRealmConfigOutput.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamRealmConfigOutput.cs
@@ -1,12 +1,12 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamRealmConfigOutput
-	{
-		public System.Collections.Generic.Dictionary<string, string> Config;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamRealmConfigOutput
+    {
+        public System.Collections.Generic.Dictionary<string, string> Config;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDependenciesPair.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDependenciesPair.cs
@@ -1,13 +1,13 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamServiceDependenciesPair
-	{
-		public string name;
-		public System.Collections.Generic.List<BeamDependencyData> dependencies;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamServiceDependenciesPair
+    {
+        public string name;
+        public System.Collections.Generic.List<BeamDependencyData> dependencies;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDeployLogResult.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDeployLogResult.cs
@@ -1,14 +1,14 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamServiceDeployLogResult
-	{
-		public string Message;
-		public string Level;
-		public string TimeStamp;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamServiceDeployLogResult
+    {
+        public string Message;
+        public string Level;
+        public string TimeStamp;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDeployReportResult.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDeployReportResult.cs
@@ -1,13 +1,13 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamServiceDeployReportResult
-	{
-		public bool Success;
-		public string FailureReason;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamServiceDeployReportResult
+    {
+        public bool Success;
+        public string FailureReason;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDiscoveryEvent.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDiscoveryEvent.cs
@@ -1,19 +1,19 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamServiceDiscoveryEvent
-	{
-		public string cid;
-		public string pid;
-		public string prefix;
-		public string service;
-		public bool isRunning;
-		public bool isContainer;
-		public int healthPort;
-		public string containerId;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamServiceDiscoveryEvent
+    {
+        public string cid;
+        public string pid;
+        public string prefix;
+        public string service;
+        public bool isRunning;
+        public bool isContainer;
+        public int healthPort;
+        public string containerId;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceListResult.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceListResult.cs
@@ -1,23 +1,23 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamServiceListResult
-	{
-		public bool IsLocal;
-		public bool IsDockerRunning;
-		public System.Collections.Generic.List<string> BeamoIds;
-		public System.Collections.Generic.List<bool> ShouldBeEnabledOnRemote;
-		public System.Collections.Generic.List<bool> RunningState;
-		public System.Collections.Generic.List<string> ProtocolTypes;
-		public System.Collections.Generic.List<string> ImageIds;
-		public System.Collections.Generic.List<string> ContainerNames;
-		public System.Collections.Generic.List<string> ContainerIds;
-		public System.Collections.Generic.List<string> LocalHostPorts;
-		public System.Collections.Generic.List<string> LocalContainerPorts;
-		public System.Collections.Generic.List<string> Dependencies;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamServiceListResult
+    {
+        public bool IsLocal;
+        public bool IsDockerRunning;
+        public System.Collections.Generic.List<string> BeamoIds;
+        public System.Collections.Generic.List<bool> ShouldBeEnabledOnRemote;
+        public System.Collections.Generic.List<bool> RunningState;
+        public System.Collections.Generic.List<string> ProtocolTypes;
+        public System.Collections.Generic.List<string> ImageIds;
+        public System.Collections.Generic.List<string> ContainerNames;
+        public System.Collections.Generic.List<string> ContainerIds;
+        public System.Collections.Generic.List<string> LocalHostPorts;
+        public System.Collections.Generic.List<string> LocalContainerPorts;
+        public System.Collections.Generic.List<string> Dependencies;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceManifestOutput.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceManifestOutput.cs
@@ -1,12 +1,12 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamServiceManifestOutput
-	{
-		public System.Collections.Generic.List<BeamCliServiceManifest> manifests;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamServiceManifestOutput
+    {
+        public System.Collections.Generic.List<BeamCliServiceManifest> manifests;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceRemoteDeployProgressResult.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceRemoteDeployProgressResult.cs
@@ -1,14 +1,14 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamServiceRemoteDeployProgressResult
-	{
-		public string BeamoId;
-		public double BuildAndTestProgress;
-		public double ContainerUploadProgress;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamServiceRemoteDeployProgressResult
+    {
+        public string BeamoId;
+        public double BuildAndTestProgress;
+        public double ContainerUploadProgress;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceRunProgressResult.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceRunProgressResult.cs
@@ -1,13 +1,13 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamServiceRunProgressResult
-	{
-		public string BeamoId;
-		public double LocalDeployProgress;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamServiceRunProgressResult
+    {
+        public string BeamoId;
+        public double LocalDeployProgress;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceRunReportResult.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceRunReportResult.cs
@@ -1,13 +1,13 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamServiceRunReportResult
-	{
-		public bool Success;
-		public string FailureReason;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamServiceRunReportResult
+    {
+        public bool Success;
+        public string FailureReason;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceTemplate.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceTemplate.cs
@@ -1,12 +1,12 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamServiceTemplate
-	{
-		public string id;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamServiceTemplate
+    {
+        public string id;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesDeploy.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesDeploy.cs
@@ -1,119 +1,119 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ServicesDeployArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>These are the ids for services you wish to be enabled once Beam-O receives the updated manifest</summary>
-		public string[] enable;
-		/// <summary>These are the ids for services you wish to be disabled once Beam-O receives the updated manifest</summary>
-		public string[] disable;
-		/// <summary>If this option is set to a valid path to a ServiceManifest JSON, deploys that instead</summary>
-		public string fromFile;
-		/// <summary>Associates this comment along with the published Manifest. You'll be able to read it via the Beamable Portal</summary>
-		public string comment;
-		/// <summary>Any number of strings in the format BeamoId::Comment
-		///Associates each comment to the given Beamo Id if it's among the published services. You'll be able to read it via the Beamable Portal</summary>
-		public string[] serviceComments;
-		/// <summary>A custom docker registry url to use when uploading. By default, the result from the beamo/registry network call will be used, with minor string manipulation to add https scheme, remove port specificatino, and add /v2 </summary>
-		public string dockerRegistryUrl;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the enable value was not default, then add it to the list of args.
-			if ((this.enable != default(string[])))
-			{
-				for (int i = 0; (i < this.enable.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--enable=" + this.enable[i]));
-				}
-			}
-			// If the disable value was not default, then add it to the list of args.
-			if ((this.disable != default(string[])))
-			{
-				for (int i = 0; (i < this.disable.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--disable=" + this.disable[i]));
-				}
-			}
-			// If the fromFile value was not default, then add it to the list of args.
-			if ((this.fromFile != default(string)))
-			{
-				genBeamCommandArgs.Add((("--from-file=\"" + this.fromFile)
-								+ "\""));
-			}
-			// If the comment value was not default, then add it to the list of args.
-			if ((this.comment != default(string)))
-			{
-				genBeamCommandArgs.Add((("--comment=\"" + this.comment)
-								+ "\""));
-			}
-			// If the serviceComments value was not default, then add it to the list of args.
-			if ((this.serviceComments != default(string[])))
-			{
-				for (int i = 0; (i < this.serviceComments.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--service-comments=" + this.serviceComments[i]));
-				}
-			}
-			// If the dockerRegistryUrl value was not default, then add it to the list of args.
-			if ((this.dockerRegistryUrl != default(string)))
-			{
-				genBeamCommandArgs.Add((("--docker-registry-url=\"" + this.dockerRegistryUrl)
-								+ "\""));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ServicesDeployWrapper ServicesDeploy(ServicesDeployArgs deployArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("services");
-			genBeamCommandArgs.Add("deploy");
-			genBeamCommandArgs.Add(deployArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ServicesDeployWrapper genBeamCommandWrapper = new ServicesDeployWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ServicesDeployWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ServicesDeployWrapper OnStreamServiceDeployReportResult(System.Action<ReportDataPoint<BeamServiceDeployReportResult>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-		public virtual ServicesDeployWrapper OnRemote_progressServiceRemoteDeployProgressResult(System.Action<ReportDataPoint<BeamServiceRemoteDeployProgressResult>> cb)
-		{
-			this.Command.On("remote_progress", cb);
-			return this;
-		}
-		public virtual ServicesDeployWrapper OnLogsServiceDeployLogResult(System.Action<ReportDataPoint<BeamServiceDeployLogResult>> cb)
-		{
-			this.Command.On("logs", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ServicesDeployArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>These are the ids for services you wish to be enabled once Beam-O receives the updated manifest</summary>
+        public string[] enable;
+        /// <summary>These are the ids for services you wish to be disabled once Beam-O receives the updated manifest</summary>
+        public string[] disable;
+        /// <summary>If this option is set to a valid path to a ServiceManifest JSON, deploys that instead</summary>
+        public string fromFile;
+        /// <summary>Associates this comment along with the published Manifest. You'll be able to read it via the Beamable Portal</summary>
+        public string comment;
+        /// <summary>Any number of strings in the format BeamoId::Comment
+        ///Associates each comment to the given Beamo Id if it's among the published services. You'll be able to read it via the Beamable Portal</summary>
+        public string[] serviceComments;
+        /// <summary>A custom docker registry url to use when uploading. By default, the result from the beamo/registry network call will be used, with minor string manipulation to add https scheme, remove port specificatino, and add /v2 </summary>
+        public string dockerRegistryUrl;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the enable value was not default, then add it to the list of args.
+            if ((this.enable != default(string[])))
+            {
+                for (int i = 0; (i < this.enable.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--enable=" + this.enable[i]));
+                }
+            }
+            // If the disable value was not default, then add it to the list of args.
+            if ((this.disable != default(string[])))
+            {
+                for (int i = 0; (i < this.disable.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--disable=" + this.disable[i]));
+                }
+            }
+            // If the fromFile value was not default, then add it to the list of args.
+            if ((this.fromFile != default(string)))
+            {
+                genBeamCommandArgs.Add((("--from-file=\"" + this.fromFile) 
+                                + "\""));
+            }
+            // If the comment value was not default, then add it to the list of args.
+            if ((this.comment != default(string)))
+            {
+                genBeamCommandArgs.Add((("--comment=\"" + this.comment) 
+                                + "\""));
+            }
+            // If the serviceComments value was not default, then add it to the list of args.
+            if ((this.serviceComments != default(string[])))
+            {
+                for (int i = 0; (i < this.serviceComments.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--service-comments=" + this.serviceComments[i]));
+                }
+            }
+            // If the dockerRegistryUrl value was not default, then add it to the list of args.
+            if ((this.dockerRegistryUrl != default(string)))
+            {
+                genBeamCommandArgs.Add((("--docker-registry-url=\"" + this.dockerRegistryUrl) 
+                                + "\""));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ServicesDeployWrapper ServicesDeploy(ServicesDeployArgs deployArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("services");
+            genBeamCommandArgs.Add("deploy");
+            genBeamCommandArgs.Add(deployArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ServicesDeployWrapper genBeamCommandWrapper = new ServicesDeployWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ServicesDeployWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ServicesDeployWrapper OnStreamServiceDeployReportResult(System.Action<ReportDataPoint<BeamServiceDeployReportResult>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+        public virtual ServicesDeployWrapper OnRemote_progressServiceRemoteDeployProgressResult(System.Action<ReportDataPoint<BeamServiceRemoteDeployProgressResult>> cb)
+        {
+            this.Command.On("remote_progress", cb);
+            return this;
+        }
+        public virtual ServicesDeployWrapper OnLogsServiceDeployLogResult(System.Action<ReportDataPoint<BeamServiceDeployLogResult>> cb)
+        {
+            this.Command.On("logs", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesManifests.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesManifests.cs
@@ -1,65 +1,65 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ServicesManifestsArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Limits amount of manifests</summary>
-		public int limit;
-		/// <summary>Skip specified amount of manifests</summary>
-		public int skip;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the limit value was not default, then add it to the list of args.
-			if ((this.limit != default(int)))
-			{
-				genBeamCommandArgs.Add(("--limit=" + this.limit));
-			}
-			// If the skip value was not default, then add it to the list of args.
-			if ((this.skip != default(int)))
-			{
-				genBeamCommandArgs.Add(("--skip=" + this.skip));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ServicesManifestsWrapper ServicesManifests(ServicesManifestsArgs manifestsArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("services");
-			genBeamCommandArgs.Add("manifests");
-			genBeamCommandArgs.Add(manifestsArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ServicesManifestsWrapper genBeamCommandWrapper = new ServicesManifestsWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ServicesManifestsWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ServicesManifestsWrapper OnStreamServiceManifestOutput(System.Action<ReportDataPoint<BeamServiceManifestOutput>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ServicesManifestsArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Limits amount of manifests</summary>
+        public int limit;
+        /// <summary>Skip specified amount of manifests</summary>
+        public int skip;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the limit value was not default, then add it to the list of args.
+            if ((this.limit != default(int)))
+            {
+                genBeamCommandArgs.Add(("--limit=" + this.limit));
+            }
+            // If the skip value was not default, then add it to the list of args.
+            if ((this.skip != default(int)))
+            {
+                genBeamCommandArgs.Add(("--skip=" + this.skip));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ServicesManifestsWrapper ServicesManifests(ServicesManifestsArgs manifestsArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("services");
+            genBeamCommandArgs.Add("manifests");
+            genBeamCommandArgs.Add(manifestsArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ServicesManifestsWrapper genBeamCommandWrapper = new ServicesManifestsWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ServicesManifestsWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ServicesManifestsWrapper OnStreamServiceManifestOutput(System.Action<ReportDataPoint<BeamServiceManifestOutput>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesPromote.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesPromote.cs
@@ -1,60 +1,60 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ServicesPromoteArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>The PID for the realm from which you wish to pull the manifest from. 
-		///The current realm you are signed into will be updated to match the manifest in the given realm</summary>
-		public string sourcePid;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the sourcePid value was not default, then add it to the list of args.
-			if ((this.sourcePid != default(string)))
-			{
-				genBeamCommandArgs.Add((("--source-pid=\"" + this.sourcePid)
-								+ "\""));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ServicesPromoteWrapper ServicesPromote(ServicesPromoteArgs promoteArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("services");
-			genBeamCommandArgs.Add("promote");
-			genBeamCommandArgs.Add(promoteArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ServicesPromoteWrapper genBeamCommandWrapper = new ServicesPromoteWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ServicesPromoteWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ServicesPromoteWrapper OnStreamManifestChecksums(System.Action<ReportDataPoint<BeamManifestChecksums>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ServicesPromoteArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>The PID for the realm from which you wish to pull the manifest from. 
+        ///The current realm you are signed into will be updated to match the manifest in the given realm</summary>
+        public string sourcePid;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the sourcePid value was not default, then add it to the list of args.
+            if ((this.sourcePid != default(string)))
+            {
+                genBeamCommandArgs.Add((("--source-pid=\"" + this.sourcePid) 
+                                + "\""));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ServicesPromoteWrapper ServicesPromote(ServicesPromoteArgs promoteArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("services");
+            genBeamCommandArgs.Add("promote");
+            genBeamCommandArgs.Add(promoteArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ServicesPromoteWrapper genBeamCommandWrapper = new ServicesPromoteWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ServicesPromoteWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ServicesPromoteWrapper OnStreamManifestChecksums(System.Action<ReportDataPoint<BeamManifestChecksums>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesPs.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesPs.cs
@@ -1,65 +1,65 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ServicesPsArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Makes it so that we output the current realm's remote manifest, instead of the local one</summary>
-		public bool remote;
-		/// <summary>Outputs as json instead of summary table</summary>
-		public bool json;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the remote value was not default, then add it to the list of args.
-			if ((this.remote != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--remote=" + this.remote));
-			}
-			// If the json value was not default, then add it to the list of args.
-			if ((this.json != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--json=" + this.json));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ServicesPsWrapper ServicesPs(ServicesPsArgs psArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("services");
-			genBeamCommandArgs.Add("ps");
-			genBeamCommandArgs.Add(psArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ServicesPsWrapper genBeamCommandWrapper = new ServicesPsWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ServicesPsWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ServicesPsWrapper OnStreamServiceListResult(System.Action<ReportDataPoint<BeamServiceListResult>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ServicesPsArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Makes it so that we output the current realm's remote manifest, instead of the local one</summary>
+        public bool remote;
+        /// <summary>Outputs as json instead of summary table</summary>
+        public bool json;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the remote value was not default, then add it to the list of args.
+            if ((this.remote != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--remote=" + this.remote));
+            }
+            // If the json value was not default, then add it to the list of args.
+            if ((this.json != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--json=" + this.json));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ServicesPsWrapper ServicesPs(ServicesPsArgs psArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("services");
+            genBeamCommandArgs.Add("ps");
+            genBeamCommandArgs.Add(psArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ServicesPsWrapper genBeamCommandWrapper = new ServicesPsWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ServicesPsWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ServicesPsWrapper OnStreamServiceListResult(System.Action<ReportDataPoint<BeamServiceListResult>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesRegistry.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesRegistry.cs
@@ -1,50 +1,50 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ServicesRegistryArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ServicesRegistryWrapper ServicesRegistry()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("services");
-			genBeamCommandArgs.Add("registry");
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ServicesRegistryWrapper genBeamCommandWrapper = new ServicesRegistryWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ServicesRegistryWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ServicesRegistryWrapper OnStreamServicesRegistryOutput(System.Action<ReportDataPoint<BeamServicesRegistryOutput>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ServicesRegistryArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ServicesRegistryWrapper ServicesRegistry()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("services");
+            genBeamCommandArgs.Add("registry");
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ServicesRegistryWrapper genBeamCommandWrapper = new ServicesRegistryWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ServicesRegistryWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ServicesRegistryWrapper OnStreamServicesRegistryOutput(System.Action<ReportDataPoint<BeamServicesRegistryOutput>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesRegistryOutput.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesRegistryOutput.cs
@@ -1,12 +1,12 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamServicesRegistryOutput
-	{
-		public string registryUrl;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamServicesRegistryOutput
+    {
+        public string registryUrl;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesReset.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesReset.cs
@@ -1,68 +1,68 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ServicesResetArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Either image|container|protocols.'image' will cleanup all your locally built images for the selected Beamo Services.
-		///'container' will stop all your locally running containers for the selected Beamo Services.
-		///'protocols' will reset all the protocol data for the selected Beamo Services back to default parameters</summary>
-		public string target;
-		/// <summary>The ids for the services you wish to reset</summary>
-		public string[] ids;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// Add the target value to the list of args.
-			genBeamCommandArgs.Add(this.target.ToString());
-			// If the ids value was not default, then add it to the list of args.
-			if ((this.ids != default(string[])))
-			{
-				for (int i = 0; (i < this.ids.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--ids=" + this.ids[i]));
-				}
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ServicesResetWrapper ServicesReset(ServicesResetArgs resetArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("services");
-			genBeamCommandArgs.Add("reset");
-			genBeamCommandArgs.Add(resetArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ServicesResetWrapper genBeamCommandWrapper = new ServicesResetWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ServicesResetWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ServicesResetWrapper OnStreamServicesResetResult(System.Action<ReportDataPoint<BeamServicesResetResult>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ServicesResetArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Either image|container|protocols.'image' will cleanup all your locally built images for the selected Beamo Services.
+        ///'container' will stop all your locally running containers for the selected Beamo Services.
+        ///'protocols' will reset all the protocol data for the selected Beamo Services back to default parameters</summary>
+        public string target;
+        /// <summary>The ids for the services you wish to reset</summary>
+        public string[] ids;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // Add the target value to the list of args.
+            genBeamCommandArgs.Add(this.target.ToString());
+            // If the ids value was not default, then add it to the list of args.
+            if ((this.ids != default(string[])))
+            {
+                for (int i = 0; (i < this.ids.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--ids=" + this.ids[i]));
+                }
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ServicesResetWrapper ServicesReset(ServicesResetArgs resetArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("services");
+            genBeamCommandArgs.Add("reset");
+            genBeamCommandArgs.Add(resetArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ServicesResetWrapper genBeamCommandWrapper = new ServicesResetWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ServicesResetWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ServicesResetWrapper OnStreamServicesResetResult(System.Action<ReportDataPoint<BeamServicesResetResult>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesResetResult.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesResetResult.cs
@@ -1,13 +1,13 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamServicesResetResult
-	{
-		public string Target;
-		public System.Collections.Generic.List<string> Ids;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamServicesResetResult
+    {
+        public string Target;
+        public System.Collections.Generic.List<string> Ids;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesRun.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesRun.cs
@@ -1,74 +1,74 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ServicesRunArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>The ids for the services you wish to deploy. Ignoring this option deploys all services</summary>
-		public string[] ids;
-		/// <summary>Force the services to run with amd64 CPU architecture, useful when deploying from computers with ARM architecture</summary>
-		public bool forceAmdCpuArch;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the ids value was not default, then add it to the list of args.
-			if ((this.ids != default(string[])))
-			{
-				for (int i = 0; (i < this.ids.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--ids=" + this.ids[i]));
-				}
-			}
-			// If the forceAmdCpuArch value was not default, then add it to the list of args.
-			if ((this.forceAmdCpuArch != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--force-amd-cpu-arch=" + this.forceAmdCpuArch));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ServicesRunWrapper ServicesRun(ServicesRunArgs runArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("services");
-			genBeamCommandArgs.Add("run");
-			genBeamCommandArgs.Add(runArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ServicesRunWrapper genBeamCommandWrapper = new ServicesRunWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ServicesRunWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ServicesRunWrapper OnStreamServiceRunReportResult(System.Action<ReportDataPoint<BeamServiceRunReportResult>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-		public virtual ServicesRunWrapper OnLocal_progressServiceRunProgressResult(System.Action<ReportDataPoint<BeamServiceRunProgressResult>> cb)
-		{
-			this.Command.On("local_progress", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ServicesRunArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>The ids for the services you wish to deploy. Ignoring this option deploys all services</summary>
+        public string[] ids;
+        /// <summary>Force the services to run with amd64 CPU architecture, useful when deploying from computers with ARM architecture</summary>
+        public bool forceAmdCpuArch;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the ids value was not default, then add it to the list of args.
+            if ((this.ids != default(string[])))
+            {
+                for (int i = 0; (i < this.ids.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--ids=" + this.ids[i]));
+                }
+            }
+            // If the forceAmdCpuArch value was not default, then add it to the list of args.
+            if ((this.forceAmdCpuArch != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--force-amd-cpu-arch=" + this.forceAmdCpuArch));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ServicesRunWrapper ServicesRun(ServicesRunArgs runArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("services");
+            genBeamCommandArgs.Add("run");
+            genBeamCommandArgs.Add(runArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ServicesRunWrapper genBeamCommandWrapper = new ServicesRunWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ServicesRunWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ServicesRunWrapper OnStreamServiceRunReportResult(System.Action<ReportDataPoint<BeamServiceRunReportResult>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+        public virtual ServicesRunWrapper OnLocal_progressServiceRunProgressResult(System.Action<ReportDataPoint<BeamServiceRunProgressResult>> cb)
+        {
+            this.Command.On("local_progress", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesServiceLogs.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesServiceLogs.cs
@@ -1,59 +1,59 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ServicesServiceLogsArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>The Unique Id for this service within this Beamable CLI context</summary>
-		public string id;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the id value was not default, then add it to the list of args.
-			if ((this.id != default(string)))
-			{
-				genBeamCommandArgs.Add((("--id=\"" + this.id)
-								+ "\""));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ServicesServiceLogsWrapper ServicesServiceLogs(ServicesServiceLogsArgs serviceLogsArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("services");
-			genBeamCommandArgs.Add("service-logs");
-			genBeamCommandArgs.Add(serviceLogsArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ServicesServiceLogsWrapper genBeamCommandWrapper = new ServicesServiceLogsWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ServicesServiceLogsWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ServicesServiceLogsWrapper OnStreamGetSignedUrlResponse(System.Action<ReportDataPoint<BeamGetSignedUrlResponse>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ServicesServiceLogsArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>The Unique Id for this service within this Beamable CLI context</summary>
+        public string id;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the id value was not default, then add it to the list of args.
+            if ((this.id != default(string)))
+            {
+                genBeamCommandArgs.Add((("--id=\"" + this.id) 
+                                + "\""));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ServicesServiceLogsWrapper ServicesServiceLogs(ServicesServiceLogsArgs serviceLogsArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("services");
+            genBeamCommandArgs.Add("service-logs");
+            genBeamCommandArgs.Add(serviceLogsArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ServicesServiceLogsWrapper genBeamCommandWrapper = new ServicesServiceLogsWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ServicesServiceLogsWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ServicesServiceLogsWrapper OnStreamGetSignedUrlResponse(System.Action<ReportDataPoint<BeamGetSignedUrlResponse>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesServiceMetrics.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesServiceMetrics.cs
@@ -1,67 +1,67 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ServicesServiceMetricsArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>The Unique Id for this service within this Beamable CLI context</summary>
-		public string id;
-		/// <summary>Set to 'cpu' or 'memory'</summary>
-		public string metric;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the id value was not default, then add it to the list of args.
-			if ((this.id != default(string)))
-			{
-				genBeamCommandArgs.Add((("--id=\"" + this.id)
-								+ "\""));
-			}
-			// If the metric value was not default, then add it to the list of args.
-			if ((this.metric != default(string)))
-			{
-				genBeamCommandArgs.Add((("--metric=\"" + this.metric)
-								+ "\""));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ServicesServiceMetricsWrapper ServicesServiceMetrics(ServicesServiceMetricsArgs serviceMetricsArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("services");
-			genBeamCommandArgs.Add("service-metrics");
-			genBeamCommandArgs.Add(serviceMetricsArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ServicesServiceMetricsWrapper genBeamCommandWrapper = new ServicesServiceMetricsWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ServicesServiceMetricsWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ServicesServiceMetricsWrapper OnStreamGetSignedUrlResponse(System.Action<ReportDataPoint<BeamGetSignedUrlResponse>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ServicesServiceMetricsArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>The Unique Id for this service within this Beamable CLI context</summary>
+        public string id;
+        /// <summary>Set to 'cpu' or 'memory'</summary>
+        public string metric;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the id value was not default, then add it to the list of args.
+            if ((this.id != default(string)))
+            {
+                genBeamCommandArgs.Add((("--id=\"" + this.id) 
+                                + "\""));
+            }
+            // If the metric value was not default, then add it to the list of args.
+            if ((this.metric != default(string)))
+            {
+                genBeamCommandArgs.Add((("--metric=\"" + this.metric) 
+                                + "\""));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ServicesServiceMetricsWrapper ServicesServiceMetrics(ServicesServiceMetricsArgs serviceMetricsArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("services");
+            genBeamCommandArgs.Add("service-metrics");
+            genBeamCommandArgs.Add(serviceMetricsArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ServicesServiceMetricsWrapper genBeamCommandWrapper = new ServicesServiceMetricsWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ServicesServiceMetricsWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ServicesServiceMetricsWrapper OnStreamGetSignedUrlResponse(System.Action<ReportDataPoint<BeamGetSignedUrlResponse>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesSetLocalManifest.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesSetLocalManifest.cs
@@ -1,90 +1,90 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ServicesSetLocalManifestArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Local http services paths</summary>
-		public string[] services;
-		/// <summary>Local storages paths</summary>
-		public string[] storagePaths;
-		/// <summary>Local storages names</summary>
-		public string[] storageNames;
-		/// <summary>Names of the services that should be disabled on remote</summary>
-		public string[] disabledServices;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the services value was not default, then add it to the list of args.
-			if ((this.services != default(string[])))
-			{
-				for (int i = 0; (i < this.services.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--services=" + this.services[i]));
-				}
-			}
-			// If the storagePaths value was not default, then add it to the list of args.
-			if ((this.storagePaths != default(string[])))
-			{
-				for (int i = 0; (i < this.storagePaths.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--storage-paths=" + this.storagePaths[i]));
-				}
-			}
-			// If the storageNames value was not default, then add it to the list of args.
-			if ((this.storageNames != default(string[])))
-			{
-				for (int i = 0; (i < this.storageNames.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--storage-names=" + this.storageNames[i]));
-				}
-			}
-			// If the disabledServices value was not default, then add it to the list of args.
-			if ((this.disabledServices != default(string[])))
-			{
-				for (int i = 0; (i < this.disabledServices.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--disabled-services=" + this.disabledServices[i]));
-				}
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ServicesSetLocalManifestWrapper ServicesSetLocalManifest(ServicesSetLocalManifestArgs setLocalManifestArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("services");
-			genBeamCommandArgs.Add("set-local-manifest");
-			genBeamCommandArgs.Add(setLocalManifestArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ServicesSetLocalManifestWrapper genBeamCommandWrapper = new ServicesSetLocalManifestWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ServicesSetLocalManifestWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ServicesSetLocalManifestArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Local http services paths</summary>
+        public string[] services;
+        /// <summary>Local storages paths</summary>
+        public string[] storagePaths;
+        /// <summary>Local storages names</summary>
+        public string[] storageNames;
+        /// <summary>Names of the services that should be disabled on remote</summary>
+        public string[] disabledServices;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the services value was not default, then add it to the list of args.
+            if ((this.services != default(string[])))
+            {
+                for (int i = 0; (i < this.services.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--services=" + this.services[i]));
+                }
+            }
+            // If the storagePaths value was not default, then add it to the list of args.
+            if ((this.storagePaths != default(string[])))
+            {
+                for (int i = 0; (i < this.storagePaths.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--storage-paths=" + this.storagePaths[i]));
+                }
+            }
+            // If the storageNames value was not default, then add it to the list of args.
+            if ((this.storageNames != default(string[])))
+            {
+                for (int i = 0; (i < this.storageNames.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--storage-names=" + this.storageNames[i]));
+                }
+            }
+            // If the disabledServices value was not default, then add it to the list of args.
+            if ((this.disabledServices != default(string[])))
+            {
+                for (int i = 0; (i < this.disabledServices.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--disabled-services=" + this.disabledServices[i]));
+                }
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ServicesSetLocalManifestWrapper ServicesSetLocalManifest(ServicesSetLocalManifestArgs setLocalManifestArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("services");
+            genBeamCommandArgs.Add("set-local-manifest");
+            genBeamCommandArgs.Add(setLocalManifestArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ServicesSetLocalManifestWrapper genBeamCommandWrapper = new ServicesSetLocalManifestWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ServicesSetLocalManifestWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesStop.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesStop.cs
@@ -1,57 +1,57 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ServicesStopArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>The ids for the services you wish to stop</summary>
-		public string[] ids;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// If the ids value was not default, then add it to the list of args.
-			if ((this.ids != default(string[])))
-			{
-				for (int i = 0; (i < this.ids.Length); i = (i + 1))
-				{
-					// The parameter allows multiple values
-					genBeamCommandArgs.Add(("--ids=" + this.ids[i]));
-				}
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ServicesStopWrapper ServicesStop(ServicesStopArgs stopArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("services");
-			genBeamCommandArgs.Add("stop");
-			genBeamCommandArgs.Add(stopArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ServicesStopWrapper genBeamCommandWrapper = new ServicesStopWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ServicesStopWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ServicesStopArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>The ids for the services you wish to stop</summary>
+        public string[] ids;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the ids value was not default, then add it to the list of args.
+            if ((this.ids != default(string[])))
+            {
+                for (int i = 0; (i < this.ids.Length); i = (i + 1))
+                {
+                    // The parameter allows multiple values
+                    genBeamCommandArgs.Add(("--ids=" + this.ids[i]));
+                }
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ServicesStopWrapper ServicesStop(ServicesStopArgs stopArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("services");
+            genBeamCommandArgs.Add("stop");
+            genBeamCommandArgs.Add(stopArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ServicesStopWrapper genBeamCommandWrapper = new ServicesStopWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ServicesStopWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesTemplates.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesTemplates.cs
@@ -1,50 +1,50 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ServicesTemplatesArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ServicesTemplatesWrapper ServicesTemplates()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("services");
-			genBeamCommandArgs.Add("templates");
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ServicesTemplatesWrapper genBeamCommandWrapper = new ServicesTemplatesWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ServicesTemplatesWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ServicesTemplatesWrapper OnStreamServicesTemplatesCommandOutput(System.Action<ReportDataPoint<BeamServicesTemplatesCommandOutput>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ServicesTemplatesArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ServicesTemplatesWrapper ServicesTemplates()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("services");
+            genBeamCommandArgs.Add("templates");
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ServicesTemplatesWrapper genBeamCommandWrapper = new ServicesTemplatesWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ServicesTemplatesWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ServicesTemplatesWrapper OnStreamServicesTemplatesCommandOutput(System.Action<ReportDataPoint<BeamServicesTemplatesCommandOutput>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesTemplatesCommandOutput.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesTemplatesCommandOutput.cs
@@ -1,12 +1,12 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamServicesTemplatesCommandOutput
-	{
-		public System.Collections.Generic.List<BeamServiceTemplate> templates;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamServicesTemplatesCommandOutput
+    {
+        public System.Collections.Generic.List<BeamServiceTemplate> templates;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesUploadApi.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesUploadApi.cs
@@ -1,50 +1,50 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class ServicesUploadApiArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual ServicesUploadApiWrapper ServicesUploadApi()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("services");
-			genBeamCommandArgs.Add("upload-api");
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			ServicesUploadApiWrapper genBeamCommandWrapper = new ServicesUploadApiWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class ServicesUploadApiWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual ServicesUploadApiWrapper OnStreamServicesUploadApiOutput(System.Action<ReportDataPoint<BeamServicesUploadApiOutput>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ServicesUploadApiArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ServicesUploadApiWrapper ServicesUploadApi()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("services");
+            genBeamCommandArgs.Add("upload-api");
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ServicesUploadApiWrapper genBeamCommandWrapper = new ServicesUploadApiWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ServicesUploadApiWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ServicesUploadApiWrapper OnStreamServicesUploadApiOutput(System.Action<ReportDataPoint<BeamServicesUploadApiOutput>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesUploadApiOutput.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesUploadApiOutput.cs
@@ -1,12 +1,12 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamServicesUploadApiOutput
-	{
-		public string uploadUrl;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamServicesUploadApiOutput
+    {
+        public string uploadUrl;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamStopProjectCommandOutput.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamStopProjectCommandOutput.cs
@@ -1,13 +1,13 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamStopProjectCommandOutput
-	{
-		public string serviceName;
-		public bool didStop;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamStopProjectCommandOutput
+    {
+        public string serviceName;
+        public bool didStop;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamTailLogMessageForClient.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamTailLogMessageForClient.cs
@@ -1,15 +1,15 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamTailLogMessageForClient
-	{
-		public string raw;
-		public string logLevel;
-		public string message;
-		public string timeStamp;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamTailLogMessageForClient
+    {
+        public string raw;
+        public string logLevel;
+        public string message;
+        public string timeStamp;
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamVersion.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamVersion.cs
@@ -1,49 +1,49 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class VersionArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual VersionWrapper Version()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("version");
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			VersionWrapper genBeamCommandWrapper = new VersionWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class VersionWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual VersionWrapper OnStreamVersionResults(System.Action<ReportDataPoint<BeamVersionResults>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class VersionArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual VersionWrapper Version()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("version");
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            VersionWrapper genBeamCommandWrapper = new VersionWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class VersionWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual VersionWrapper OnStreamVersionResults(System.Action<ReportDataPoint<BeamVersionResults>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamVersionConstruct.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamVersionConstruct.cs
@@ -1,98 +1,98 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	public class VersionConstructArgs : Beamable.Common.BeamCli.IBeamCommandArgs
-	{
-		/// <summary>The major semantic version number</summary>
-		public int major;
-		/// <summary>The minor semantic version number</summary>
-		public int minor;
-		/// <summary>The patch semantic version number</summary>
-		public int patch;
-		/// <summary>When true, the command will return a non zero exit code if the specified version already exists on Nuget</summary>
-		public bool validate;
-		/// <summary>Sets the version string to a nightly version number, and will include the date string automatically</summary>
-		public bool nightly;
-		/// <summary>Sets the version string to a release candidate version number</summary>
-		public int rc;
-		/// <summary>Sets the version string to an experimental version number</summary>
-		public int exp;
-		/// <summary>Sets the version string to a production version number</summary>
-		public bool prod;
-		/// <summary>Serializes the arguments for command line usage.</summary>
-		public virtual string Serialize()
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			// Add the major value to the list of args.
-			genBeamCommandArgs.Add(this.major.ToString());
-			// Add the minor value to the list of args.
-			genBeamCommandArgs.Add(this.minor.ToString());
-			// Add the patch value to the list of args.
-			genBeamCommandArgs.Add(this.patch.ToString());
-			// If the validate value was not default, then add it to the list of args.
-			if ((this.validate != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--validate=" + this.validate));
-			}
-			// If the nightly value was not default, then add it to the list of args.
-			if ((this.nightly != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--nightly=" + this.nightly));
-			}
-			// If the rc value was not default, then add it to the list of args.
-			if ((this.rc != default(int)))
-			{
-				genBeamCommandArgs.Add(("--rc=" + this.rc));
-			}
-			// If the exp value was not default, then add it to the list of args.
-			if ((this.exp != default(int)))
-			{
-				genBeamCommandArgs.Add(("--exp=" + this.exp));
-			}
-			// If the prod value was not default, then add it to the list of args.
-			if ((this.prod != default(bool)))
-			{
-				genBeamCommandArgs.Add(("--prod=" + this.prod));
-			}
-			string genBeamCommandStr = "";
-			// Join all the args with spaces
-			genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			return genBeamCommandStr;
-		}
-	}
-	public partial class BeamCommands
-	{
-		public virtual VersionConstructWrapper VersionConstruct(VersionConstructArgs constructArgs)
-		{
-			// Create a list of arguments for the command
-			System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
-			genBeamCommandArgs.Add("beam");
-			genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
-			genBeamCommandArgs.Add("version");
-			genBeamCommandArgs.Add("construct");
-			genBeamCommandArgs.Add(constructArgs.Serialize());
-			// Create an instance of an IBeamCommand
-			Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
-			// Join all the command paths and args into one string
-			string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
-			// Configure the command with the command string
-			command.SetCommand(genBeamCommandStr);
-			VersionConstructWrapper genBeamCommandWrapper = new VersionConstructWrapper();
-			genBeamCommandWrapper.Command = command;
-			// Return the command!
-			return genBeamCommandWrapper;
-		}
-	}
-	public class VersionConstructWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
-	{
-		public virtual VersionConstructWrapper OnStreamConstructVersionOutput(System.Action<ReportDataPoint<BeamConstructVersionOutput>> cb)
-		{
-			this.Command.On("stream", cb);
-			return this;
-		}
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class VersionConstructArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>The major semantic version number</summary>
+        public int major;
+        /// <summary>The minor semantic version number</summary>
+        public int minor;
+        /// <summary>The patch semantic version number</summary>
+        public int patch;
+        /// <summary>When true, the command will return a non zero exit code if the specified version already exists on Nuget</summary>
+        public bool validate;
+        /// <summary>Sets the version string to a nightly version number, and will include the date string automatically</summary>
+        public bool nightly;
+        /// <summary>Sets the version string to a release candidate version number</summary>
+        public int rc;
+        /// <summary>Sets the version string to an experimental version number</summary>
+        public int exp;
+        /// <summary>Sets the version string to a production version number</summary>
+        public bool prod;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // Add the major value to the list of args.
+            genBeamCommandArgs.Add(this.major.ToString());
+            // Add the minor value to the list of args.
+            genBeamCommandArgs.Add(this.minor.ToString());
+            // Add the patch value to the list of args.
+            genBeamCommandArgs.Add(this.patch.ToString());
+            // If the validate value was not default, then add it to the list of args.
+            if ((this.validate != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--validate=" + this.validate));
+            }
+            // If the nightly value was not default, then add it to the list of args.
+            if ((this.nightly != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--nightly=" + this.nightly));
+            }
+            // If the rc value was not default, then add it to the list of args.
+            if ((this.rc != default(int)))
+            {
+                genBeamCommandArgs.Add(("--rc=" + this.rc));
+            }
+            // If the exp value was not default, then add it to the list of args.
+            if ((this.exp != default(int)))
+            {
+                genBeamCommandArgs.Add(("--exp=" + this.exp));
+            }
+            // If the prod value was not default, then add it to the list of args.
+            if ((this.prod != default(bool)))
+            {
+                genBeamCommandArgs.Add(("--prod=" + this.prod));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual VersionConstructWrapper VersionConstruct(VersionConstructArgs constructArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("version");
+            genBeamCommandArgs.Add("construct");
+            genBeamCommandArgs.Add(constructArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            VersionConstructWrapper genBeamCommandWrapper = new VersionConstructWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class VersionConstructWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual VersionConstructWrapper OnStreamConstructVersionOutput(System.Action<ReportDataPoint<BeamConstructVersionOutput>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
 }

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamVersionResults.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamVersionResults.cs
@@ -1,15 +1,15 @@
 
 namespace Beamable.Editor.BeamCli.Commands
 {
-	using Beamable.Common;
-	using Beamable.Common.BeamCli;
-
-	[System.SerializableAttribute()]
-	public class BeamVersionResults
-	{
-		public string version;
-		public string location;
-		public string type;
-		public string templates;
-	}
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamVersionResults
+    {
+        public string version;
+        public string location;
+        public string type;
+        public string templates;
+    }
 }


### PR DESCRIPTION
# Ticket

resolves #3178 

# Brief Description

This PR contains two changes:

1. Add the filter `--non-beamo` to `beam project deps list` in order to list only libraries that are not beamo services/storages;
2. Go through those libraries in Unity's `SolutionPostProcessor` and write in Unity's sln file so we track those projects as well.

# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
