### PR TITLE
[3360] Restructure the way that microservice clients are generated to make it easier for customer to choose in which module they want to use it

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -38,6 +38,12 @@ In most cases, this is as trivial as renaming the type inside the microservice t
 - Microservices install with current CLI version
 - Standalone Microservices no longer have a `LoadEnvironmentVariables` method, and connection strings are handled in the existing `Prepare` method.
 - `beam project generate-env` command writes a blank `.env` file and returns connection strings over STDOUT instead.
+- Generating microservice clients for Unreal now outputs them to a Plugin called `[ProjectName]MicroserviceClients` instead of placing it in some existing module. Update flow: 
+  - Delete your microservice client files in the various `AutoGen` folders where they used to live.
+  - Do a clean rebuild of your microservice solution to re-run the generation.
+  - Add `[ProjectName]MicroserviceClients.AddMicroserviceClient(Module)` to all your `Build.cs` files of modules in which you want to use the clients.
+  - Add `[ProjectName]MicroserviceClients` to the list of plugins in your project (or as a dependency of other plugins in which you want to use the clients).
+  - Rebuild your project.
 
 ### Fixed
 

--- a/cli/cli/Services/ProjectService.cs
+++ b/cli/cli/Services/ProjectService.cs
@@ -72,7 +72,7 @@ public class ProjectData
 		public bool Equals(Unreal other) => Path == other.Path;
 
 		public override bool Equals(object obj) => (obj is Unreal unreal && Equals(unreal)) ||
-												   (obj is string unrealPath && Equals(unrealPath));
+		                                           (obj is string unrealPath && Equals(unrealPath));
 
 		public override int GetHashCode() => (Path != null ? Path.GetHashCode() : 0);
 
@@ -117,52 +117,10 @@ public class ProjectService
 		_configService.SaveDataFile(Constants.CONFIG_LINKED_PROJECTS, _projects);
 	}
 
