### PR TITLE
remove source link

### DIFF
--- a/cli/cli/Services/VersionService.cs
+++ b/cli/cli/Services/VersionService.cs
@@ -93,7 +93,7 @@ public class VersionService
 	public static PackageVersion GetNugetPackagesForExecutingCliVersion()
 	{
 		var currentVersion = GetExecutingCliVersion();
-		if (currentVersion.Major == 0)
+		if (currentVersion.Major == 0 || currentVersion == "1.0.0")
 		{
 			// if the major is 0, then its likely 0.0.0 or 0.0.123, 
 			//  which means we want to use our local dev nuget package version, which is 0.0.123

--- a/client/Packages/com.beamable/Common/Runtime/Util/BeamAssemblyVersionUtil.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Util/BeamAssemblyVersionUtil.cs
@@ -22,7 +22,28 @@ namespace Beamable.Common.Util
 		public static string GetVersion(Type t)
 		{
 			var attribute = t.Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-			return attribute.InformationalVersion;
+			
+			// starting with net8, the attribute includes the commit hash, which we don't want.
+			return RemoveSourceLinkFromVersion(attribute.InformationalVersion);
+		}
+
+		/// <summary>
+		/// A utility method to take a semver string and remove the SourceLink part of the string, which
+		/// is signaled by a '+' character.
+		/// In Beamable's use cases, the SourceLink invalidates several versioning assumptions.
+		/// https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/source-link 
+		/// </summary>
+		/// <param name="informationVersion"></param>
+		/// <returns></returns>
+		public static string RemoveSourceLinkFromVersion(string informationVersion)
+		{
+			var plusSymbolIndex = informationVersion.IndexOf('+');
+			if (plusSymbolIndex >= 0)
+			{
+				informationVersion = informationVersion.Substring(0, plusSymbolIndex);
+			}
+
+			return informationVersion;
 		}
 	}
 }


### PR DESCRIPTION
In net8, the version string we were using gets a default change. 

https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/source-link

I don't want to turn it off at a project level, because we may benefit from the source link stuff at dev/IDE time... But for our runtime use cases, we don't need the source commit hash. 