### PR TITLE
3164 - content rename delay

### DIFF
--- a/client/Packages/com.beamable/Editor/Modules/Content/ContentIO.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/ContentIO.cs
@@ -989,9 +989,12 @@ namespace Beamable.Editor.Content
 				throw new Exception(result);
 			}
 
-			EditorUtility.SetDirty(content);
-			AssetDatabase.ForceReserializeAssets(new[] { nextAssetpath },
-				ForceReserializeAssetsOptions.ReserializeAssetsAndMetadata);
+			EditorApplication.delayCall += () =>
+			{
+				EditorUtility.SetDirty(content);
+				AssetDatabase.ForceReserializeAssets(new[] {nextAssetpath},
+				                                     ForceReserializeAssetsOptions.ReserializeAssetsAndMetadata);
+			};
 		}
 
 

--- a/client/Packages/com.beamable/Editor/Modules/Content/ContentValidationPropertyDrawer.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/ContentValidationPropertyDrawer.cs
@@ -187,11 +187,6 @@ namespace Beamable.Editor.Content
 		public static DefaultPropertyFieldDelegate VanillaPropertyField;
 		static RefEditorGUI()
 		{
-			Init();
-		}
-
-		static void Init()
-		{
 			_propertyDrawerTypes = TypeCache.GetTypesDerivedFrom<PropertyDrawer>().ToArray();
 
 			var t = typeof(EditorGUI);
@@ -250,6 +245,7 @@ namespace Beamable.Editor.Content
 				}
 				return true;
 			};
+
 		}
 
 		static Type GetPropertyType(SerializedProperty prop)
@@ -283,15 +279,6 @@ namespace Beamable.Editor.Content
 
 		static Type GetPropertyDrawerType(Type fieldType)
 		{
-			if (_propertyDrawerTypes == null)
-			{
-				Init();
-			}
-
-			if (_propertyDrawerTypes == null)
-			{
-				throw new Exception("cannot initialize property drawer types :( ");
-			}
 			return _propertyDrawerTypes.FirstOrDefault(drawerType =>
 			{
 				var attributes = drawerType.GetCustomAttributes<CustomPropertyDrawer>();

--- a/client/Packages/com.beamable/Editor/Modules/Content/ContentValidationPropertyDrawer.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/ContentValidationPropertyDrawer.cs
@@ -187,6 +187,11 @@ namespace Beamable.Editor.Content
 		public static DefaultPropertyFieldDelegate VanillaPropertyField;
 		static RefEditorGUI()
 		{
+			Init();
+		}
+
+		static void Init()
+		{
 			_propertyDrawerTypes = TypeCache.GetTypesDerivedFrom<PropertyDrawer>().ToArray();
 
 			var t = typeof(EditorGUI);
@@ -245,7 +250,6 @@ namespace Beamable.Editor.Content
 				}
 				return true;
 			};
-
 		}
 
 		static Type GetPropertyType(SerializedProperty prop)
@@ -279,6 +283,15 @@ namespace Beamable.Editor.Content
 
 		static Type GetPropertyDrawerType(Type fieldType)
 		{
+			if (_propertyDrawerTypes == null)
+			{
+				Init();
+			}
+
+			if (_propertyDrawerTypes == null)
+			{
+				throw new Exception("cannot initialize property drawer types :( ");
+			}
 			return _propertyDrawerTypes.FirstOrDefault(drawerType =>
 			{
 				var attributes = drawerType.GetCustomAttributes<CustomPropertyDrawer>();


### PR DESCRIPTION
this is sort of a test, but on an outside project from Beamable, I hit a similar issue where if you commit an asset to the asset database, and in the same _editor frame_, modify it; stuff gets un happy. In my side project, I fixed this with a delay frame. 