-	public void AddUnrealProjectWithOss(string projectPath)
+	public void AddUnrealProject(string projectPath, string microservicePluginName, string microservicePluginNameBp)
 	{
 		// Always ensure that we store things relative to the root of the UE project (not the repo)
 		var unrealRootPath = EnsureUnrealRootPath(projectPath);
-
-		// Ensure we have the OSS as a plugin.
-		var foundOss = unrealRootPath.GetDirectories("Plugins/OnlineSubsystemBeamable").Any();
-		if (!foundOss) throw new CliException("The selected UE project does not contain the OnlineSubsystemBeamable plugin. You should never see this. If you do, report a bug.");
-
-		// Find beamable folder (it must exist either as a parent of the UE project root OR inside the UE project root folder.
-		var beamableFolderPath = FindBeamableFolderPath(unrealRootPath);
-
-		// The path must always be stored relative to the .beamable folder as we run commands always through that.
-		projectPath = Path.GetRelativePath(beamableFolderPath.ToString(), unrealRootPath.ToString());
-		projectPath = projectPath.StartsWith(".") ? projectPath.Substring(1) : projectPath;
-		projectPath = projectPath.StartsWith("/") ? projectPath.Substring(1) : projectPath;
-
-		// Configure the ProjectData for Unreal
-		var projData = new ProjectData.Unreal();
-		projData.Path = projectPath;
-		projData.SourceFilesPath = projectPath + "Plugins/OnlineSubsystemBeamable/Source/";
-
-		projData.CoreProjectName = "OnlineSubsystemBeamable";
-		projData.BlueprintNodesProjectName = "OnlineSubsystemBeamableBp";
-
-		// These are defined relative to the SourceFilesPath
-		projData.MsCoreHeaderPath = projData.CoreProjectName + "/Public/Customer/";
-		projData.MsCoreCppPath = projData.CoreProjectName + "/Private/Customer/";
-		projData.MsBlueprintNodesHeaderPath = projData.BlueprintNodesProjectName + "/Public/Customer/";
-		projData.MsBlueprintNodesCppPath = projData.BlueprintNodesProjectName + "/Private/Customer/";
-
-		projData.BeamableBackendGenerationPassFile = projectPath + $"Plugins/BeamableCore/Source/{UnrealSourceGenerator.currentGenerationPassDataFilePath}.json";
-
-		// Save it
-		_projects.unrealProjectsPaths.Add(projData);
-		_configService.SaveDataFile(Constants.CONFIG_LINKED_PROJECTS, _projects);
-	}
-
-	public void AddUnrealProject(string projectPath, string msClientModuleName, string blueprintNodesModuleName, bool msClientModuleIsPublicPrivate, bool blueprintNodesModuleIsPublicPrivate)
-	{
-		// Always ensure that we store things relative to the root of the UE project (not the repo)
-		var unrealRootPath = EnsureUnrealRootPath(projectPath);
-
-		// Ensure we DON'T have the OSS as a plugin.
-		var foundOss = unrealRootPath.GetDirectories("Plugins/OnlineSubsystemBeamable").Any();
-		if (foundOss) throw new CliException("The selected UE project contains the OnlineSubsystemBeamable plugin. If you're a customer seeing this, please report a bug.");
 
 		// Find beamable folder (it must exist either as a parent of the UE project root OR inside the UE project root folder.
 		var beamableFolderPath = FindBeamableFolderPath(unrealRootPath);
@@ -176,16 +134,16 @@ public class ProjectService
 
 		var pathToBackendGenerationJson = $"Plugins/BeamableCore/Source/{UnrealSourceGenerator.currentGenerationPassDataFilePath}.json";
 		projData.Path = projectPath;
-		projData.SourceFilesPath = projectPath + (string.IsNullOrEmpty(projectPath) ? "Source/" : "/Source/");
+		projData.SourceFilesPath = projectPath + $"Plugins/{microservicePluginName}/";
 
-		projData.CoreProjectName = msClientModuleName;
-		projData.BlueprintNodesProjectName = blueprintNodesModuleName;
+		projData.CoreProjectName = microservicePluginName;
+		projData.BlueprintNodesProjectName = microservicePluginNameBp;
 
 		// These are defined relative to the SourceFilesPath
-		projData.MsCoreHeaderPath = projData.CoreProjectName + (msClientModuleIsPublicPrivate ? "/Public/" : "/");
-		projData.MsCoreCppPath = projData.CoreProjectName + (msClientModuleIsPublicPrivate ? "/Private/" : "/");
-		projData.MsBlueprintNodesHeaderPath = projData.BlueprintNodesProjectName + (blueprintNodesModuleIsPublicPrivate ? "/Public/" : "/");
-		projData.MsBlueprintNodesCppPath = projData.BlueprintNodesProjectName + (blueprintNodesModuleIsPublicPrivate ? "/Private/" : "/");
+		projData.MsCoreHeaderPath = "Source/" + projData.CoreProjectName + "/Public/";
+		projData.MsCoreCppPath = "Source/" + projData.CoreProjectName + "/Private/";
+		projData.MsBlueprintNodesHeaderPath = "Source/" + projData.BlueprintNodesProjectName + "/Public/";
+		projData.MsBlueprintNodesCppPath = "Source/" + projData.BlueprintNodesProjectName + "/Private/";
 
 		projData.BeamableBackendGenerationPassFile = projectPath + pathToBackendGenerationJson;
 
@@ -229,7 +187,7 @@ public class ProjectService
 		var info = await GetTemplateInfo();
 
 		if (!info.HasTemplates ||
-			!string.Equals(version, info.templateVersion, StringComparison.CurrentCultureIgnoreCase))
+		    !string.Equals(version, info.templateVersion, StringComparison.CurrentCultureIgnoreCase))
 		{
 			await PromptAndInstallTemplates(info.templateVersion, version, true);
 		}
@@ -385,6 +343,7 @@ public class ProjectService
 			throw new CliException(
 				$"Solution file({microserviceInfo.SolutionPath}) should not exists outside working directory({_configService.WorkingDirectory}) or its subdirectories.");
 		}
+
 		if (!File.Exists(microserviceInfo.SolutionPath))
 		{
 			string correctSlnPath = string.Empty;
@@ -411,6 +370,7 @@ public class ProjectService
 			var directory = Path.GetDirectoryName(microserviceInfo.SolutionPath);
 			args.ServicesBaseFolderPath = Path.Combine(directory!, "services");
 		}
+
 		microserviceInfo.ServicePath = Path.Combine(args.ServicesBaseFolderPath, args.ProjectName);
 		await RunDotnetCommand($"new beamstorage -n {args.ProjectName} -o {microserviceInfo.ServicePath}");
 		await RunDotnetCommand($"sln {microserviceInfo.SolutionPath} add {microserviceInfo.ServicePath}");
