### PR TITLE
Windows bash path fix

### DIFF
--- a/cli/.run/BEAM-Windows-Cli-Install.run.xml
+++ b/cli/.run/BEAM-Windows-Cli-Install.run.xml
@@ -7,7 +7,7 @@
     <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
     <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$/cli/" />
     <option name="INDEPENDENT_INTERPRETER_PATH" value="false" />
-    <option name="INTERPRETER_PATH" value="$PROJECT_DIR$/../../../../../../Program Files/Git/bin/bash.exe" />
+    <option name="INTERPRETER_PATH" value="C:/Program Files/Git/bin/bash.exe" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="EXECUTE_IN_TERMINAL" value="false" />
     <option name="EXECUTE_SCRIPT_FILE" value="true" />

--- a/cli/.run/BEAM-Windows-Sync-Rider-Run-Settings-Unity.run.xml
+++ b/cli/.run/BEAM-Windows-Sync-Rider-Run-Settings-Unity.run.xml
@@ -7,7 +7,7 @@
     <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
     <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="INDEPENDENT_INTERPRETER_PATH" value="false" />
-    <option name="INTERPRETER_PATH" value="$PROJECT_DIR$/../../../../../../Program Files/Git/bin/bash.exe" />
+    <option name="INTERPRETER_PATH" value="C:/Program Files/Git/bin/bash.exe" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="EXECUTE_IN_TERMINAL" value="false" />
     <option name="EXECUTE_SCRIPT_FILE" value="true" />

--- a/cli/.run/BEAM-Windows-Sync-Rider-Run-Settings-Unreal.run.xml
+++ b/cli/.run/BEAM-Windows-Sync-Rider-Run-Settings-Unreal.run.xml
@@ -7,7 +7,7 @@
     <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
     <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="INDEPENDENT_INTERPRETER_PATH" value="false" />
-    <option name="INTERPRETER_PATH" value="$PROJECT_DIR$/../../../../../../Program Files/Git/bin/bash.exe" />
+    <option name="INTERPRETER_PATH" value="C:/Program Files/Git/bin/bash.exe" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="EXECUTE_IN_TERMINAL" value="false" />
     <option name="EXECUTE_SCRIPT_FILE" value="true" />

--- a/cli/.run/TEMPLATE-Set-Local-Packages.run.xml
+++ b/cli/.run/TEMPLATE-Set-Local-Packages.run.xml
@@ -7,7 +7,7 @@
     <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
     <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$/.." />
     <option name="INDEPENDENT_INTERPRETER_PATH" value="false" />
-    <option name="INTERPRETER_PATH" value="$PROJECT_DIR$/../../../../../../Program Files/Git/bin/bash.exe" />
+    <option name="INTERPRETER_PATH" value="C:/Program Files/Git/bin/bash.exe" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="EXECUTE_IN_TERMINAL" value="false" />
     <option name="EXECUTE_SCRIPT_FILE" value="true" />


### PR DESCRIPTION
I think it is a save assumption for that having installed in default install directory instead of relying on _very_ specific relative path.