### PR TITLE
fixes 3176 - use separate location for baked content

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disabling Content inspectors no longer causes compiler errors.
 - Leaderboard `rankgt` field is not null when specifying outlier.
 - Fix renaming content throwing infinite warnings
+- Content cache evicts old content for new content id versions
 
 ### Removed
 

--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cid and Pid are stored in `Beam.GlobalScope`
 - Dotnet is automatically installed to the project's /Library folder
 - Beam CLI is automatically installed to the project's /Library folder
+- Baked content exists in a separate memory location than the deserialized `content.json` CDN cache
 
 ### Fixed
 

--- a/client/Packages/com.beamable/Common/Runtime/Content/ContentDataInfo.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Content/ContentDataInfo.cs
@@ -1,18 +1,135 @@
+using Beamable.Common.Content.Serialization;
+using Beamable.Common.Spew;
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace Beamable.Common.Content
 {
 	[Serializable]
 	public class ContentDataInfo
 	{
+		private static readonly ClientContentSerializer _serializer = new ClientContentSerializer();
+		
 		public string contentId;
 		public string data;
+		
+		/// <summary>
+		/// Added in 1.19.17; so may be absent from earlier records.
+		/// To safely access this property, please use <see cref="GetContentVersion"/>
+		/// </summary>
+		[SerializeField]
+		public string contentVersion;
+
+		public string GetContentVersion()
+		{
+			if (!string.IsNullOrEmpty(contentVersion))
+			{
+				// hooray, there is a content version hanging out we can use without needing to work for it.
+				return contentVersion;
+			}
+			
+			// because the contentVersion field was added late, it may be blank, so we need to retrieve it
+			//  from the internal data structure.
+			var content = _serializer.Deserialize<ContentObject>(data, true);
+			contentVersion = content.Version;
+			return contentVersion;
+		}
 	}
 
 	[Serializable]
-	public class ContentDataInfoWrapper
+	public class ContentDataInfoWrapper : ISerializationCallbackReceiver
 	{
+		/// <summary>
+		/// Member holding the serialized content. However,
+		/// instead of writing/reading from this, please use
+		/// <see cref="TryGetContent"/>, and <see cref="UpdateContentInfo"/>
+		/// </summary>
 		public List<ContentDataInfo> content = new List<ContentDataInfo>();
+
+		[NonSerialized]
+		public Dictionary<string, ContentDataInfo> KeyToContentData = new Dictionary<string, ContentDataInfo>();
+
+		public static string GetCacheKey(string contentId, string contentVersion) => contentId + contentVersion;
+
+		/// <summary>
+		/// Retrieve raw content data from the collection
+		/// </summary>
+		/// <param name="contentId"></param>
+		/// <param name="version"></param>
+		/// <param name="contentInfo"></param>
+		/// <returns></returns>
+		public bool TryGetContent(string contentId, string version, out ContentDataInfo contentInfo)
+		{
+			var key = GetCacheKey(contentId, version);
+			return KeyToContentData.TryGetValue(key, out contentInfo);
+		} 
+		
+		public bool TryUpdateContent(ClientContentInfo info, string raw)
+		{
+			// we only need one entry per content-id, and we'll save the latest version of it. 
+			var key = GetCacheKey(info.contentId, info.version);
+
+			if (KeyToContentData.ContainsKey(key))
+			{
+				// the version is the same, and this content does not need to be updated.
+				return false;
+			}
+			else
+			{
+				// but much more likely, this acts as more of a NEW content write,
+				var newItem = KeyToContentData[key] = new ContentDataInfo
+				{
+					data = raw, contentVersion = info.version, contentId = info.contentId
+				};
+				
+				// and we need to add it to the actual serialized data
+				content.Add(newItem);
+				return true;
+			}
+		}
+		
+		public void OnBeforeSerialize()
+		{
+			content ??= new List<ContentDataInfo>();
+
+			// we need to evict old files. 
+			//  since new content is always added to the end,
+			//  we'll evict any content with a repeat content-id
+			//  going from back to front.
+			var seen = new HashSet<string>();
+			var startSize = content.Count;
+			for (var i = content.Count - 1; i >= 0; i--)
+			{
+				var info = content[i];
+				if (seen.Contains(info.contentId))
+				{
+					// because we are going backwards through the list, we 
+					//  can safely delete entries as we go and avoid concurrent modification
+					content.RemoveAt(i);
+				}
+
+				seen.Add(info.contentId);
+			}
+			var endSize = content.Count;
+			PlatformLogger.Log($"Content Data Info: Before serializing, removed {startSize - endSize} entries.");
+		}
+
+		public void OnAfterDeserialize()
+		{
+			KeyToContentData.Clear();
+			content ??= new List<ContentDataInfo>();
+
+			// iterate through the content backwards, because
+			//  we'll find the latest content first, since new content 
+			//  was always appended to the end of the list in pre 1.19.17 versions
+			for (var i = content.Count - 1; i >= 0 ; i -- )
+			{
+				var info = content[i];
+				var key = GetCacheKey(info.contentId, info.GetContentVersion());
+
+				KeyToContentData[key] = info;
+			}
+		}
 	}
 }