@@ -423,10 +383,7 @@ public class ProjectService
 		string usedVersion = args.SpecifiedVersion.ToString();
 		await EnsureCanUseTemplates(usedVersion);
 
-		var microserviceInfo = new NewServiceInfo
-		{
-			SolutionPath = args.SlnFilePath
-		};
+		var microserviceInfo = new NewServiceInfo { SolutionPath = args.SlnFilePath };
 		if (!args.GetSlnExists())
 		{
 			await CreateNewSolution(args.GetSlnDirectory(), args.GetSlnFileName());
@@ -472,6 +429,7 @@ public class ProjectService
 		{
 			throw new CliException($"{solutionPath} does not exist");
 		}
+
 		var commonProjectName = $"{projectName}Common";
 		var projectPath = Path.Combine(rootServicesPath, projectName);
 		var commonProjectPath = Path.Combine(rootServicesPath, commonProjectName);
@@ -615,6 +573,7 @@ COPY {commonProjectName}/. .
 			throw new CliException(
 				$"The given id=[{serviceName}] does not match any local services in the local beamo manifest.");
 		}
+
 		var canBeBuiltLocally = args.BeamoLocalSystem.VerifyCanBeBuiltLocally(serviceName);
 		if (!canBeBuiltLocally)
 		{
@@ -640,11 +599,7 @@ COPY {commonProjectName}/. .
 		using var cts = new CancellationTokenSource();
 
 		var command = CliExtensions.GetDotnetCommand(args.AppContext.DotnetPath, commandStr)
-			.WithEnvironmentVariables(new Dictionary<string, string>
-			{
-				["DOTNET_WATCH_SUPPRESS_EMOJIS"] = "1",
-				["DOTNET_WATCH_RESTART_ON_RUDE_EDIT"] = "1",
-			})
+			.WithEnvironmentVariables(new Dictionary<string, string> { ["DOTNET_WATCH_SUPPRESS_EMOJIS"] = "1", ["DOTNET_WATCH_RESTART_ON_RUDE_EDIT"] = "1", })
 			.WithStandardOutputPipe(PipeTarget.ToDelegate(line =>
 			{
 				if (line.Trim() == "dotnet watch : Waiting for a file to change before restarting dotnet...")
@@ -692,11 +647,7 @@ COPY {commonProjectName}/. .
 				});
 			}
 
-			return new ProjectErrorReport
-			{
-				errors = outputs,
-				isSuccess = outputs.Count == 0
-			};
+			return new ProjectErrorReport { errors = outputs, isSuccess = outputs.Count == 0 };
 		}
 		catch (Exception ex)
 		{
@@ -711,6 +662,7 @@ public class ProjectErrorReport
 	public bool isSuccess;
 	public List<ProjectErrorResult> errors = new List<ProjectErrorResult>();
 }
