### PR TITLE
remove dockerfile and alpha sub sets

### DIFF
--- a/cli/cli/App.cs
+++ b/cli/cli/App.cs
@@ -384,8 +384,15 @@ public class App
 
 		// sort the commands
 		var root = CommandProvider.GetService<RootCommand>();
+		SortCommands(root);
+	}
+
+	void SortCommands(Command root)
+	{
 		var subCommandField = typeof(Command).GetField("_subcommands", BindingFlags.Instance | BindingFlags.NonPublic);
+		if (subCommandField == null) return;
 		var subCommands = (List<Command>)subCommandField.GetValue(root);
+		if (subCommands == null) return;
 		subCommands.Sort((a, b) =>
 		{
 			if (a is not IAppCommand aCommand)
@@ -405,9 +412,20 @@ public class App
 			}
 
 			// and all commands are sorted by their order
-			return bCommand.Order.CompareTo(aCommand.Order);
+			// return bCommand.Order.CompareTo(aCommand.Order);
+			if (bCommand.Order != aCommand.Order)
+			{
+				return bCommand.Order.CompareTo(aCommand.Order);
+			}
+
+			return String.Compare(a.Name, b.Name, StringComparison.Ordinal);
 
 		});
+
+		foreach (var subCommand in subCommands)
+		{
+			SortCommands(subCommand);
+		}
 	}
 
 	public static IEnumerable<HelpSectionDelegate> GetHelpLayout()

--- a/cli/cli/App.cs
+++ b/cli/cli/App.cs
@@ -412,12 +412,12 @@ public class App
 			}
 
 			// and all commands are sorted by their order
-			// return bCommand.Order.CompareTo(aCommand.Order);
 			if (bCommand.Order != aCommand.Order)
 			{
 				return bCommand.Order.CompareTo(aCommand.Order);
 			}
 
+			// or alphabet order
 			return String.Compare(a.Name, b.Name, StringComparison.Ordinal);
 
 		});

--- a/cli/cli/Commands/Project/NewMicroserviceCommand.cs
+++ b/cli/cli/Commands/Project/NewMicroserviceCommand.cs
@@ -207,7 +207,7 @@ public class NewMicroserviceCommand : AppCommand<NewMicroserviceArgs>, IStandalo
 		await args.BeamoLocalSystem.InitManifest();
 
 		// Make sure we have the correct docker file
-		var regularDockerfilePath = service.RelativeDockerfilePath;
+		var regularDockerfilePath = args.ConfigService.BeamableRelativeToExecutionRelative(service.RelativeDockerfilePath);
 		var beamableDevDockerfilePath = regularDockerfilePath + "-BeamableDev";
 		if (File.Exists(beamableDevDockerfilePath))
 		{

--- a/cli/tests/Examples/Project/BeamProjectNewFlows.cs
+++ b/cli/tests/Examples/Project/BeamProjectNewFlows.cs
@@ -42,6 +42,12 @@ public class BeamProjectNewFlows : CLITestExtensions
 		Assert.That(BFile.Exists($"{serviceName}/services/{serviceName}/{serviceName}.csproj"),
 			$"There must be a csproj file after beam project new {serviceName}");
 
+		Assert.That(BFile.Exists($"{serviceName}/services/{serviceName}/Dockerfile"),
+			$"There must be a dockerfile");
+		Assert.That(!BFile.Exists($"{serviceName}/services/{serviceName}/Dockerfile-BeamableDev"),
+			$"There must not be a dev dockerfile");
+
+		
 		// the contents of the file beamoId should be equal to the name of the service created
 		
 		


### PR DESCRIPTION
1. I added a check to the test that the Dockerfile-BeamableDev was getting deleted- and it turned out we needed it in an execution relative path.
2. I made the sort function recursive- because we were only sorting the top-level commands, And
3. I made it so that if the ORDER of two commands are the same, they are then sorted by alphabet