### PR TITLE
fixes 3335 - usam refresh button broken, and some speed improvements

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI2/UsamWindow.cs
+++ b/client/Packages/com.beamable.server/Editor/UI2/UsamWindow.cs
@@ -127,7 +127,7 @@ namespace Beamable.Editor.Microservice.UI2
 		private void HandleRefreshButtonClicked()
 		{
 			_codeService = Scope.GetService<CodeService>();
-			_codeService.RefreshServices().Then(_ => Build());
+			_codeService.Init().Then(_ => Build()).Error(Debug.LogError);
 		}
 
 		private void HandleCreateNewButtonClicked(ServiceType serviceType)

--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/CodeService.cs
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/CodeService.cs
@@ -69,6 +69,9 @@ namespace Beamable.Server.Editor.Usam
 		{
 			if (EditorApplication.isPlayingOrWillChangePlaymode)
 				return;
+			
+			UsamLogger.ResetLogTimer();
+			
 			UsamLogger.Log("Running init");
 			_services = GetBeamServices();
 			UsamLogger.Log("Have services");
@@ -119,6 +122,7 @@ namespace Beamable.Server.Editor.Usam
 			
 			
 			UsamLogger.Log("Completed");
+			UsamLogger.StopLogTimer();
 		}
 
 		public async Promise Migrate(List<IDescriptor> allDescriptors, Action<float, string> updateCallback, CancellationToken token)

--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/CodeService.cs
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/CodeService.cs
@@ -477,8 +477,7 @@ namespace Beamable.Server.Editor.Usam
 
 		private void PopulateDataWithLocal()
 		{
-			_services = GetBeamServices();
-			_storages = GetBeamStorages();
+			GetBeamServicePosts(out _services, out _storages);
 
 			for (int i = 0; i < _services.Count; i++)
 			{

--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/SolutionPostProcessor.cs
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/SolutionPostProcessor.cs
@@ -40,14 +40,13 @@ EndProject";
 
 		public static string OnGeneratedSlnSolution(string path, string content)
 		{
-			var serviceFiles = CodeService.GetBeamServices();
+			CodeService.GetBeamServicePosts(out var serviceFiles, out var storageFiles);
 			// TODO: Validate that these files actually exist/map to valid projects
 			foreach (var signpost in serviceFiles)
 			{
 				content = InjectProject(content, signpost.name, signpost.CsprojFilePath);
 			}
 
-			var storageFiles = CodeService.GetBeamStorages();
 			// TODO: Validate that these files actually exist/map to valid projects
 			foreach (var signpost in storageFiles)
 			{

--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/UsamLogger.cs
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/UsamLogger.cs
@@ -8,11 +8,39 @@ namespace Beamable.Server.Editor.Usam
 	[SpewLogger]
 	public class UsamLogger
 	{
+		private static long _previousStopWatchSeconds;
+		private static Stopwatch _stopwatch = new Stopwatch();
+		
 		[Conditional(Constants.Features.Spew.SPEW_ALL), Conditional(Constants.Features.Spew.SPEW_USAM)]
 		public static void Log(params object[] msg)
 		{
-			Logger.DoSimpleSpew("USAM: " + string.Join(",", msg.Select(x => x?.ToString())));
+			if (_stopwatch.IsRunning)
+			{
+				var diff = _stopwatch.ElapsedMilliseconds - _previousStopWatchSeconds;
+				Logger.DoSimpleSpew($"USAM: total=({_stopwatch.ElapsedMilliseconds}) elapsed=({diff})" + string.Join(",", msg.Select(x => x?.ToString())));
+				_previousStopWatchSeconds = _stopwatch.ElapsedMilliseconds;
+
+			}
+			else
+			{			
+				Logger.DoSimpleSpew($"USAM: " + string.Join(",", msg.Select(x => x?.ToString())));
+			}
+		}
+		
+		[Conditional(Constants.Features.Spew.SPEW_ALL), Conditional(Constants.Features.Spew.SPEW_USAM)]
+		public static void ResetLogTimer()
+		{
+			_stopwatch.Restart();
+			_previousStopWatchSeconds = 0;
+		}
+		
+		[Conditional(Constants.Features.Spew.SPEW_ALL), Conditional(Constants.Features.Spew.SPEW_USAM)]
+		public static void StopLogTimer()
+		{
+			_stopwatch.Stop();
+			_previousStopWatchSeconds = 0;
 		}
 	}
+
 }
 

--- a/client/Packages/com.beamable/Common/Runtime/BeamCli/ErrorOutput.cs
+++ b/client/Packages/com.beamable/Common/Runtime/BeamCli/ErrorOutput.cs
@@ -27,4 +27,10 @@ namespace Beamable.Common.BeamCli
 		public string fullTypeName;
 		public string stackTrace;
 	}
+
+	[Serializable]
+	public class EofOutput
+	{
+		// nothing. 
+	}
 }

--- a/client/Packages/com.beamable/Common/Runtime/BeamCli/IBeamCommand.cs
+++ b/client/Packages/com.beamable/Common/Runtime/BeamCli/IBeamCommand.cs
@@ -9,6 +9,7 @@ namespace Beamable.Common.BeamCli
 		IBeamCommand On<T>(string type, Action<ReportDataPoint<T>> cb);
 		IBeamCommand On(Action<ReportDataPointDescription> cb);
 		IBeamCommand OnError(Action<ReportDataPoint<ErrorOutput>> cb);
+		IBeamCommand OnTerminate(Action<ReportDataPoint<EofOutput>> cb);
 	}
 
 	public class BeamCommandWrapper

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCommand.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCommand.cs
@@ -359,21 +359,15 @@ namespace Beamable.Editor.BeamCli
 							return;
 						}
 
