### PR TITLE
fixes 3216 - docker uri fallbacks and override

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unreal Microservice client generation now correctly generates non-primitives used in C#MS signatures, including containers and nested containers.
 - Unreal Microservice client generation now happens for all microservices at once and support shared code.
 This means Unreal now supports multiple microservices as well as shared libraries!
+- `BEAM_DOCKER_URI` environment variable will override docker connection uri
 
 ### Changed
 
@@ -40,6 +41,7 @@ In most cases, this is as trivial as renaming the type inside the microservice t
 - `project new-storage` path fixes.
 - Progress bars and logs do not appear side by side.
 - Fixed issue that caused incorrect code-gen of Unreal wrapper types in SAMS-Client code
+- Docker will not connect at common unix home directory if `/var/run/docker.sock` is not available
 
 ## [1.19.12]
 

--- a/cli/cli/Services/BeamoLocalSystem.cs
+++ b/cli/cli/Services/BeamoLocalSystem.cs
@@ -4,6 +4,7 @@ using Beamable.Common.Api.Realms;
 using Docker.DotNet;
 using Docker.DotNet.Models;
 using Serilog;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 namespace cli.Services;
@@ -72,7 +73,8 @@ public partial class BeamoLocalSystem
 
 		// We use a 60 second timeout because the Docker Daemon is VERY slow... If you ever see an "The operation was cancelled" message that happens inconsistently,
 		// try changing this value before going down the rabbit hole.
-		_client = new DockerClientConfiguration(new AnonymousCredentials(), TimeSpan.FromSeconds(60))
+		var uri = GetLocalDockerEndpoint(configService);
+		_client = new DockerClientConfiguration(uri, new AnonymousCredentials(), TimeSpan.FromSeconds(60))
 			.CreateClient();
 
 		// Load or create the local manifest
@@ -119,6 +121,43 @@ public partial class BeamoLocalSystem
 
 		// Make a cancellation token source to cancel the docker event stream we listen for updates. See StartListeningToDocker.
 		_dockerListeningThreadCancel = new CancellationTokenSource();
+	}
+	
+	private static Uri GetLocalDockerEndpoint(ConfigService config)
+	{
+		var custom = config.CustomDockerUri;
+		if (!string.IsNullOrEmpty(custom))
+		{
+			
+			Log.Verbose($"using custom docker uri=[{custom}]");
+			return new Uri(custom);
+		}
+		
+		var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		if (isWindows)
+		{
+			var uri = new Uri("npipe://./pipe/docker_engine");
+			Log.Verbose($"Using standard windows docker uri=[{uri}]");
+			return uri;
+		}
+
+		var possibleLocations = new string[]
+		{
+			"/var/run/docker.sock", 
+			Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + "/.docker/run/docker.sock"
+		};
+		for (var i = 0; i < possibleLocations.Length; i++)
+		{
+			var location = possibleLocations[i];
+			if (i == possibleLocations.Length -1 || File.Exists(location))
+			{
+				var uri = new Uri("unix:" + location);
+				Log.Verbose($"Using standard unix docker uri=[{uri}]");
+				return uri;
+			}
+		}
+
+		throw new CliException($"No docker address found. Use the {ConfigService.ENV_VAR_DOCKER_URI} environment variable to set a Docker Uri.");
 	}
 
 	/// <summary>

--- a/cli/cli/Services/ConfigService.cs
+++ b/cli/cli/Services/ConfigService.cs
@@ -174,6 +174,14 @@ public class ConfigService
 	}
 
 	public const string ENV_VAR_WINDOWS_VOLUME_NAMES = "BEAM_DOCKER_WINDOWS_CONTAINERS";
+	public const string ENV_VAR_DOCKER_URI = "BEAM_DOCKER_URI";
+
+	/// <summary>
+	/// Enabling a custom Docker Uri allows for a customer to have a customized docker install and still
+	/// tell the Beam CLI where the docker socket is available.
+	/// </summary>
+	public string CustomDockerUri => Environment.GetEnvironmentVariable(ENV_VAR_DOCKER_URI);
+	
 	/// <summary>
 	/// Github Action Runners for windows don't seem to work with volumes for mongo.
 	/// </summary>


### PR DESCRIPTION
If for whatever reason, the standard docker `.sock` file isn't working on Unix, now we'll automatically try the second most common location for the `.sock` file. 

If that fails, there is a new ENV var that can be used to override all docker uri, `BEAM_DOCKER_URI`. 