--- a/client/Packages/com.beamable/Common/Runtime/Content/ContentDataInfo.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Content/ContentDataInfo.cs
@@ -80,7 +80,9 @@ namespace Beamable.Common.Content
 				// but much more likely, this acts as more of a NEW content write,
 				var newItem = KeyToContentData[key] = new ContentDataInfo
 				{
-					data = raw, contentVersion = info.version, contentId = info.contentId
+					data = raw, 
+					contentVersion = info.version, 
+					contentId = info.contentId
 				};
 				
 				// and we need to add it to the actual serialized data
@@ -120,14 +122,9 @@ namespace Beamable.Common.Content
 			KeyToContentData.Clear();
 			content ??= new List<ContentDataInfo>();
 
-			// iterate through the content backwards, because
-			//  we'll find the latest content first, since new content 
-			//  was always appended to the end of the list in pre 1.19.17 versions
-			for (var i = content.Count - 1; i >= 0 ; i -- )
+			foreach (var info in content)
 			{
-				var info = content[i];
 				var key = GetCacheKey(info.contentId, info.GetContentVersion());
-
 				KeyToContentData[key] = info;
 			}
 		}

--- a/client/Packages/com.beamable/Editor/Modules/Content/ContentDownloader.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/ContentDownloader.cs
@@ -38,8 +38,7 @@ namespace Beamable.Editor.Content
 			var contentTypeReflectionCache = BeamEditor.GetReflectionSystem<ContentTypeReflectionCache>();
 			bool disableExceptions = ContentConfiguration.Instance.DisableContentDownloadExceptions;
 
-			var entries = summary.GetAllDownloadEntries();
-			var downloadPromiseGenerators = entries.Select(operation =>
+			var downloadPromiseGenerators = summary.GetAllDownloadEntries().Select(operation =>
 			{
 				var type = operation.ContentId.Split('.')[0];
 				if (!contentTypeReflectionCache.HasContentTypeValidClass(type))
@@ -48,9 +47,8 @@ namespace Beamable.Editor.Content
 					return null;
 				}
 
-				return new Func<Promise<Tuple<ContentObject, string>>>(async () =>
+				return new Func<Promise<Tuple<ContentObject, string>>>(() => FetchContentFromCDN(operation.Uri).Map(response =>
 				{
-					var response = await FetchContentFromCDN(operation.Uri);
 					var contentType = contentTypeReflectionCache.GetTypeFromId(operation.ContentId);
 					var newAsset = serializer.DeserializeByType(response, contentType, disableExceptions);
 					newAsset.Tags = operation.Tags;
@@ -63,8 +61,7 @@ namespace Beamable.Editor.Content
 					progressCallback?.Invoke(completed / totalOperations, (int)completed, totalOperations);
 
 					return new Tuple<ContentObject, string>(newAsset, operation.AssetPath);
-				
-				});
+				}));
 			}).ToList();
 
 			downloadPromiseGenerators.RemoveAll(item => item == null);
@@ -83,17 +80,9 @@ namespace Beamable.Editor.Content
 
 		}
 
-		private async Promise<string> FetchContentFromCDN(string uri)
+		private Promise<string> FetchContentFromCDN(string uri)
 		{
-			try
-			{
-				return await _requester.Request(Method.GET, uri, includeAuthHeader: false, parser: s => s);
-			}
-			catch (Exception ex)
-			{
-				Debug.LogException(ex);
-				throw;
-			}
+			return _requester.Request(Method.GET, uri, includeAuthHeader: false, parser: s => s);
 		}
 	}
 

--- a/client/Packages/com.beamable/Editor/Modules/Content/ContentIO.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/ContentIO.cs
@@ -1169,7 +1169,12 @@ namespace Beamable.Editor.Content
 
 				var version = serverReference.version;
 				content.SetIdAndVersion(content.Id, version);
