### PR TITLE
usam nightly fixes

### DIFF
--- a/cli/cli/Commands/Project/GeneratePropertiesFileCommand.cs
+++ b/cli/cli/Commands/Project/GeneratePropertiesFileCommand.cs
@@ -1,3 +1,4 @@
+using cli.Services;
 using Serilog;
 using System.CommandLine;
 
@@ -25,8 +26,21 @@ public class GeneratePropertiesFileCommand : AppCommand<GeneratePropertiesFileCo
 			(args, i) => args.OutputPath = i);
 		AddArgument(new Argument<string>("beam-path", description: "Beam path to be used"),
 			(args, i) => args.BeamPath = i);
-		AddArgument(new Argument<string>("solution-dir", description: "The solution path to be used"),
-			(args, i) => args.SolutionDir = i);
+		AddArgument(new Argument<string>("solution-dir", description: @"The solution path to be used. 
+The following values have special meaning and are not treated as paths... 
+- """ + Beamable.Common.BeamCli.Contracts.CliConstants.GENERATE_PROPS_SLN_NEXT_TO_PROPS + @""" = $([System.IO.Path]::GetDirectoryName(`$(DirectoryBuildPropsPath)`)) "),
+			(args, i) =>
+			{
+				if (i == Beamable.Common.BeamCli.Contracts.CliConstants.GENERATE_PROPS_SLN_NEXT_TO_PROPS)
+				{
+					args.SolutionDir = "$([System.IO.Path]::GetDirectoryName(`$(DirectoryBuildPropsPath)`))";
+				}
+				else
+				{
+					args.SolutionDir = i;
+				}
+			});
+		
 
 		AddOption(new Option<string>("--build-dir", description: "A path relative to the given solution directory, that will be used to store the projects /bin and /obj directories. Note: the given path will have the project's assembly name and the bin or obj folder appended"),
 			(args, i) => args.RelativeBuildDir = i);
@@ -39,6 +53,7 @@ public class GeneratePropertiesFileCommand : AppCommand<GeneratePropertiesFileCo
 			throw new CliException($"Output path argument passed does not exist. path=[{args.OutputPath}]");
 		}
 
+	
 		const string buildDirFlag = "BUILD_DIR_OPTIONS";
 
 		// this line could be used on the second propertyGroup to only apply those values to project that are considered beamable projects.

--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/CodeService.cs
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/CodeService.cs
@@ -679,7 +679,7 @@ namespace Beamable.Server.Editor.Usam
 			{
 				output = ".",
 				beamPath = beamPath,
-				solutionDir = "\"$([System.IO.Path]::GetDirectoryName(`$(DirectoryBuildPropsPath)`))\"",
+				solutionDir = CliConstants.GENERATE_PROPS_SLN_NEXT_TO_PROPS,
 				buildDir = "/Temp/beam/USAMBuilds"
 			});
 

--- a/client/Packages/com.beamable/Common/Runtime/BeamCli/Contracts/Constants.cs
+++ b/client/Packages/com.beamable/Common/Runtime/BeamCli/Contracts/Constants.cs
@@ -1,0 +1,11 @@
+namespace Beamable.Common.BeamCli.Contracts
+{
+	public static class CliConstants
+	{
+		/// <summary>
+		/// A magical constant that is used in the 'beam project generate-props` call to signify that the
+		/// $(SolutionDir) should be set to the same place as the Directory.Build.Props file.
+		/// </summary>
+		public const string GENERATE_PROPS_SLN_NEXT_TO_PROPS = "<dir.props>";
+	}
+}

--- a/client/Packages/com.beamable/Common/Runtime/BeamCli/Contracts/Constants.cs.meta
+++ b/client/Packages/com.beamable/Common/Runtime/BeamCli/Contracts/Constants.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 54da9e6a4eea4cd99e021d8a2dd76cdf
+timeCreated: 1712339999


### PR DESCRIPTION
1. instead of passing in a groovy string over the CLI- use a keyphrase to indicate the pattern
2. defer final handling until after STDOUT callback has had a chance to run