### PR TITLE
more dotnet 8 porting and fixing builds

### DIFF
--- a/build/bin/modify-unity-files.sh
+++ b/build/bin/modify-unity-files.sh
@@ -23,6 +23,7 @@ rm -f client/Packages/com.beamable/Runtime/Environment/Resources/env-staging.jso
 rm -f client/Packages/com.beamable/Runtime/Environment/Resources/env-prod.json
 rm -f client/Packages/com.beamable/Runtime/Environment/Resources/env-prod.json.meta
 
-# map samples
-# TODO
+# remove generated cli folder
+rm -rf client/Packages/com.beamable/Editor/BeamCli/Commands/bin
+rm -rf client/Packages/com.beamable/Editor/BeamCli/Commands/obj
 

--- a/cli/tests/tests.csproj
+++ b/cli/tests/tests.csproj
@@ -9,7 +9,7 @@
 
         <OutputType>Library</OutputType>
 
-        <LangVersion>10</LangVersion>
+        <LangVersion>11</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/client/Assets/ExampleScript.cs
+++ b/client/Assets/ExampleScript.cs
@@ -1,0 +1,7 @@
+namespace DefaultNamespace
+{
+	public class ExampleScript
+	{
+		
+	}
+}

--- a/client/Assets/ExampleScript.cs.meta
+++ b/client/Assets/ExampleScript.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6e4115ca0a4f4e348961a6b8fa774b09
+timeCreated: 1713276417

--- a/client/Assets/StolenUtils.cs
+++ b/client/Assets/StolenUtils.cs
@@ -1,0 +1,7 @@
+namespace DefaultNamespace
+{
+	public class StolenUtils
+	{
+		
+	}
+}

--- a/client/Assets/StolenUtils.cs.meta
+++ b/client/Assets/StolenUtils.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fc4c4a739e7a47e9a573cd492c751d9c
+timeCreated: 1713276750

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCommand.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCommand.cs
@@ -53,7 +53,7 @@ namespace Beamable.Editor.BeamCli.Commands
 				refreshToken = _requester?.AccessToken?.RefreshToken,
 				log = "Information",
 				skipStandaloneValidation = true,
-				dotnetPath = DotnetUtil.DotnetPath,
+				dotnetPath = Path.GetFullPath(DotnetUtil.DotnetPath),
 				quiet = true,
 			};
 			return beamArgs;

