### PR TITLE
fixes 3149 - adds retry to platform requester based on ssl connection issues

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Leaderboard `rankgt` field is not null when specifying outlier.
 - Fix renaming content throwing infinite warnings
 - Content cache evicts old content for new content id versions
+- `PlatformRequester` will reattempt failed requests caused by SSL connection issues.
 
 ### Removed
 


### PR DESCRIPTION
Moe was having issues downloading content, and would randomly (but consistently at least once through the whole process) get SSL connection issues. 

It seems there may be a bug in the Unity Web Requester. I added some retry logic for this specific issue, matching on the error text specifically. Moe ran this code, and it did fix the problem. 