-						// if (!_earlyExit)
+
+						_dispatcher.Schedule(() =>
 						{
-							_dispatcher.Schedule(() =>
-							{
-								if (_exitCode >= 0) return;
-								// there still may pending log lines, so we need to make sure they get processed before claiming the process is complete
-								// _hasExited = true;
-								_exitCode = _process.ExitCode;
+							if (_exitCode >= 0) return;
+							// there still may pending log lines, so we need to make sure they get processed before claiming the process is complete
+							_exitCode = _process.ExitCode;
+							_status.TrySetResult(0);
+						});
 
-								// OnExit?.Invoke(_process.ExitCode);
-								// HandleOnExit();
-
-								_status.TrySetResult(0);
-							});
-						}
 					});
 				};
 

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCommand.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCommand.cs
@@ -55,6 +55,7 @@ namespace Beamable.Editor.BeamCli.Commands
 				skipStandaloneValidation = true,
 				dotnetPath = Path.GetFullPath(DotnetUtil.DotnetPath),
 				quiet = true,
+				raw = true
 			};
 			return beamArgs;
 		}
@@ -161,7 +162,7 @@ namespace Beamable.Editor.BeamCli
 		private Process _process;
 		protected virtual bool CaptureStandardBuffers => true;
 		public bool AutoLogErrors { get; set; } = false;
-		private TaskCompletionSource<int> _status, _standardOutComplete;
+		private TaskCompletionSource<int> _status;
 
 		protected int _exitCode = -1;
 		private bool _hasExecuted;
@@ -191,6 +192,11 @@ namespace Beamable.Editor.BeamCli
 		public IBeamCommand OnError(Action<ReportDataPoint<ErrorOutput>> cb)
 		{
 			return On<ErrorOutput>("error", cb);
+		}
+		
+		public IBeamCommand OnTerminate(Action<ReportDataPoint<EofOutput>> cb)
+		{
+			return On<EofOutput>("eof", cb);
 		}
 
 		public IBeamCommand On<T>(string type, Action<ReportDataPoint<T>> cb)
@@ -306,6 +312,8 @@ namespace Beamable.Editor.BeamCli
 			if (string.IsNullOrEmpty(Command)) throw new InvalidOperationException("must set command before running");
 			_hasExecuted = true;
 
+			
+			
 			using (_process = new System.Diagnostics.Process())
 			{
 				if (_command.Contains(".dll"))
@@ -340,7 +348,6 @@ namespace Beamable.Editor.BeamCli
 				_process.StartInfo.EnvironmentVariables["BEAM_DOTNET_PATH"] = Path.GetFullPath(DotnetUtil.DotnetPath);
 				
 				_status = new TaskCompletionSource<int>();
-				_standardOutComplete = new TaskCompletionSource<int>();
 				EventHandler eh = (s, e) =>
 				{
 					Task.Run(async () =>
@@ -352,22 +359,34 @@ namespace Beamable.Editor.BeamCli
 							return;
 						}
 
-						_dispatcher.Schedule(() =>
+						// if (!_earlyExit)
 						{
-							// there still may pending log lines, so we need to make sure they get processed before claiming the process is complete
-							// _hasExited = true;
-							_exitCode = _process.ExitCode;
+							_dispatcher.Schedule(() =>
+							{
+								if (_exitCode >= 0) return;
+								// there still may pending log lines, so we need to make sure they get processed before claiming the process is complete
+								// _hasExited = true;
+								_exitCode = _process.ExitCode;
 
-							// OnExit?.Invoke(_process.ExitCode);
-							// HandleOnExit();
+								// OnExit?.Invoke(_process.ExitCode);
+								// HandleOnExit();
 
-							_status.TrySetResult(0);
-						});
+								_status.TrySetResult(0);
+							});
+						}
 					});
 				};
 
 				_process.Exited += eh;
 
+				var earlyExitTask = new TaskCompletionSource<int>();
+				OnTerminate(_ =>
+				{
+					CliLogger.Log("Early EOF exit");
+					_exitCode = 0;
+					earlyExitTask.SetResult(1);
+				});
+				
 				var pid = 0;
 				try
 				{
@@ -432,7 +451,7 @@ namespace Beamable.Editor.BeamCli
 					_process.BeginOutputReadLine();
 					_process.BeginErrorReadLine();
 
-					await _status.Task;
+					await Task.WhenAny(_status.Task, earlyExitTask.Task);
 
 					IEnumerator Defer()
 					{


### PR DESCRIPTION
When you click refresh, we need to re-init, not just refresh the services; this is because the refresh function relies on variables destroyed by the domain reload. 

Also, I added in the log EOF thing for CLI invocations, to allow for the SDK client to stop caring about process handles after they receive the EOF signal. 

Also also, We were doing to recursive file scans, and I combined them into one, which saved about 250ms on my machine (each recursive scan took 250ms, so cutting one was good). 