--- a/client/Packages/com.beamable/Samples/LightBeamSamples/FriendsManager/Prefabs/Selector/Editor/LightBeam.FriendsManager.Selector.Editor.asmdef
+++ b/client/Packages/com.beamable/Samples/LightBeamSamples/FriendsManager/Prefabs/Selector/Editor/LightBeam.FriendsManager.Selector.Editor.asmdef
@@ -2,7 +2,7 @@
     "name": "LightBeam.FriendsManager.Selector.Editor",
     "rootNamespace": "",
     "references": [
-        "GUID:b0ad3935c4c674c07a88e2e7adf00841"
+        "LightBeam.FriendsManager"
     ],
     "includePlatforms": [
         "Editor"

--- a/microservice/beamable.tooling.common/Microservice/ServiceMethod.cs
+++ b/microservice/beamable.tooling.common/Microservice/ServiceMethod.cs
@@ -33,17 +33,17 @@ namespace Beamable.Server
 		/// <summary>
 		/// Whether or not this is a method that is meant to be called by the beamable backend as part of one of our federated flows (<see cref="FederatedLoginCallableGenerator"/>).
 		/// </summary>
-		public bool IsFederatedCallbackMethod { get; init; }
+		public bool IsFederatedCallbackMethod { get; set; }
 		
 		/// <summary>
 		/// The tag associated with the service method.
 		/// </summary>
-		public string Tag { get; init; }
+		public string Tag { get; set; }
 
 		/// <summary>
 		/// The path associated with the service method.
 		/// </summary>
-		public string Path { get; init; }
+		public string Path { get; set; }
 
 		/// <summary>
 		/// Factory function to create an instance of the service method's target.
@@ -53,22 +53,22 @@ namespace Beamable.Server
 		/// <summary>
 		/// The set of required scopes for accessing the service method.
 		/// </summary>
-		public HashSet<string> RequiredScopes { get; init; }
+		public HashSet<string> RequiredScopes { get; set; }
 
 		/// <summary>
 		/// Indicates whether an authenticated user is required to access the service method.
 		/// </summary>
-		public bool RequireAuthenticatedUser { get; init; }
+		public bool RequireAuthenticatedUser { get; set; }
 
 		/// <summary>
 		/// List of parameter information for the service method.
 		/// </summary>
-		public List<ParameterInfo> ParameterInfos { get; init; }
+		public List<ParameterInfo> ParameterInfos { get; set; }
 
 		/// <summary>
 		/// The method to be invoked for the service.
 		/// </summary>
-		public MethodInfo Method { get; init; }
+		public MethodInfo Method { get; set; }
 
 		/// <summary>
 		/// List of parameter deserializers for the service method.
@@ -78,7 +78,7 @@ namespace Beamable.Server
 		/// <summary>
 		/// List of parameter names for the service method.
 		/// </summary>
-		public List<string> ParameterNames { get; init; }
+		public List<string> ParameterNames { get; set; }
 
 		/// <summary>
 		/// Dictionary mapping parameter names to their corresponding deserializers.

--- a/microservice/beamable.tooling.common/beamable.tooling.common.csproj
+++ b/microservice/beamable.tooling.common/beamable.tooling.common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <LangVersion>11</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
@@ -14,8 +14,6 @@
       <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.3.2" />
       <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
       <PackageReference Include="Serilog" Version="2.10.0" />
-        <PackageReference Include="System.Text.Json" Version="8.0.0"/>
-        <PackageReference Include="Meziantou.Polyfill" Version="1.0.37"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/microservice/beamable.tooling.common/beamable.tooling.common.csproj
+++ b/microservice/beamable.tooling.common/beamable.tooling.common.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>11</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -13,6 +14,8 @@
       <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.3.2" />
       <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
       <PackageReference Include="Serilog" Version="2.10.0" />
+        <PackageReference Include="System.Text.Json" Version="8.0.0"/>
+        <PackageReference Include="Meziantou.Polyfill" Version="1.0.37"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/microservice/microservice/microservice.csproj
+++ b/microservice/microservice/microservice.csproj
@@ -12,11 +12,11 @@
 
     <DefineConstants>DB_MICROSERVICE;DISABLE_BEAMABLE_ASYNCMETHODBUILDER;BEAMABLE_IGNORE_MONGO_MOCKS</DefineConstants>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 
     <AssemblyName>BeamableMicroserviceBase</AssemblyName>
 
-    <LangVersion>10</LangVersion>
+    <LangVersion>11</LangVersion>
 
 
 

--- a/microservice/microservice/microservice.csproj
+++ b/microservice/microservice/microservice.csproj
@@ -17,7 +17,8 @@
     <AssemblyName>BeamableMicroserviceBase</AssemblyName>
 
     <LangVersion>11</LangVersion>
-
+    <!-- These warnings are XML documentation missing related   -->
+    <NoWarn>1573,1591,1574,1572</NoWarn>
 
 
   </PropertyGroup>
@@ -26,7 +27,6 @@
 
   <PropertyGroup>
 
-    <NoWarn>1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/microservice/microserviceTests/microserviceTests.csproj
+++ b/microservice/microserviceTests/microserviceTests.csproj
@@ -9,7 +9,7 @@
         <DefineConstants>DB_MICROSERVICE;DISABLE_BEAMABLE_ASYNCMETHODBUILDER</DefineConstants>
         <TargetFramework>net6.0</TargetFramework>
         <AssemblyName>BeamableMicroserviceBaseTests</AssemblyName>
-        <LangVersion>10</LangVersion>
+        <LangVersion>11</LangVersion>
         <OutputType>Library</OutputType>
 
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/templates/BeamService/BeamService.csproj
+++ b/templates/BeamService/BeamService.csproj
@@ -19,7 +19,7 @@
         <OutputType>Exe</OutputType>
 
         <!-- As of Beamable 1.0, net6.0 is required. -->
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <!-- Advanced C# Features are disabled by default. The Unity SDK does not support these features. 
              If you enable them, it will be harder to copy/paste code between the service and Unity. -->
         <ImplicitUsings>disable</ImplicitUsings>

--- a/templates/BeamStorage/BeamStorage.csproj
+++ b/templates/BeamStorage/BeamStorage.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <!-- Make sure that the built dlls and their dependencies are in the output directory -->


### PR DESCRIPTION
1. downgrading one of our libraries from netX to netstandard. My thinking here is that our utility libraries should really not be targetting netX version at all, ever. NetX changes every few years, and keeping up with the maintenance is a struggle. We'll have to pay that for SOME of our projects, but ideally a limited set. 
2. remove some bad files from the release process
3. use full dotnet path