+
 public class ProjectErrorResult
 {
 	public string level;

--- a/cli/cli/Services/SwaggerService.cs
+++ b/cli/cli/Services/SwaggerService.cs
@@ -109,8 +109,10 @@ public class SwaggerService
 			// on the "Source" folder of the plugin (or, in SAMS case, the project)
 			if (targetEngine == TARGET_ENGINE_NAME_UNREAL)
 			{
+				UnrealSourceGenerator.includeStatementPrefix = "BeamableCore/Public/";
 				UnrealSourceGenerator.headerFileOutputPath = "BeamableCore/Public/";
 				UnrealSourceGenerator.cppFileOutputPath = "BeamableCore/Private/";
+				UnrealSourceGenerator.blueprintIncludeStatementPrefix = "BeamableCoreBlueprintNodes/Public/BeamFlow/ApiRequest/";
 				UnrealSourceGenerator.blueprintHeaderFileOutputPath = "BeamableCoreBlueprintNodes/Public/BeamFlow/ApiRequest/";
 				UnrealSourceGenerator.blueprintCppFileOutputPath = "BeamableCoreBlueprintNodes/Private/BeamFlow/ApiRequest/";
 				UnrealSourceGenerator.previousGenerationPassesData = new PreviousGenerationPassesData();

--- a/cli/cli/Services/UnrealSourceGenerator/Declarations/UnrealJsonSerializableTypeDeclaration.cs
+++ b/cli/cli/Services/UnrealSourceGenerator/Declarations/UnrealJsonSerializableTypeDeclaration.cs
@@ -415,8 +415,8 @@ void U{NamespacedTypeName}::DeserializeRequestResponse(UObject* RequestData, FSt
 
 
 		processDictionary.Add(nameof(exportMacro), exportMacro);
-		processDictionary.Add(nameof(headerFileOutputPath), headerFileOutputPath);
-		processDictionary.Add(nameof(blueprintHeaderFileOutputPath), blueprintHeaderFileOutputPath);
+		processDictionary.Add(nameof(includeStatementPrefix), includeStatementPrefix);
+		processDictionary.Add(nameof(blueprintIncludeStatementPrefix), blueprintIncludeStatementPrefix);
 
 		processDictionary.Add(nameof(NamespacedTypeName), NamespacedTypeName);
 		processDictionary.Add(nameof(UPropertyDeclarations), propertyDeclarations);
@@ -474,7 +474,7 @@ public:
 
 	public const string JSON_SERIALIZABLE_TYPE_CPP =
 		@$"
-#include ""₢{nameof(headerFileOutputPath)}₢AutoGen/₢{nameof(NamespacedTypeName)}₢.h""
+#include ""₢{nameof(includeStatementPrefix)}₢AutoGen/₢{nameof(NamespacedTypeName)}₢.h""
 ₢{nameof(JsonUtilsInclude)}₢
 ₢{nameof(DefaultValueHelpersInclude)}₢
 
@@ -502,7 +502,7 @@ void U₢{nameof(NamespacedTypeName)}₢::BeamDeserializeProperties(const TShare
 	public const string JSON_SERIALIZABLE_TYPES_LIBRARY_HEADER = $@"#pragma once
 
 #include ""CoreMinimal.h""
-#include ""₢{nameof(headerFileOutputPath)}₢AutoGen/₢{nameof(NamespacedTypeName)}₢.h""
+#include ""₢{nameof(includeStatementPrefix)}₢AutoGen/₢{nameof(NamespacedTypeName)}₢.h""
 
 #include ""₢{nameof(NamespacedTypeName)}₢Library.generated.h""
 
@@ -524,7 +524,7 @@ public:
 }};";
 
 	public const string JSON_SERIALIZABLE_TYPES_LIBRARY_CPP = $@"
-#include ""₢{nameof(headerFileOutputPath)}₢AutoGen/₢{nameof(NamespacedTypeName)}₢Library.h""
+#include ""₢{nameof(includeStatementPrefix)}₢AutoGen/₢{nameof(NamespacedTypeName)}₢Library.h""
 
 #include ""CoreMinimal.h""
 

--- a/cli/cli/Services/UnrealSourceGenerator/UnrealApiSubsystemDeclaration.cs
+++ b/cli/cli/Services/UnrealSourceGenerator/UnrealApiSubsystemDeclaration.cs
@@ -171,7 +171,7 @@ public struct UnrealApiSubsystemDeclaration
 
 		var isMSGen = UnrealSourceGenerator.genType == UnrealSourceGenerator.GenerationType.Microservice;
 		helperDict.Add(nameof(UnrealSourceGenerator.exportMacro), UnrealSourceGenerator.exportMacro);
-		helperDict.Add(nameof(UnrealSourceGenerator.headerFileOutputPath), UnrealSourceGenerator.headerFileOutputPath);
+		helperDict.Add(nameof(UnrealSourceGenerator.includeStatementPrefix), UnrealSourceGenerator.includeStatementPrefix);
 		helperDict.Add(nameof(SubsystemName), SubsystemName);
 		helperDict.Add(nameof(_assignMicroserviceId), isMSGen ? $"MicroserviceName = TEXT(\"{ServiceName}\");" : "");
 
@@ -244,7 +244,7 @@ public:
 ";
 
 	public const string U_SUBSYSTEM_CPP = $@"
-#include ""₢{nameof(UnrealSourceGenerator.headerFileOutputPath)}₢AutoGen/SubSystems/Beam₢{nameof(SubsystemName)}₢Api.h""
+#include ""₢{nameof(UnrealSourceGenerator.includeStatementPrefix)}₢AutoGen/SubSystems/Beam₢{nameof(SubsystemName)}₢Api.h""
 #include ""BeamCoreSettings.h""
 
 

--- a/cli/cli/Services/UnrealSourceGenerator/UnrealEndpointDeclaration.cs
+++ b/cli/cli/Services/UnrealSourceGenerator/UnrealEndpointDeclaration.cs
@@ -218,8 +218,8 @@ public struct UnrealEndpointDeclaration
 
 		helperDict.Add(nameof(exportMacro), exportMacro);
 		helperDict.Add(nameof(blueprintExportMacro), blueprintExportMacro);
-		helperDict.Add(nameof(headerFileOutputPath), headerFileOutputPath);
-		helperDict.Add(nameof(blueprintHeaderFileOutputPath), blueprintHeaderFileOutputPath);
+		helperDict.Add(nameof(includeStatementPrefix), includeStatementPrefix);
+		helperDict.Add(nameof(blueprintIncludeStatementPrefix), blueprintIncludeStatementPrefix);
 
 		helperDict.Add(nameof(GlobalNamespacedEndpointName), GlobalNamespacedEndpointName);
 		helperDict.Add(nameof(SubsystemNamespacedEndpointName), SubsystemNamespacedEndpointName);
@@ -425,7 +425,7 @@ DECLARE_DELEGATE_OneParam(FOn₢{nameof(GlobalNamespacedEndpointName)}₢FullRes
 ";
 
 	public const string U_ENDPOINT_CPP = $@"
-#include ""₢{nameof(headerFileOutputPath)}₢AutoGen/SubSystems/₢{nameof(NamespacedOwnerServiceName)}₢/₢{nameof(GlobalNamespacedEndpointName)}₢Request.h""
+#include ""₢{nameof(includeStatementPrefix)}₢AutoGen/SubSystems/₢{nameof(NamespacedOwnerServiceName)}₢/₢{nameof(GlobalNamespacedEndpointName)}₢Request.h""
 
 void U₢{nameof(GlobalNamespacedEndpointName)}₢Request::BuildVerb(FString& VerbString) const
 {{
@@ -851,12 +851,12 @@ public:
 
 	public const string BEAM_FLOW_BP_NODE_CPP = $@"
 
-#include ""₢{nameof(blueprintHeaderFileOutputPath)}₢AutoGen/₢{nameof(NamespacedOwnerServiceName)}₢/K2BeamNode_ApiRequest_₢{nameof(GlobalNamespacedEndpointName)}₢.h""
+#include ""₢{nameof(blueprintIncludeStatementPrefix)}₢AutoGen/₢{nameof(NamespacedOwnerServiceName)}₢/K2BeamNode_ApiRequest_₢{nameof(GlobalNamespacedEndpointName)}₢.h""
 
 #include ""BeamK2.h""
 
-#include ""₢{nameof(headerFileOutputPath)}₢AutoGen/SubSystems/Beam₢{nameof(NamespacedOwnerServiceName)}₢Api.h""
-#include ""₢{nameof(headerFileOutputPath)}₢AutoGen/SubSystems/₢{nameof(NamespacedOwnerServiceName)}₢/₢{nameof(GlobalNamespacedEndpointName)}₢Request.h""
+#include ""₢{nameof(includeStatementPrefix)}₢AutoGen/SubSystems/Beam₢{nameof(NamespacedOwnerServiceName)}₢Api.h""
+#include ""₢{nameof(includeStatementPrefix)}₢AutoGen/SubSystems/₢{nameof(NamespacedOwnerServiceName)}₢/₢{nameof(GlobalNamespacedEndpointName)}₢Request.h""
 ₢{nameof(ResponseTypeIncludeStatement)}₢
 
 #define LOCTEXT_NAMESPACE ""K2BeamNode_ApiRequest_₢{nameof(GlobalNamespacedEndpointName)}₢""

--- a/cli/cli/Services/UnrealSourceGenerator/UnrealSourceGenerator.cs
+++ b/cli/cli/Services/UnrealSourceGenerator/UnrealSourceGenerator.cs
@@ -177,6 +177,18 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 	public static string blueprintExportMacro = "BEAMABLECOREBLUEPRINTNODES_API";
 
 	/// <summary>
+	/// Set this before calling <see cref="Generate"/> when you want to describe a prefix to add before the path to the autogen folder in include statements.
+	/// Typically, this is the same as <see cref="headerFileOutputPath"/>. However, for microservice clients we remove the "Source/" part of the path.
+	/// </summary>
+	public static string includeStatementPrefix = "BeamableCore/Public/";
+	
+	/// <summary>
+	/// Set this before calling <see cref="Generate"/> when you want to describe a prefix to add before the path to the autogen folder in include statements.
+	/// Typically, this is the same as <see cref="blueprintHeaderFileOutputPath"/>. However, for microservice clients we remove the "Source/" part of the path.
+	/// </summary>
+	public static string blueprintIncludeStatementPrefix = "BeamableCoreBlueprintNodes/Public/BeamFlow/ApiRequest/";
+	
+	/// <summary>
 	/// Set this before calling <see cref="Generate"/> when you want to control where the AutoGen folder will be created.
 	/// It can be the same as <see cref="cppFileOutputPath"/>.
 	/// </summary>
@@ -1426,7 +1438,7 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 			}
 
 			unrealServiceDecl.IncludeStatements.AddRange(
-				unrealServiceDecl.GetAllEndpoints().Select(e => $"#include \"{headerFileOutputPath}AutoGen/SubSystems/{e.NamespacedOwnerServiceName}/{e.GlobalNamespacedEndpointName}Request.h\"")
+				unrealServiceDecl.GetAllEndpoints().Select(e => $"#include \"{includeStatementPrefix}AutoGen/SubSystems/{e.NamespacedOwnerServiceName}/{e.GlobalNamespacedEndpointName}Request.h\"")
 			);
 
 			// If we had declared it already, replace that old declaration with the new one.
@@ -2471,7 +2483,7 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 					return $"#include \"{includeStatement}\"";
 
 				var header = $"{GetNamespacedTypeNameFromUnrealType(unrealType)}.h";
-				return $"#include \"{headerFileOutputPath}AutoGen/Enums/{header}\"";
+				return $"#include \"{includeStatementPrefix}AutoGen/Enums/{header}\"";
 			}
 
 			if (unrealType.IsOptional())
@@ -2479,7 +2491,7 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 				if (previousGenerationPassesData.InEngineTypeToIncludePaths.TryGetValue(unrealType, out var includeStatement))
 					return $"#include \"{includeStatement}\"";
 				var header = $"{GetNamespacedTypeNameFromUnrealType(unrealType)}.h";
-				return $"#include \"{headerFileOutputPath}AutoGen/Optionals/{header}\"";
+				return $"#include \"{includeStatementPrefix}AutoGen/Optionals/{header}\"";
 			}
 
 			if (unrealType.IsWrapperArray())
@@ -2487,7 +2499,7 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 				if (previousGenerationPassesData.InEngineTypeToIncludePaths.TryGetValue(unrealType, out var includeStatement))
 					return $"#include \"{includeStatement}\"";
 				var header = $"{GetNamespacedTypeNameFromUnrealType(unrealType)}.h";
-				return $"#include \"{headerFileOutputPath}AutoGen/Arrays/{header}\"";
+				return $"#include \"{includeStatementPrefix}AutoGen/Arrays/{header}\"";
 			}
 
 			if (unrealType.IsWrapperMap())
@@ -2495,7 +2507,7 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 				if (previousGenerationPassesData.InEngineTypeToIncludePaths.TryGetValue(unrealType, out var includeStatement))
 					return $"#include \"{includeStatement}\"";
 				var header = $"{GetNamespacedTypeNameFromUnrealType(unrealType)}.h";
-				return $"#include \"{headerFileOutputPath}AutoGen/Maps/{header}\"";
+				return $"#include \"{includeStatementPrefix}AutoGen/Maps/{header}\"";
 			}
 
 			if (unrealType.IsUnrealArray())
