### PR TITLE
fixes 3328 - make save-to-file opt out

### DIFF
--- a/cli/beamable.common/beamable.common.csproj
+++ b/cli/beamable.common/beamable.common.csproj
@@ -39,7 +39,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="12.0.2"/>
     </ItemGroup>
 
-    <Target Name="CopyCodeToUnity" AfterTargets="Build" Condition="Exists('../../client/Packages/com.beamable') AND Exists('../cli/bin/Debug/net8.0/Beamable.Tools.dll')">
+    <Target Name="CopyCodeToUnity" AfterTargets="Build" Condition="'$(ReleaseSharedCode)'=='true' AND Exists('../../client/Packages/com.beamable') AND Exists('../cli/bin/Debug/net8.0/Beamable.Tools.dll')">
         <!-- This is sort of jank, but this will use the build of the cli bin if it exists to copy the src over to Unity. -->
         <Exec Command="dotnet ../cli/bin/Debug/net8.0/Beamable.Tools.dll unity release-shared-code ../beamable.common/beamable.common.csproj ../../client com.beamable Common . --logs v"/>
     </Target>

--- a/cli/beamable.server.common/beamable.server.common.csproj
+++ b/cli/beamable.server.common/beamable.server.common.csproj
@@ -44,7 +44,7 @@
     </ItemGroup>
     
     
-    <Target Name="CopyCodeToUnity" AfterTargets="Build" Condition="Exists('../../client/Packages/com.beamable') AND Exists('../cli/bin/Debug/net8.0/Beamable.Tools.dll')">
+    <Target Name="CopyCodeToUnity" AfterTargets="Build" Condition="'$(ReleaseSharedCode)'=='true' AND Exists('../../client/Packages/com.beamable') AND Exists('../cli/bin/Debug/net8.0/Beamable.Tools.dll')">
         <!-- This is sort of jank, but this will use the build of the cli bin if it exists to copy the src over to Unity. -->
         <Exec Command="dotnet ../cli/bin/Debug/net8.0/Beamable.Tools.dll unity release-shared-code ../beamable.server.common/beamable.server.common.csproj ../../client com.beamable.server Runtime/Common Runtime/Common --logs v"/>
         <Exec Command="dotnet ../cli/bin/Debug/net8.0/Beamable.Tools.dll unity release-shared-code ../beamable.server.common/beamable.server.common.csproj ../../client com.beamable.server SharedRuntime SharedRuntime --logs v"/>

--- a/cli/cli/Commands/InitCommand.cs
+++ b/cli/cli/Commands/InitCommand.cs
@@ -44,7 +44,7 @@ public class InitCommand : AtomicCommand<InitCommandArgs, InitCommandResult>,
 		AddOption(new RefreshTokenOption(), (args, i) => args.refreshToken = i);
 
 		AddOption(new SaveToEnvironmentOption(), (args, b) => args.saveToEnvironment = b);
-		AddOption(new SaveToFileOption(), (args, b) => args.saveToFile = b);
+		SaveToFileOption.Bind(this);
 		AddOption(new CustomerScopedOption(), (args, b) => args.customerScoped = b);
 		AddOption(new PrintToConsoleOption(), (args, b) => args.printToConsole = b);
 	}

--- a/cli/cli/Commands/LoginCommand.cs
+++ b/cli/cli/Commands/LoginCommand.cs
@@ -8,7 +8,12 @@ using Spectre.Console;
 
 namespace cli;
 
-public class LoginCommandArgs : CommandArgs
+public interface IArgsWithSaveToFile
+{
+	public bool SaveToFile { get; set; }
+}
+
+public class LoginCommandArgs : CommandArgs, IArgsWithSaveToFile
 {
 	public string username;
 	public string password;
@@ -17,6 +22,12 @@ public class LoginCommandArgs : CommandArgs
 	public bool printToConsole;
 	public bool customerScoped;
 	public string refreshToken = "";
+	
+	public bool SaveToFile
+	{
+		get => saveToFile;
+		set => saveToFile = value;
+	}
 }
 
 public class LoginCommand : AppCommand<LoginCommandArgs>
