### PR TITLE
fixes 3323 - async void no-no

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.19.18]
 ### Changed
-- `async void` methods are not allowed in Microservices
+- `async void` methods are not allowed in Microservices, and will cause the Microservice to fail. Instead, consider using methods with `async Task`, or `async Promise`. 
 
 ## [1.19.17]
 ### Fixed

--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.18]
+### Changed
+- `async void` methods are not allowed in Microservices
+
 ## [1.19.17]
 ### Fixed
 - Mock `Unity.Addressable` reference included in Microservice builds

--- a/microservice/beamable.tooling.common/Microservice/ServiceMethodHelper.cs
+++ b/microservice/beamable.tooling.common/Microservice/ServiceMethodHelper.cs
@@ -269,6 +269,14 @@ namespace Beamable.Server
             var requiredUser = attribute.RequireAuthenticatedUser;
 
             Log.Debug("Found {method} for {path}", method.Name, servicePath);
+            
+            var isAsync = null != method.GetCustomAttribute<AsyncStateMachineAttribute>();
+            var isVoid = method.ReturnType == typeof(void);
+            if (isAsync && isVoid)
+            {
+	            throw new BeamableMicroserviceException($"The following method is invalid, method=[{type.Name}.{method.Name}]. Callable methods in Beamable Microservices are not allowed to have the `async void` method signature. Consider using `async Promise` or `async Task` instead. ");
+            }
+            
             var serviceMethod = CreateMethod(
 	            serviceAttribute,
 	            provider,

--- a/microservice/microserviceTests/microservice/dbmicroservice/BeamableMicroServiceTests/AsyncVoidTests.cs
+++ b/microservice/microserviceTests/microservice/dbmicroservice/BeamableMicroServiceTests/AsyncVoidTests.cs
@@ -1,0 +1,97 @@
+using Beamable.Common;
+using Beamable.Microservice.Tests.Socket;
+using Beamable.Server;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+
+namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTests;
+
+public class AsyncVoidTests : CommonTest
+{
+	[Test]
+	[NonParallelizable]
+	public async Task ClientCallablesWithAsyncVoidShouldGoKerblam()
+	{
+		TestSocket testSocket = null;
+		var ms = new TestSetup(new TestSocketProvider(socket =>
+		{
+			testSocket = socket;
+			socket.AddStandardMessageHandlers();
+		}));
+
+		Assert.ThrowsAsync<BeamableMicroserviceException>(async () =>
+		{
+			await ms.Start<InvalidService_AsyncVoids>(new TestArgs());
+		});
+	}
+	
+	
+	[Test]
+	[NonParallelizable]
+	public async Task InitializeAndShutdown()
+	{
+
+		TestSocket testSocket = null;
+		var ms = new TestSetup(new TestSocketProvider(socket =>
+		{
+			testSocket = socket;
+			socket.AddStandardMessageHandlers();
+		}));
+
+		await ms.Start<ValidService_VariousSigs>(new TestArgs());
+		Assert.IsTrue(ms.HasInitialized);
+
+		// simulate shutdown event...
+		await ms.OnShutdown(this, null);
+		Assert.IsTrue(testSocket.AllMocksCalled());
+	}
+
+
+
+	[Microservice("invalid_asyncVoids", UseLegacySerialization = true, EnableEagerContentLoading = false)]
+	public class InvalidService_AsyncVoids : Microservice
+	{
+		[ClientCallable]
+		public async void IShouldNotExist()
+		{
+		   
+		}
+	}
+
+	[Microservice("valid_asyncs", UseLegacySerialization = true, EnableEagerContentLoading = false)]
+	public class ValidService_VariousSigs : Microservice
+	{
+		[ClientCallable]
+		public void Void()
+		{
+		   
+		}
+		
+		[ClientCallable]
+		public Promise Promise()
+		{
+		   return Beamable.Common.Promise.Success;
+		}
+		
+		[ClientCallable]
+		public Promise<int> PromiseGeneric()
+		{
+			return Promise<int>.Successful(3);
+		}
+		
+		[ClientCallable]
+		public Task Task()
+		{
+			return System.Threading.Tasks.Task.CompletedTask;
+		}
+		
+		
+		[ClientCallable]
+		public Task<int> TaskGeneric()
+		{
+			return System.Threading.Tasks.Task.FromResult(3);
+		}
+	}
+
+}


### PR DESCRIPTION
adds a validation step when scanning for client-callables that will cause the `Start` method to explode.