### PR TITLE
fixes unity cli gen

### DIFF
--- a/cli/cli/App.cs
+++ b/cli/cli/App.cs
@@ -304,7 +304,8 @@ public class App
 
 
 		// content commands
-		Commands.AddRootCommand<ContentCommand, ContentCommandArgs>();
+		
+		Commands.AddRootCommand<ContentCommand>();
 		Commands.AddSubCommandWithHandler<ContentPullCommand, ContentPullCommandArgs, ContentCommand>();
 		Commands.AddSubCommandWithHandler<ContentStatusCommand, ContentStatusCommandArgs, ContentCommand>();
 		Commands.AddSubCommandWithHandler<ContentOpenCommand, ContentOpenCommandArgs, ContentCommand>();

--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -44,6 +44,10 @@ In most cases, this is as trivial as renaming the type inside the microservice t
 - Fixed issue that caused incorrect code-gen of Unreal wrapper types in SAMS-Client code
 - Docker will not connect at common unix home directory if `/var/run/docker.sock` is not available
 
+### Removed
+
+- `beam content` no longer directly opens content folder.
+
 ## [1.19.12]
 
 ### Added

--- a/cli/cli/Commands/Content/ContentCommand.cs
+++ b/cli/cli/Commands/Content/ContentCommand.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 
 namespace cli.Content;
 
-public class ContentCommand : CommandGroup<ContentCommandArgs>
+public class ContentCommand : CommandGroup
 {
 	public static readonly Option<string> MANIFEST_OPTION =
 		new("--manifest-id", () => "global", "Set the manifest to use, 'global' by default");
@@ -12,26 +12,9 @@ public class ContentCommand : CommandGroup<ContentCommandArgs>
 	public static readonly Option<string[]> MANIFESTS_FILTER_OPTION =
 		new("--ids", Array.Empty<string>, "Inform a subset of ','-separated manifest ids for which to return data. By default, will return all manifests");
 
-	private ContentService _contentService;
 
 	public ContentCommand() : base("content", "Open content folder in file explorer")
 	{
-	}
-
-	public override void Configure()
-	{
-		AddOption(MANIFEST_OPTION, (args, s) => args.ManifestId = s);
-	}
-
-	public override Task Handle(ContentCommandArgs args)
-	{
-		_contentService = args.ContentService;
-
-		new Process
-		{
-			StartInfo = new ProcessStartInfo(_contentService.GetLocalCache(args.ManifestId).ContentDirPath) { UseShellExecute = true }
-		}.Start();
-		return Task.CompletedTask;
 	}
 }
 

--- a/cli/cli/Services/UnityCliGenerator.cs
+++ b/cli/cli/Services/UnityCliGenerator.cs
@@ -181,7 +181,10 @@ public class UnityCliGenerator : ICliGenerator
 		{
 			return runtimeType.FullName;
 		}
-		return ConvertToSnakeCase("Beam" + runtimeType.Name);
+
+		var name = runtimeType.Name.Replace("[]", "");
+		
+		return ConvertToSnakeCase("Beam" + name);
 	}
 
 

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentLocalManifest.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentLocalManifest.cs
@@ -1,0 +1,59 @@
+
+namespace Beamable.Editor.BeamCli.Commands
+{
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    public class ContentLocalManifestArgs : Beamable.Common.BeamCli.IBeamCommandArgs
+    {
+        /// <summary>Inform a subset of ','-separated manifest ids for which to return data. By default, will return all manifests</summary>
+        public string[] ids;
+        /// <summary>Serializes the arguments for command line usage.</summary>
+        public virtual string Serialize()
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            // If the ids value was not default, then add it to the list of args.
+            if ((this.ids != default(string[])))
+            {
+                genBeamCommandArgs.Add((("--ids=\"" + this.ids) 
+                                + "\""));
+            }
+            string genBeamCommandStr = "";
+            // Join all the args with spaces
+            genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            return genBeamCommandStr;
+        }
+    }
+    public partial class BeamCommands
+    {
+        public virtual ContentLocalManifestWrapper ContentLocalManifest(ContentLocalManifestArgs localManifestArgs)
+        {
+            // Create a list of arguments for the command
+            System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
+            genBeamCommandArgs.Add("beam");
+            genBeamCommandArgs.Add(defaultBeamArgs.Serialize());
+            genBeamCommandArgs.Add("content");
+            genBeamCommandArgs.Add("local-manifest");
+            genBeamCommandArgs.Add(localManifestArgs.Serialize());
+            // Create an instance of an IBeamCommand
+            Beamable.Common.BeamCli.IBeamCommand command = this._factory.Create();
+            // Join all the command paths and args into one string
+            string genBeamCommandStr = string.Join(" ", genBeamCommandArgs);
+            // Configure the command with the command string
+            command.SetCommand(genBeamCommandStr);
+            ContentLocalManifestWrapper genBeamCommandWrapper = new ContentLocalManifestWrapper();
+            genBeamCommandWrapper.Command = command;
+            // Return the command!
+            return genBeamCommandWrapper;
+        }
+    }
+    public class ContentLocalManifestWrapper : Beamable.Common.BeamCli.BeamCommandWrapper
+    {
+        public virtual ContentLocalManifestWrapper OnStreamLocalContentState(System.Action<ReportDataPoint<BeamLocalContentState>> cb)
+        {
+            this.Command.On("stream", cb);
+            return this;
+        }
+    }
+}

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentLocalManifest.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentLocalManifest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 763afdb8102e847038bd74c41070f4f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentManifest.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentManifest.cs
@@ -1,0 +1,13 @@
+
+namespace Beamable.Editor.BeamCli.Commands
+{
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamLocalContentManifest
+    {
+        public string ManifestId;
+        public BeamLocalContentManifestEntry Entries;
+    }
+}

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentManifest.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentManifest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1fdc3ac1e91d44035be9167301ba0c62
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentManifestEntry.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentManifestEntry.cs
@@ -1,0 +1,17 @@
+
+namespace Beamable.Editor.BeamCli.Commands
+{
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamLocalContentManifestEntry
+    {
+        public string FullId;
+        public string TypeName;
+        public string Name;
+        public int CurrentStatus;
+        public string Hash;
+        public string[] Tags;
+    }
+}

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentManifestEntry.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentManifestEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f7b579c459e4405e87df9c47e92572e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentState.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentState.cs
@@ -1,0 +1,12 @@
+
+namespace Beamable.Editor.BeamCli.Commands
+{
+    using Beamable.Common;
+    using Beamable.Common.BeamCli;
+    
+    [System.SerializableAttribute()]
+    public class BeamLocalContentState
+    {
+        public BeamLocalContentManifest Manifests;
+    }
+}

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentState.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 84e164bf2629a40cd9a139c1caa58ab4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDiscoveryEvent.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDiscoveryEvent.cs
@@ -13,7 +13,9 @@ namespace Beamable.Editor.BeamCli.Commands
         public string service;
         public bool isRunning;
         public bool isContainer;
+        public string serviceType;
         public int healthPort;
+        public int dataPort;
         public string containerId;
     }
 }


### PR DESCRIPTION
There are 2 big things here,

1. seems like struct array fields were being named with a trailing `[]`, so I did the dumbest thing, and just removed the `[]` occurance... That seemed to do the trick, 
2. the `beam content` command had default parameters, which is a very unique thing in the CLI, and the generation pass was producing something silly to account for it. Instead of fixing the generation pass, I decided that the `beam content` ought NOT to be doing some unique, and I removed the code. 