@@ -2527,9 +2539,9 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 
 				var header = $"{GetNamespacedTypeNameFromUnrealType(unrealType)}.h";
 				if (unrealType.IsBeamNode())
-					return $"#include \"{blueprintHeaderFileOutputPath}AutoGen/{header}\"";
+					return $"#include \"{blueprintIncludeStatementPrefix}AutoGen/{header}\"";
 
-				return $"#include \"{headerFileOutputPath}AutoGen/{header}\"";
+				return $"#include \"{includeStatementPrefix}AutoGen/{header}\"";
 			}
 		}
 

--- a/cli/cli/Utils/ProjectClientHelper.cs
+++ b/cli/cli/Utils/ProjectClientHelper.cs
@@ -1,5 +1,6 @@
 using Beamable.Common;
 using cli.Dotnet;
+using cli.Services;
 using Spectre.Console;
 
 namespace cli.Utils;
@@ -37,51 +38,16 @@ public class UnrealProjectClient : IProjectClient
 		if (unrealArgs == null) throw new Exception("Something went wrong. Please report this to Beamable customer service.");
 
 		var unrealRootDir = new DirectoryInfo(relativePath);
+		var unrealProject = unrealRootDir.GetFiles().FirstOrDefault(f => f.Extension.Contains(".uproject"));
 		var isUnrealRoot = unrealRootDir.GetFiles().Any(f => f.Extension.Contains(".uproject"));
 		if (!isUnrealRoot) throw new Exception("Found an invalid Unreal root directory. Something went wrong. Please report this to Beamable customer service.");
 
