### PR TITLE
[issue/3249] AssumeNewUser should not allow negative userId

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-=======
 ## [1.19.18]
 ### Changed
 - `async void` methods are not allowed in Microservices, and will cause the Microservice to fail. Instead, consider using methods with `async Task`, or `async Promise`. 

--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+ - `AssumeNewUser` does not allow `userId` that is not a positive value
+
 ## [1.19.17]
 ### Fixed
 - Mock `Unity.Addressable` reference included in Microservice builds

--- a/client/Packages/com.beamable.server/SharedRuntime/Microservice.cs
+++ b/client/Packages/com.beamable.server/SharedRuntime/Microservice.cs
@@ -139,6 +139,12 @@ namespace Beamable.Server
 		[Obsolete("Please use the " + nameof(AssumeNewUser) +" instead")]
 		protected RequestHandlerData AssumeUser(long userId, bool requireAdminUser = true)
 		{
+			if (userId <= 0)
+			{
+				throw new InvalidArgumentException(
+					nameof(userId), $"Invalid User Id of value: {userId}. Should be a positive value.");
+			}
+
 			// require admin privs.
 			if (requireAdminUser)
 			{
@@ -182,6 +188,12 @@ namespace Beamable.Server
 		/// <returns>A <see cref="UserRequestDataHandler"/> object that contains a request context, and a collection of services to execute SDK calls against.</returns>
 		protected UserRequestDataHandler AssumeNewUser(long userId, Action<IDependencyBuilder> configurator = null, bool requireAdminUser = true)
 		{
+			if (userId <= 0)
+			{
+				throw new InvalidArgumentException(
+					nameof(userId), $"Invalid User Id of value: {userId}. Should be a positive value.");
+			}
+
 			// require admin privs.
 			if (requireAdminUser)
 			{

--- a/client/Packages/com.beamable.server/SharedRuntime/MicroserviceException.cs
+++ b/client/Packages/com.beamable.server/SharedRuntime/MicroserviceException.cs
@@ -107,4 +107,13 @@ namespace Beamable.Server
 
 		}
 	}
+
+	public class InvalidArgumentException : MicroserviceException
+	{
+		public InvalidArgumentException(string argumentName, string message) : base(400, "invalidArgument",
+			$"Invalid value passed to argument [{argumentName}]. Message: {message}")
+		{
+
+		}
+	}
 }


### PR DESCRIPTION
# Ticket

resolves #3249 

# Brief Description

We should forbid invalid userIds in the call of `AssumeNewUser`. However that is more complicated since
it would require an API call to do so. In that case we are only checking if the `userId` is a positive value.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
