### PR TITLE
adds spew logging for cli

### DIFF
--- a/client/Packages/com.beamable/Common/Runtime/Constants/Implementations/SpewConstants.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Constants/Implementations/SpewConstants.cs
@@ -7,6 +7,7 @@
 			public static partial class Spew
 			{
 				public const string SPEW_ALL = "SPEW_ALL";
+				public const string SPEW_CLI = "SPEW_CLI";
 				public const string SPEW_NOTIFICATION = "SPEW_NOTIFICATION";
 				public const string SPEW_CHAT = "SPEW_CHAT";
 				public const string SPEW_PUBNUB_SUBSCRIPTION = "SPEW_PUBNUB_SUBSCRIPTION";

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCommand.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCommand.cs
@@ -3,6 +3,7 @@ using Beamable.Common;
 using Beamable.Common.Api;
 using Beamable.Common.BeamCli;
 using Beamable.Common.Dependencies;
+using Beamable.Common.Spew;
 using Beamable.Editor.Dotnet;
 using System;
 using System.Collections.Generic;
@@ -378,6 +379,7 @@ namespace Beamable.Editor.BeamCli
 							KillProc();
 							return;
 						}
+						CliLogger.Log("stdout", args.Data, System.Environment.NewLine+System.Environment.NewLine  ,_command );
 
 						_dispatcher.Schedule(() =>
 						{
@@ -399,6 +401,8 @@ namespace Beamable.Editor.BeamCli
 							return;
 						}
 
+						CliLogger.Log("stderr", args.Data, System.Environment.NewLine+System.Environment.NewLine  ,_command );
+
 						_dispatcher.Schedule(() =>
 						{
 							try
@@ -412,6 +416,7 @@ namespace Beamable.Editor.BeamCli
 						});
 					};
 
+					CliLogger.Log("starting", _command);
 					_process.Start();
 					pid = _process.Id;
 					_collection?.Add(pid);
@@ -423,6 +428,8 @@ namespace Beamable.Editor.BeamCli
 
 					if (_exitCode != 0)
 					{
+						CliLogger.Log("failed", _command, $"errors-count=[{_errors.Count}]");
+
 						foreach (var err in _errors)
 						{
 							BeamEditorContext.Default.Dispatcher.Schedule(() => Debug.LogError(err.message));

--- a/client/Packages/com.beamable/Editor/BeamCli/CliSpewLogger.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/CliSpewLogger.cs
@@ -1,0 +1,17 @@
+using Beamable.Common;
+using Beamable.Common.Spew;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Beamable.Editor.BeamCli
+{
+	[SpewLogger]
+	public class CliLogger
+	{
+		[Conditional(Constants.Features.Spew.SPEW_ALL), Conditional(Constants.Features.Spew.SPEW_CLI)]
+		public static void Log(params object[] msg)
+		{
+			Logger.DoSpew("CLI: " + string.Join(",", msg.Select(x => x?.ToString())));
+		}
+	}
+}

--- a/client/Packages/com.beamable/Editor/BeamCli/CliSpewLogger.cs.meta
+++ b/client/Packages/com.beamable/Editor/BeamCli/CliSpewLogger.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f95425b42de84ef3899b3c5a8c18e0c7
+timeCreated: 1712260985


### PR DESCRIPTION
Now, if you enable SPEW_ALL or SPEW_CLI, you'll get very verbose CLI logging for every command invoked, and all stdout and stderr from each command. 