### PR TITLE
pre generate meta files for CLI generation

### DIFF
--- a/.github/workflows/generateUnityCLI.yml
+++ b/.github/workflows/generateUnityCLI.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Clear old files
         working-directory: ./client/Packages/com.beamable/Editor/BeamCli/Commands
         run: |
+          rm -rf *.cs
           rm -rf *.meta
       - name: Restore Tools
         working-directory: ./cli/cli
@@ -43,7 +44,6 @@ jobs:
       - name: Build CLI 
         run: |
            dotnet msbuild -r:True -t:Build ./cli/cli -p:BEAM_GENERATE_INTERFACE=true
-    
       - name: Delete Trash Files
         working-directory: ./client/Packages/com.beamable/Editor/BeamCli/Commands
         run: |
@@ -52,77 +52,6 @@ jobs:
       - name: List files (post)
         working-directory: ./client/Packages/com.beamable/Editor/BeamCli/Commands
         run: ls -a
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Prepare Config-Defaults
-        run: |
-          chmod +x ./build/create_config_defaults.sh
-          ./build/create_config_defaults.sh
-        shell: bash
-      # - name: Cache Docker Layers
-      #   uses: actions/cache@v3
-      #   id: cache_docker
-      #   with:
-      #     path: ./docker-cache
-      #     key: Docker-gzipped-${{ matrix.unityVersion }}-${{ matrix.targetPlatform }}
-      #     restore-keys: |
-      #       Docker-gzipped-${{ matrix.unityVersion }}-${{ matrix.targetPlatform }}
-      # - name: Load Docker Image If Exits
-      #   if: ${{ steps.cache_docker.outputs.cache-hit }}
-      #   continue-on-error: true
-      #   run: |
-      #     chmod +x ./build/prepare_base_image.sh
-      #     UNITY_VERSION=${{ matrix.unityVersion }} TARGET_PLATFORM=${{matrix.targetPlatform}} ./build/prepare_base_image.sh
-      #   shell: bash
-      - name: Cache Unity Folders
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ matrix.projectPath }}/Library
-            ${{ matrix.projectPath }}/Temp
-            ${{ matrix.projectPath }}/obj
-          key: Library-${{ matrix.projectPath }}-${{ matrix.unityVersion }}-${{ matrix.targetPlatform }}
-          restore-keys: |
-            Library-${{ matrix.projectPath }}-${{ matrix.unityVersion }}-${{ matrix.targetPlatform }}
-      - name: Clean the build directory
-        continue-on-error: true
-        run: |
-          rm -rf /github/workspace/dist
-        shell: bash
-      - uses: game-ci/unity-builder@v4
-        timeout-minutes: 60
-        env:
-          UNITY_EMAIL: ${{  secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-        with:
-          runAsHostUser: true
-          targetPlatform: ${{ matrix.targetPlatform }}
-          unityVersion: ${{ matrix.unityVersion }}
-          projectPath: ${{ matrix.projectPath }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          versioning: Custom
-          version: 1.2.0
-          androidVersionCode: ${{ github.run_number }}
-          allowDirtyBuild: true
-          buildsPath: dist
-          buildMethod: BuildSampleProject.Development
-
-      # - name: Save Docker Image If Exits
-      #   if: ${{ !steps.cache_docker.outputs.cache-hit }}
-      #   run: |
-      #     chmod +x ./build/save_base_image.sh
-      #     UNITY_VERSION=${{ matrix.unityVersion }} TARGET_PLATFORM=${{matrix.targetPlatform}} ./build/save_base_image.sh
-      #   shell: bash
-
-      # - name: Cleanup other files
-      #   run: |
-      #     chmod -R 777 client
-      #     rm -f client/ProjectSettings/Packages/com.unity.services.core/Settings.json
-      #     rm -f client/UserSettings/EditorUserSettings.assets
       - name: Check for Changes
         run: echo ::set-output name=any::$(if [ -n "$(git status --porcelain)" ]; then echo "true"; else echo "false"; fi)
         id: changes

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/Beam.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/Beam.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 17657a825598f4764b28ac2bad6dd8a9
+guid: 50f39a24cab0e9ddd688682641b0305b
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamAccountMeCommandOutput.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamAccountMeCommandOutput.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1182d09efa78ca3c8b9234d34a9a308f
+guid: 6e6b0a3be0bb83a3d4f74203185af961
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamAccountMeExternalIdentity.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamAccountMeExternalIdentity.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 51b5ec87c5a38ffd2b6c2dbf5ae197e1
+guid: b2418a3bb34acec697229d597483d8dd
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamBuildProjectCommandOutput.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamBuildProjectCommandOutput.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c88f564168a015a08a8b9d7600e0381b
+guid: 1d8533cc6edb1795e3c45c88cb755bd4
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCheckPerfCommandOutput.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCheckPerfCommandOutput.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 421291a8bdf0e98089cee22a315047b0
+guid: 51a9f3764e22b5ecd5e8bf6b372677fc
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceComponent.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceComponent.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8551728405b2f30b3ad56a56910915ec
+guid: be05c74baec6441f783b98347fb7561d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceDependency.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceDependency.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e51dcaeb0780087f6ac1890a4b18b02e
+guid: 43d5c48512a48a51f628c5553d70bec6
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceManifest.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceManifest.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a8a95fa3c26d1cdce9c9edda07ea6631
+guid: 0edf9e22a0dbcf574c73320dea885615
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceReference.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceReference.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c5741d58c7192664289c70f1c31f4393
+guid: 2747a9d4c10fa9a428d85cf1906f6dab
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceStorageReference.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCliServiceStorageReference.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1eab0d636342b6460aab1054d6e122bd
+guid: c89ab82733de484d19ccf34f229d7f53
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfig.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfig.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8eccd075977d2492aaf500dd6cdbfe5d
+guid: 1b4ee4804b1db2530193aa9f4a94761c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfigCommandResult.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfigCommandResult.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 39b383f1d3019442bb2517928b1def03
+guid: 6381134aa49ae994e0336a3b26949d29
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfigRealm.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfigRealm.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a50b6986ae361e55c850f7d18b1a566d
+guid: e9eb9d9b1e1a5c4b5f386a3417ce2d8d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfigRealmRemove.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfigRealmRemove.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e4fccab02e30c055aab3eb0b4e42d2b4
+guid: 5e7f052fa479b9afaf68b192fd69ac59
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfigRealmSet.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConfigRealmSet.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0744696235040b314ae469256da4eb07
+guid: 58a226a8bb16beb2c058fd55e0c931eb
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConstructVersionOutput.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamConstructVersionOutput.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5753f94ed634cb57096c9b59b46c3d71
+guid: 4859078990c795f56a94d62c9b2bc7ba
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentLocalManifest.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentLocalManifest.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 95d6afa0040eacd9faa3e16c97d567f4
+guid: 1c814eb48085f56e237f767eab41423d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamDependencyData.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamDependencyData.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b616f369c0b5d3c56afd7cb623ad7a69
+guid: e1fbae9bb04a80289f8e9e97fdcbb189
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamGenerateOApiCommandOutput.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamGenerateOApiCommandOutput.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4b5cefbfcf40dad4088d2c81067ec10b
+guid: 5db9134bc08051adc4642836d86b448c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamGetLogsUrlHeader.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamGetLogsUrlHeader.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2b742cdb21e3d689787f1669c852111c
+guid: dc2e683b170f1261a3ce5281b73b0744
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamGetSignedUrlResponse.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamGetSignedUrlResponse.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bc5114e6fbb2d2f92982b6606505e1e4
+guid: cc4ee0acaa69b05a56f281e4e51073e1
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamInit.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamInit.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 20b66f8964a93467f87335ff9017af07
+guid: 280a03cc7186d27502fcfe18e6127cc5
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamInitCommandResult.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamInitCommandResult.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b771364a7cd5a4743a7833be2c642c03
+guid: 845a842728f63ff8b4d51fda1dcdd9a1
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListCommandResult.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListCommandResult.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4980e3ddffdd54dde87176a6639c067f
+guid: 202c8080e766801b41d909bdbc16397d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListDepsCommandResults.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListDepsCommandResults.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 31bf7982d6d511ed587d7618fdbb74d3
+guid: d5c8d14a1bb1fd2c8f51bdb292e0c135
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListenPlayer.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListenPlayer.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7009f9aac0a413ef0b7735146c5aac14
+guid: 3fe2fe8114996ccbd94ffb2ed9f88924
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListenServer.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListenServer.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 05a13871683569363b044a9b416245da
+guid: 96e1c2fc0c2349f5dfe492ca75ddf6f3
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentManifest.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentManifest.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 478fa02a0d581d37184fde8ee8b0584e
+guid: 3548d58c5834fe495e770fead778f7e6
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentManifestEntry.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentManifestEntry.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 23689b110de79beeab2d379612d7665a
+guid: 6184e63b4b432aa9b9ce7331bbd1ddfe
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentState.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamLocalContentState.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9a7f3387189495d5294aa4aafcb435c3
+guid: 5fd99e4b8a9b0b9d0c856af600be8dfe
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamManifestChecksum.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamManifestChecksum.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 35d7a3bd4f238bc45836b23bc1b40851
+guid: c32a6e5005991c4ead48c7576084b36d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamManifestChecksums.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamManifestChecksums.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a1c785d17d2caf0968ca52875b0daef6
+guid: 149a7c858ef906fde8c6cb7c4f90e348
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamMe.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamMe.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 08499c28930e640f08e476e4021f48dc
+guid: d860feb0448a9034354388bec10aae65
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamNotificationPlayerOutput.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamNotificationPlayerOutput.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ef9cc81b2694627fc9e8632a79d806b9
+guid: 7b64561faef5f2a1a922efafc4c62e26
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamNotificationServerOutput.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamNotificationServerOutput.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c34647c49895cd980806c8f939a4f100
+guid: 15dc27ae84bbc44aa59744332ec4ab85
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamOapiDownload.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamOapiDownload.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c985df7e56e7341b7b5c557d7e6c5c28
+guid: 300ec27436feb234f272ed44b78c5928
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProfileCheckCounters.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProfileCheckCounters.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 82b95afe4478ed48fbd78a87b2be9128
+guid: cf3c8055e67bd4359edac1a59397eabb
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProfileCheckNbomber.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProfileCheckNbomber.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b9c56a14c4712313097da4a014527474
+guid: 2089c040335a6ee22d00344365264d64
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectAddUnityProject.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectAddUnityProject.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: fcbd621679f6745f2b0784b4fe73853c
+guid: f21de2daf8675bec8e24b0c269bd6bdd
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectBuild.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectBuild.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6bbe67433021f559fa1a5f9cd38f6e7b
+guid: ae191796becdcbd2dc4f2b181bf366d3
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDeps.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDeps.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c2e9e443cad5ce957a1767d34a141ddb
+guid: 4ed6c551c7c44b25943532e47622adb1
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDepsAdd.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDepsAdd.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: cc71e2df8f43416c49a95684d9e2e8f7
+guid: f774fd82f9fc197716de3a1f216eb0ae
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDepsList.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDepsList.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7d6c392f98f97459f800491f622206ff
+guid: c26dada8727d2b89945e42161853a3ca
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDepsRemove.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDepsRemove.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 366e9a398489bba38a17c7b637f13f59
+guid: b1b521b1bda99734b5a8bf9d61b3c437
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectErrorReport.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectErrorReport.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 05965b946f1ca2faa801757241b925a2
+guid: ce428be98252a1f990966b5ede052bfe
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectErrorResult.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectErrorResult.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7e88f48c965c39131945bdea5e0ffe01
+guid: 0f42dad689d5b29b5d4ebd75129ebc4a
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateClient.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateClient.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e89ba3a7f0afee6408d0fdf606e833b6
+guid: 987d0cfafd279e84608fd2ee4c679c6b
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateEnv.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateEnv.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: faa4354a1cb644b04adcb4f70b27c401
+guid: df9c5500f74ac5f2c11acb5f62248d72
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateProperties.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateProperties.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 424447e284836460985f74723aadde45
+guid: 5cc980e4f0cf9a8d92b265148ba82721
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectList.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectList.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e312ae2bfe19a4e85b91d02941b350ef
+guid: 9004cce6aa8268c29cbd9ed3ea224212
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectLogs.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectLogs.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b3efd10c8a0494985968cebc16dd0313
+guid: e3221447820678f089966892384eb657
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewCommonLib.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewCommonLib.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e71e438d846078fec894077f38da27dc
+guid: 8e7f4bdee0433d611c0538a1686627ed
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewService.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewService.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 24a9232ba0f705565826d1010bbcb584
+guid: e19465c324621597c159580f62bd78a2
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewStorage.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewStorage.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 378ad9e658223d8809071237fc331b5e
+guid: 0c7f093bb1fc8553c9689a4fefa104e5
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectOapi.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectOapi.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a31cce668600a377fad51ef075832a36
+guid: c2fd3c165bf0998157a547f9c843b4ee
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectOpenSwagger.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectOpenSwagger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e2b7b260cf019465a8ad28bf51c0629c
+guid: f6bfb7f2d8d9e3e0cf73b835cba5da36
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectPs.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectPs.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e8e62ed0d0f604ad5ac7ba62fade0ac8
+guid: d3061a542cd7b8d890463cbbb7fbe1f4
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectRegenerate.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectRegenerate.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9743009906666429b8b008c4b95ac457
+guid: 5342a3aff153c39ef48dd14b72621c85
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectRun.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectRun.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 800c7436845b9d4c99084d1c43876c3b
+guid: 59b564174d3f28ad5343ced00c1e958a
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectStop.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectStop.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4c9acdee2a236a7e784b112896b76920
+guid: f49f3d23c325c05165fb86a631d7c8a2
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectVersion.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectVersion.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: da8dbe6516326804792a7d4dd0bafad6
+guid: f93902d7e6437f4d188c57461af4fcb4
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectVersionCommandResult.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectVersionCommandResult.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9269ed3a063de6c48907dc02a60d952f
+guid: 5eca08866e4143ad1211fba4159b3eb4
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamRealmConfigOutput.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamRealmConfigOutput.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6706f0907d07aefd1a05250d1343ea16
+guid: bfc6932797b42652c7d8f8fa469ea1ee
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDependenciesPair.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDependenciesPair.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2a4e0d317c2403f9898d3add1207cbdc
+guid: 7fa69ef47e6c95440a1796bd58651c82
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDeployLogResult.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDeployLogResult.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0c86dd9564f36e44a9c46478b691559a
+guid: 37f67373b9b022597d695fea77ed0b68
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDeployReportResult.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDeployReportResult.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9392f344d69204905bf5bacd833ae74a
+guid: 3e7e1e0c454236f0ce44138e83c8b5dc
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDiscoveryEvent.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceDiscoveryEvent.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f56967a5d50b54ede8e641731aed7c0b
+guid: b22d24737f0b3136fbc13c9cb528e8fe
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceListResult.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceListResult.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6c5bbae0a97b34b2caa18fc9d09b4610
+guid: f69ebad611a93a2db56afc5b5260f3ed
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceManifestOutput.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceManifestOutput.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9effc7b1fcfe51e6b8e508bd11a9f1ad
+guid: 6c243185f0c4054ee90fe509c335ee04
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceRemoteDeployProgressResult.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceRemoteDeployProgressResult.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5c946523efe0143ac8df872422c0d9e8
+guid: 0ecf0fe0352640db87ba01c013dd4797
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceRunProgressResult.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceRunProgressResult.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6edc6ba94de694c269ec55a3806a873d
+guid: 31c926725ba8a616870298468250fcbc
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceRunReportResult.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceRunReportResult.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d5443536c61654814ae7c977aab60585
+guid: ce17ad3bc9455cdb3785b296e7b75347
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceTemplate.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServiceTemplate.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: dfc46dac1519dbc32808f43bb2c9844e
+guid: 091206856516b36ec7149081e2a558eb
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesDeploy.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesDeploy.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d2b9e4890408844c0876b81e3a7618f4
+guid: 9e32daa6f1fad44ac58b50831990fcee
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesManifests.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesManifests.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c05b066289d4ac7eca5216e33eff8881
+guid: b7d6c5eec1f06c4c7ebef4cb4cab24b9
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesPromote.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesPromote.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b21e36b325dc07e85b1df09b0d65726e
+guid: 64f80b474e0cf4b6dea727f85413cade
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesPs.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesPs.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 36afe18340b3447b3a10623694cd9d18
+guid: 9cfa4723c1b220faab5190ac230d687b
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesRegistry.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesRegistry.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6899962c4c6cb7ac7862c3d06a06171d
+guid: 50b154156b0717a88c5f576099e98267
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesRegistryOutput.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesRegistryOutput.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7a67a5f5e66d30b479dc3e7ad1dfdcdf
+guid: 5c24c70d1d3f7369b56a1a133a48b296
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesReset.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesReset.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b1189b33bf94b4120a5bd9843a9722fe
+guid: eed967e730c207e9f49051b3a302cf58
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesResetResult.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesResetResult.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c4e3963698cca438fa1b6e39798cdeb2
+guid: 7a6c9f603e5618a94be202de46560758
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesRun.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesRun.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c452575389ef04443a498c4705c9645a
+guid: cd65757a4d71fab786757f48285b0327
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesServiceLogs.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesServiceLogs.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d434ea170bb5b442b91a97d9cf28ecf0
+guid: b7c9b61a0255b3e7b796d15a689e2a80
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesServiceMetrics.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesServiceMetrics.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 36c197c0780519277b452b22f3be0195
+guid: 09537fac21cd4bc69347de18fb7cf4b8
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesSetLocalManifest.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesSetLocalManifest.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f9df4577b8ec5413db5124cad39495cb
+guid: c4855a55b885396665abac94fb69923d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesStop.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesStop.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 279a47afdba4d4363b56de11efbf2842
+guid: f8274ddf0c7765f824ffc4a1987ec51b
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesTemplates.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesTemplates.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a7e7e4d9c3013a56395e605df15a19b0
+guid: d3ff9294d37f2a54849295298dccf734
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesTemplatesCommandOutput.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesTemplatesCommandOutput.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9b7b2c5edc97d9890bd355a7836da6cf
+guid: f32e0539fa78a31942062f8b2ea01100
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesUploadApi.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesUploadApi.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 379c5ec033a85cf76848aacadfc5bd60
+guid: fc47080b9c9e8f8dcf0dae0c55281f77
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesUploadApiOutput.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesUploadApiOutput.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 403a7542fa120977fa310ef8a1a80035
+guid: 2b21abb8ac7ffbee331bc5c23d2f375d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamStopProjectCommandOutput.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamStopProjectCommandOutput.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bf5918c9328a66c4dbe76e38ea30fe32
+guid: 607e48956d3a907f544416aa10de4ddd
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamTailLogMessageForClient.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamTailLogMessageForClient.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5646153bc95ef0ac6bd78aa7ef3f1012
+guid: 0b1d067482a801680455642171350dba
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamVersion.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamVersion.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 19e314150bf6c437db9f8b68b82b3a6f
+guid: 23e81402123250861ee92ab9697992a8
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamVersionConstruct.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamVersionConstruct.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7f9cb49174ceddca7a777a59e28f71bb
+guid: 0ff62a434457b6d525dbc520b2756d92
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamVersionResults.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamVersionResults.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: fe5be6e6e8277425ba024e183ad0cc1b
+guid: c6493661a58b68cbecc4d2acbb259fe7
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
Trying to get the CLI automation to not totally stink with regards to meta file generation. 
Previously, I'd been spinning up Unity to build the project for the SINGULAR reason that it would generate meta files for me in a Unity compatible way.

but the huge problem is that it generates _different_ meta files all the time. 

new solution, _don't_ do that. Instead, our CLI generation can pre-generate the meta files itself. The toughest part is that we need a guid... The guid needs to be unique, and "hopefully" not collide with any existing Unity stuff. So, new plan, lets just generate a guid based on the hash of the relative file path. I think the odds of collision are safely low enough, and if there IS a collision, we can fix it later. 