-		// If the project is using our OSS plugin, we don't need to ask for the module name or BP name (as the MS code gets injected into the plugin itself). 
-		var isUsingOss = unrealRootDir.GetDirectories("Plugins/OnlineSubsystemBeamable").Any();
-		if (isUsingOss)
-		{
-			unrealArgs.ProjectService.AddUnrealProjectWithOss(relativePath);
-		}
-		else
-		{
-			var msModuleName = unrealArgs.msModuleName;
-			if (string.IsNullOrEmpty(msModuleName))
-				msModuleName = AnsiConsole.Prompt(new TextPrompt<string>("Enter the Runtime module name to which we'll add the generated Microservice Client subsystem:"));
-			var msModulePath = Path.Combine(unrealArgs.ConfigService.BaseDirectory, relativePath + @"\Source\", msModuleName);
-			if (!Directory.Exists(msModulePath))
-			{
-				AnsiConsole.Write(new Text($"Module entered was not found in {msModulePath}.", new Style(Color.Red)));
-				return;
-			}
-			// TODO: It'd be nice to add a validation that the entered module was in-fact a Runtime module.
-			// TODO: We can do this by looking at the .uproject file.
-
-			var bpNodesModuleName = unrealArgs.bpModuleName;
-			if (string.IsNullOrEmpty(bpNodesModuleName))
-				bpNodesModuleName =
-					AnsiConsole.Prompt(
-						new TextPrompt<string>("Enter the UncookedOnly module name to which we'll add the generated Microservice Client's helper BP Nodes:").DefaultValue(
-							$"{msModuleName}Bp"));
-			var bpNodesModulePath = Path.Combine(unrealArgs.ConfigService.BaseDirectory, relativePath + @"\Source\", bpNodesModuleName);
-			if (!Directory.Exists(bpNodesModulePath))
-			{
-				AnsiConsole.Write(new Text($"Module entered was not found in {bpNodesModulePath}.", new Style(Color.Red)));
-				return;
-			}
-			// TODO: It'd be nice to add a validation that the entered module was in-fact an UncookedOnly module.
-			// TODO: We can do this by looking at the .uproject file.
-
-			var msModulePublicPrivate = unrealArgs.msModulePublicPrivate ??
-										AnsiConsole.Prompt(new ConfirmationPrompt($"Does the selected Runtime module ({msModuleName}) split files between Public/Private folders?"));
-			var bpNodesPublicPrivate = unrealArgs.bpModulePublicPrivate ??
-									   AnsiConsole.Prompt(new ConfirmationPrompt($"Does the selected UncookedOnly module ({bpNodesModuleName}) split files between Public/Private folders?"));
-
-			unrealArgs.ProjectService.AddUnrealProject(relativePath, msModuleName, bpNodesModuleName, msModulePublicPrivate, bpNodesPublicPrivate);
-		}
+		// Get the name of the project
+		var projectName = unrealProject.Name[..unrealProject.Name.IndexOf('.')];
+		var microservicePluginName = $"{projectName}MicroserviceClients";
+		var microservicePluginBpName = $"{projectName}MicroserviceClientsBp";
+		
+		unrealArgs.ProjectService.AddUnrealProject(relativePath, microservicePluginName, microservicePluginBpName);
 	}
 }
 


### PR DESCRIPTION
# Ticket

https://github.com/beamable/BeamableProduct/issues/3360

# Brief Description

Unreal Microservice Client CodeGen no longer injects the clients into an existing module; instead it creates a new plugin and module "ProjectName"MicroserviceClients and puts the clients there.

This solves 2 issues:
- Customers can reference this plugin inside other plugins from which they might want to call microservices.
  - For customers, this also enables the ability to integrate microservice calls into the OnlineSubsystemBeamable package's "Customer" sub-folders.
- We can also reference this plugin from any BEAMPROJ_ samples we have and want to access a specific microservice we have declared in our main Unreal repo.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