@@ -35,7 +46,7 @@ public class LoginCommand : AppCommand<LoginCommandArgs>
 		AddOption(new UsernameOption(), (args, i) => args.username = i);
 		AddOption(new PasswordOption(), (args, i) => args.password = i);
 		AddOption(new SaveToEnvironmentOption(), (args, b) => args.saveToEnvironment = b);
-		AddOption(new SaveToFileOption(), (args, b) => args.saveToFile = b);
+		SaveToFileOption.Bind(this);
 		AddOption(new CustomerScopedOption(), (args, b) => args.customerScoped = b);
 		AddOption(new RefreshTokenOption(), (args, i) => args.refreshToken = i);
 		AddOption(new PrintToConsoleOption(), (args, b) => args.printToConsole = b);
@@ -133,12 +144,12 @@ public class LoginCommand : AppCommand<LoginCommandArgs>
 	{
 		if (!string.IsNullOrEmpty(args.username)) return args.username;
 		return AnsiConsole.Prompt(
-			new TextPrompt<string>("Please enter your [green]username[/]:")
+			new TextPrompt<string>("Please enter your [green]email[/]:")
 				.PromptStyle("green")
-				.ValidationErrorMessage("[red]Not a valid username[/]")
+				.ValidationErrorMessage("[red]Not a valid email[/]")
 				.Validate(email =>
 				{
-					if (!email.Contains("@")) return ValidationResult.Error("[red]username must be an email[/]");
+					if (!email.Contains("@")) return ValidationResult.Error("[red]email is invalid[/]");
 					return ValidationResult.Success();
 				})).ToString();
 	}

--- a/cli/cli/Commands/Organization/RegisterCommand.cs
+++ b/cli/cli/Commands/Organization/RegisterCommand.cs
@@ -31,7 +31,7 @@ public class RegisterCommand : AppCommand<RegisterCommandArgs>, IStandaloneComma
 	{
 		AddOption(new Option<string>("--alias", "The name you will use to sign into the organization"), (args, i) => args.alias = i);
 		AddOption(new Option<string>("--game", "The first game for the organization"), (args, i) => args.gameName = i);
-		AddOption(new Option<string>("--username", "The admin email for the new organization"), (args, i) => args.username = i);
+		AddOption(new Option<string>("--email", "The admin email for the new organization"), (args, i) => args.username = i);
 		AddOption(new Option<string>("--password", "The admin password for the new organization"), (args, i) => args.password = i);
 		AddOption(new Option<bool>("--accept-legal", "Accept the Beamable legal agreements"), (args, i) => args.agreedToLegal = i);
 	}
@@ -111,7 +111,7 @@ public class RegisterCommand : AppCommand<RegisterCommandArgs>, IStandaloneComma
 			return Task.FromResult(args.username);
 
 		return Task.FromResult(AnsiConsole.Prompt(
-			new TextPrompt<string>("Please enter your [green]username[/]:")
+			new TextPrompt<string>("Please enter your [green]email[/]:")
 				.PromptStyle("green")
 		));
 	}

--- a/cli/cli/Options/SaveToFileOption.cs
+++ b/cli/cli/Options/SaveToFileOption.cs
@@ -1,6 +1,73 @@
-﻿namespace cli;
+﻿using System.CommandLine;
 
