### PR TITLE
fixes 3240 - reports parse errors on pipe

### DIFF
--- a/cli/tests/Examples/CLITest.cs
+++ b/cli/tests/Examples/CLITest.cs
@@ -111,7 +111,8 @@ public class CLITest
 		_configurator = new Action<IDependencyBuilder>(_ => { });
 	}
 
-	protected int Run(params string[] args)
+	protected int Run(params string[] args) => RunFull(args, assertExitCode: true);
+	protected int RunFull(string[] args, bool assertExitCode=false, Action<IDependencyBuilder>? configurator=null)
 	{
 		var exitCode = Cli.RunWithParams(builder =>
 		{
@@ -122,6 +123,7 @@ public class CLITest
 			builder.AddSingleton<IBeamableRequester>(_mockRequester.Object);
 
 			_configurator?.Invoke(builder);
+			configurator?.Invoke(builder);
 		},
 		logger => logger
 		.WriteTo.Console(new MessageTemplateTextFormatter(
@@ -131,7 +133,10 @@ public class CLITest
 
 		args);
 
-		Assert.AreEqual(0, exitCode, $"Command had a non zero exit code. Check logs. code=[{exitCode}] command=[{string.Join(" ", args)}]");
+		if (assertExitCode)
+		{
+			Assert.AreEqual(0, exitCode, $"Command had a non zero exit code. Check logs. code=[{exitCode}] command=[{string.Join(" ", args)}]");
+		}
 		return exitCode;
 	}
 }

--- a/cli/tests/Examples/ParserErrors/ParserErrorTest.cs
+++ b/cli/tests/Examples/ParserErrors/ParserErrorTest.cs
@@ -1,0 +1,44 @@
+using cli;
+using cli.Services;
+using Moq;
+using NUnit.Framework;
+using System;
+
+namespace tests.Examples.ParserErrors;
+
+public class ParserErrorTest : CLITest
+{
+	[Test]
+	public void ReportsParseErrorOnRaw()
+	{
+		Mock<IDataReporterService>(mock =>
+		{
+			// the data reporter service needs to get called
+			mock.Setup(x => x.Exception(
+				It.Is<Exception>(ex => ex.Message == "Unrecognized command or argument 's'."), 
+				1, 
+				It.IsAny<string>()));
+		});
+		var exitCode = RunFull(new string[]{"me", "s", "--raw"});
+		Assert.That(exitCode, Is.EqualTo(1), "exit code should indicate failure");
+	}
+
+	[Test]
+	public void DoesNotReportErrorIfNotOnRaw()
+	{
+		ResetConfigurator();
+		var exitCode = RunFull(new string[]{"me", "s"}, configurator: builder =>
+		{
+			var mock = new Mock<IDataReporterService>();
+			mock.Setup(x => x.Exception(It.IsAny<Exception>(), It.IsAny<int>(), It.IsAny<string>()))
+				.Callback<Exception, int, string>((ex, code, invocation) => Assert.Fail($"No error should be reported! message=[{ex.Message}]"));
+			builder.ReplaceSingleton<IDataReporterService>(mock.Object);
+
+			var mockApp = new Mock<IAppContext>();
+			mockApp.SetupGet(x => x.UsePipeOutput).Returns(false);
+			builder.ReplaceSingleton(mockApp.Object);
+		});
+		Assert.That(exitCode, Is.EqualTo(1), "exit code should indicate failure");
+	}
+
+}


### PR DESCRIPTION
Now if you do this,
```
beam me s --raw
```

you'll get proper output on the raw channel that tells you the error,
```
chrishanna@Chriss-MacBook-Pro-2 BeamableNightly % beam me s --raw
{"ts":1712158729699,"type":"error","data":{"message":"Unrecognized command or argument 's'.","invocation":"![ Beamable.Tools [ me [ --raw ] ] *[ --quiet ] ]   ???--> s","exitCode":1,"typeName":"Exception","fullTypeName":"System.Exception","stackTrace":null}}
```