-				contentData[i] = new ContentDataInfo { contentId = content.Id, data = content.ToJson() };
+				contentData[i] = new ContentDataInfo
+				{
+					contentId = content.Id, 
+					contentVersion = content.Version,
+					data = content.ToJson()
+				};
 			}
 
 			ContentDataInfoWrapper fileData = new ContentDataInfoWrapper { content = contentData.ToList() };

--- a/client/Packages/com.beamable/Runtime/Modules/Content/ContentCache.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/Content/ContentCache.cs
@@ -142,7 +142,17 @@ namespace Beamable.Content
 				return false;
 			}
 
-			content = DeserializeContent(info, existingInfo.data);
+			try
+			{
+				content = DeserializeContent(info, existingInfo.data);
+			}
+			catch (Exception ex)
+			{
+				PlatformLogger.Log(
+					$"ContentCache: Unable to deserialize content type correctly {info.contentId}: version: {info.version} message: {ex.Message}");
+				return false;
+			}
+
 			return true;
 		}
 

--- a/client/Packages/com.beamable/Runtime/Modules/Content/ContentService.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/Content/ContentService.cs
@@ -207,13 +207,13 @@ namespace Beamable.Content
 		/// <summary>
 		/// Member holds all content that has been cached as a result of fetching new content
 		/// </summary>
-		public ContentDataInfoWrapper CachedContentDataInfo;
+		public ContentDataInfoWrapper CachedContentDataInfo = new ContentDataInfoWrapper();
 		
 		/// <summary>
 		/// Member holds all content that was baked into the current build
 		/// To resolve content, please use the <see cref="GetContent(string,string)"/> method.
 		/// </summary>
-		public ContentDataInfoWrapper BakedContentDataInfo;
+		public ContentDataInfoWrapper BakedContentDataInfo = new ContentDataInfoWrapper();
 
 		private Dictionary<string, ClientContentInfo> bakedManifestInfo =
 			new Dictionary<string, ClientContentInfo>();
@@ -359,9 +359,6 @@ namespace Beamable.Content
 			}
 			bool contentDataExists = File.Exists(contentPath);
 
-			// initialize the cached content as empty to begin, 
-			CachedContentDataInfo = new ContentDataInfoWrapper();
-			
 			// but if there is local file content, then scoop it up!
 			if (contentDataExists)
 			{

--- a/client/Packages/com.beamable/Runtime/Modules/Content/ContentService.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/Content/ContentService.cs
@@ -205,11 +205,15 @@ namespace Beamable.Content
 		private static bool _testScopeEnabled;
 
 		/// <summary>
-		/// A utility used during Content Baking.
-		/// This field should not be used in regular use.
+		/// Member holds all content that has been cached as a result of fetching new content
+		/// </summary>
+		public ContentDataInfoWrapper CachedContentDataInfo;
+		
+		/// <summary>
+		/// Member holds all content that was baked into the current build
 		/// To resolve content, please use the <see cref="GetContent(string,string)"/> method.
 		/// </summary>
-		public ContentDataInfoWrapper ContentDataInfo;
+		public ContentDataInfoWrapper BakedContentDataInfo;
 
 		private Dictionary<string, ClientContentInfo> bakedManifestInfo =
 			new Dictionary<string, ClientContentInfo>();
@@ -275,8 +279,9 @@ namespace Beamable.Content
 			});
 
 
-			InitializeBakedContent();
+			InitializeCachedContent();
 			InitializeBakedManifest();
+			BakedContentDataInfo = LoadBakedContent();
 
 			Subscribables = new Dictionary<string, ManifestSubscription>();
 			AddSubscriber(CurrentDefaultManifestID);
@@ -295,11 +300,50 @@ namespace Beamable.Content
 			}
 		}
 