-public class SaveToFileOption : ConfigurableOptionFlag
+namespace cli;
+
+public class SaveToFileOption
 {
-	public SaveToFileOption() : base("save-to-file", "Save login refresh token to file") { }
+	/// <summary>
+	/// Add the --save-to-file and --no-token-save options to a command.
+	/// The --save-to-file existed in 1.x, and was defaulted to FALSE.
+	///
+	/// In 2.0, --no-token-save was introduced, and the intention is that tokens
+	/// DO save by default. The new option exists as a way to OPT OUT. 
+	/// </summary>
+	/// <param name="command"></param>
+	/// <typeparam name="T"></typeparam>
+	public static void Bind<T>(AppCommand<T> command)
+		where T : CommandArgs, IArgsWithSaveToFile
+	{
+		const string saveToFileStr = "--save-to-file";
+		const string noTokenSaveStr = "--no-token-save";
+
+		const bool saveToFileDefault = true;
+		const bool noTokenSaveDefault = false;
+		
+		// included for legacy reasons. 
+		var saveToFileOption = new Option<bool>(saveToFileStr, 
+			
+			// Hey You, Watch out! This default value affects the algorithm in the parse handling! 
+			getDefaultValue: () => saveToFileDefault, 
+			description: "Save login refresh token to file");
+		
+		// this option is legacy, and we don't really want people using it anymore. 
+		saveToFileOption.IsHidden = true;
+		
+		var noTokenOption = new Option<bool>(noTokenSaveStr, 
+			
+			// Hey You, Watch out! This default value affects the algorithm in the parse handling! 
+			getDefaultValue: () => noTokenSaveDefault, 
+			description: $"Prevent auth tokens from being saved to disk. This replaces the legacy {saveToFileStr} option.");
+		
+		command.AddOption<bool>(saveToFileOption, (args, value) => args.SaveToFile = value);
+		command.AddOption<bool>(noTokenOption, (args, context, noTokenSave) =>
+		{
+			var saveToFile = context.ParseResult.GetValueForOption(saveToFileOption);
+
+			switch (saveToFile, noTokenSave)
+			{
+				case (saveToFileDefault, !noTokenSaveDefault):
+					// saveToFile defaults to true, but noTokenSave has higher order, and since that defaults to false, the noTokenSave wins.
+					args.SaveToFile = false;
+					break;
+				
+				case (false, true):
+					// double positive is a positive. Don't save it.
+					args.SaveToFile = false;
+					break;
+				
+				case (!saveToFileDefault, noTokenSaveDefault):
+					// saveToFile is non-default, so it wins this case. 
+					args.SaveToFile = false;
+					break;
+				
+				case (saveToFileDefault, noTokenSaveDefault):
+					// the default case is to save it!
+					args.SaveToFile = true;
+					break;
+			}
+			
+			
+		});
+		
+	}
 }

--- a/cli/cli/Options/SaveToFileOption.cs
+++ b/cli/cli/Options/SaveToFileOption.cs
@@ -33,7 +33,7 @@ public class SaveToFileOption
 			
 			// This default value is assumed "false" in the SaveToFileOption.ShouldSaveToFile function
 			getDefaultValue: () => false, 
-			description: $"Prevent auth tokens from being saved to disk. This replaces the legacy {saveToFileStr} option.");
+			description: $"Prevent auth tokens from being saved to disk. This replaces the legacy {saveToFileStr} option");
 		
 		command.AddOption<bool>(saveToFileOption, (args, value) => args.SaveToFile = value);
 		command.AddOption<bool>(noTokenOption, (args, context, noTokenSave) =>

--- a/cli/cli/Options/UsernameOption.cs
+++ b/cli/cli/Options/UsernameOption.cs
@@ -5,6 +5,8 @@ namespace cli;
 public class UsernameOption : Option<string>
 {
 	public UsernameOption()
-		: base("--username", "Specify user name")
-	{ }
+		: base("--email", "Specify user email address")
+	{
+		AddAlias("--username"); // exists for legacy reasons, because this option used to indicate username, but we've ALWAYS required an email. 
+	}
 }


### PR DESCRIPTION
Now when you do, 
```
beam init
```

the `-save-to-file` stuff happens automatically. Actually, there is a new property, `--no-token-save` that allows you to opt-OUT of token saving. I left the ability to specify `--save-to-file=false` as a backwards compat thing. 

I also took this opportunity to change "username" to "email", because I think its a source of confusion. 

Also, the build release stuff is currently broken, so I masked it with a build-prop.