-		private void InitializeBakedContent()
+		/// <summary>
+		/// Build the path string using a file system accessor and the PID.
+		/// </summary>
+		/// <param name="fsa">The file system accessor that it's being used for content.</param>
+		/// <returns>eturns the path where the content cache data is stored.</returns>
+		public static string ContentPath(IBeamableFilesystemAccessor fsa)
+		{
+			var pid = Beam.RuntimeConfigProvider.Pid;
+			var cid = Beam.RuntimeConfigProvider.Cid;
+
+			return $"{fsa.GetPersistentDataPathWithoutTrailingSlash()}/{pid}-{cid}/content/content.json";
+		}
+		
+		/// <summary>
+		/// get the baked content and hold it as an in-memory dictionary for use later
+		/// </summary>
+		ContentDataInfoWrapper LoadBakedContent()
+		{
+			var bakedFile = Resources.Load<TextAsset>(BAKED_FILE_RESOURCE_PATH);
+
+			if (bakedFile == null)
+			{
+				return new ContentDataInfoWrapper();
+			}
+			
+			string json = bakedFile.text;
+			var isValidJson = Json.IsValidJson(json);
+			if (isValidJson)
+			{
+				return DeserializeDataCache<ContentDataInfoWrapper>(json);
+			}
+			else
+			{
+				json = Gzip.Decompress(bakedFile.bytes);
+				return DeserializeDataCache<ContentDataInfoWrapper>(json);
+			}
+		}
+
+		private void InitializeCachedContent()
 		{
 			// remove content in old format
-			string contentDirectory = Path.Combine(FilesystemAccessor.GetPersistentDataPathWithoutTrailingSlash(), "content");
-			const string contentFileName = "content.json";
+			var contentPath = ContentPath(FilesystemAccessor);
+			var contentDirectory = Path.GetDirectoryName(contentPath);
+			var contentFileName = Path.GetFileName(contentPath);
 			if (Directory.Exists(contentDirectory))
 			{
 				DirectoryInfo info = new DirectoryInfo(contentDirectory);
@@ -313,9 +357,12 @@ namespace Beamable.Content
 					file.Delete();
 				}
 			}
-			string contentPath = Path.Combine(contentDirectory, contentFileName);
 			bool contentDataExists = File.Exists(contentPath);
 
+			// initialize the cached content as empty to begin, 
+			CachedContentDataInfo = new ContentDataInfoWrapper();
+			
+			// but if there is local file content, then scoop it up!
 			if (contentDataExists)
 			{
 				var json = File.ReadAllText(contentPath);
@@ -323,40 +370,7 @@ namespace Beamable.Content
 				contentDataExists = contentData != null && contentData.content?.Count > 0;
 				if (contentDataExists)
 				{
-					ContentDataInfo = contentData;
-				}
-			}
-
-			if (!contentDataExists)
-			{
-				var bakedFile = Resources.Load<TextAsset>(BAKED_FILE_RESOURCE_PATH);
-
-				if (bakedFile == null)
-				{
-					return;
-				}
-
-				string json = bakedFile.text;
-				var isValidJson = Json.IsValidJson(json);
-				if (isValidJson)
-				{
-					ContentDataInfo = DeserializeDataCache<ContentDataInfoWrapper>(json);
-				}
-				else
-				{
-					json = Gzip.Decompress(bakedFile.bytes);
-					ContentDataInfo = DeserializeDataCache<ContentDataInfoWrapper>(json);
-				}
-
-				// save baked data to disk
-				try
-				{
-					Directory.CreateDirectory(Path.GetDirectoryName(contentPath));
-					File.WriteAllText(contentPath, json);
-				}
-				catch (Exception e)
-				{
-					Debug.LogError($"[EXTRACT] Failed to write baked data to disk: {e.Message}");
+					CachedContentDataInfo = contentData;
 				}
 			}
 		}


### PR DESCRIPTION
In ye olde version, 
When content turned on, we'd check to see if a local file, `content.json` existed. 

if it did, great, we wouldn't do much except load the entire json blob into memory and hold onto all the content.
If it didn't, fine, then we'd unpack the baked content file into the `content.json`, and then load _that_ up into memory.
Later, there was some code to check if the file existed or didn't, and maybe would or wouldn't keep trying to load it. 

the problem is that if we bake content once, ship a game, that game fetches some CDN content, then we re-bake content and re-ship the game, none of the new baked content _matters_ to the game, since the CDN cache already has ahold of the `content.json` file.


---

In ye new version,
When content turns on, we'll load up the baked content _and_ the cached content into _separate_ data structures. 
When we resolve content, we'll just each structure in order. 

now, if you re-bake content, it doesn't collide with CDN content what so ever. 


-----


Also, I changed the lookup function to use a dictionary instead of iterating through the list every time.
Also also, when the list is serialized to disk, I do a cache eviction pass to get rid of old content ids. I'm still not cleaning up everything, but this should reduce duplicate ids pointing to different versions. This fixes the enum content bug