### PR TITLE
various small fixes for CLI deploy

### DIFF
--- a/cli/cli/Commands/Services/ServicesDeployCommand.cs
+++ b/cli/cli/Commands/Services/ServicesDeployCommand.cs
@@ -14,9 +14,6 @@ namespace cli;
 
 public class ServicesDeployCommandArgs : LoginCommandArgs
 {
-	public string[] BeamoIdsToEnable;
-	public string[] BeamoIdsToDisable;
-
 	public string FromJsonFile;
 
 	public string RemoteComment;
@@ -44,12 +41,6 @@ public class ServicesDeployCommand : AppCommand<ServicesDeployCommandArgs>,
 
 	public override void Configure()
 	{
-		AddOption(new Option<string[]>("--enable", "These are the ids for services you wish to be enabled once Beam-O receives the updated manifest") { AllowMultipleArgumentsPerToken = true },
-			(args, i) => args.BeamoIdsToEnable = i.Length == 0 ? null : i);
-
-		AddOption(new Option<string[]>("--disable", "These are the ids for services you wish to be disabled once Beam-O receives the updated manifest") { AllowMultipleArgumentsPerToken = true },
-			(args, i) => args.BeamoIdsToDisable = i.Length == 0 ? null : i);
-
 		AddOption(new Option<string>("--from-file", () => null, $"If this option is set to a valid path to a ServiceManifest JSON, deploys that instead"),
 			(args, i) => args.FromJsonFile = i);
 
@@ -155,25 +146,7 @@ public class ServicesDeployCommand : AppCommand<ServicesDeployCommandArgs>,
 
 			return;
 		}
-
-		// Enable the list of BeamoIds that were given
-		LogToSendResult("Enabling given BeamoIds to enable", "INFO");
-		args.BeamoIdsToEnable ??= Array.Empty<string>();
-		foreach (string beamoId in args.BeamoIdsToEnable)
-		{
-			var sd = _localBeamo.BeamoManifest.ServiceDefinitions.First(def => def.BeamoId == beamoId);
-			sd.ShouldBeEnabledOnRemote = true;
-		}
-
-		// Disable the list of BeamoIds that were given
-		LogToSendResult("Disabling given BeamoIds to disable", "INFO");
-		args.BeamoIdsToDisable ??= Array.Empty<string>();
-		foreach (string beamoId in args.BeamoIdsToDisable)
-		{
-			var sd = _localBeamo.BeamoManifest.ServiceDefinitions.First(def => def.BeamoId == beamoId);
-			sd.ShouldBeEnabledOnRemote = false;
-		}
-
+		
 		// Parse and prepare per-service comments dictionary (BeamoId => CommentString) 
 		LogToSendResult("Parse and prepare per-service comments dictionary", "INFO");
 		var perServiceComments = new Dictionary<string, string>();

--- a/cli/cli/Services/BeamoLocalSystem_Docker.cs
+++ b/cli/cli/Services/BeamoLocalSystem_Docker.cs
@@ -260,7 +260,7 @@ public partial class BeamoLocalSystem
 						// https://regex101.com/r/gpX8Ix/1
 						var regex = new Regex("Step ([0-9]+)/([0-9]+) :");
 
-						BeamableLogger.Log(message.Stream);
+						Log.Debug(message.Stream);
 						BeamableLogger.LogError(message.ErrorMessage);
 						if (message.Error != null)
 						{

--- a/cli/cli/Services/BeamoLocalSystem_LocalRuntime.cs
+++ b/cli/cli/Services/BeamoLocalSystem_LocalRuntime.cs
@@ -332,13 +332,13 @@ public partial class BeamoLocalSystem
 	/// </summary>
 	private bool VerifyCanBeBuiltLocally(BeamoLocalManifest manifest, BeamoServiceDefinition toCheck)
 	{
+		var missingLocalSource = string.IsNullOrEmpty(toCheck.ProjectDirectory);
+		if (missingLocalSource) return false; 
+
 		switch (toCheck.Protocol)
 		{
 			case BeamoProtocolType.HttpMicroservice:
-				var missingLocalSource = string.IsNullOrEmpty(toCheck.ProjectDirectory);
-
-				if (missingLocalSource) return false;
-
+			
 				var hasDockerfile = File.Exists(Path.Combine(toCheck.ProjectDirectory, "Dockerfile"));
 				if (!hasDockerfile) return false;
 

--- a/cli/cli/Services/ProjectContextUtil.cs
+++ b/cli/cli/Services/ProjectContextUtil.cs
@@ -77,10 +77,11 @@ public static class ProjectContextUtil
 				};
 				manifest.ServiceDefinitions.Add(existingDefinition);
 				manifest.HttpMicroserviceRemoteProtocols.Add(remoteService.serviceName, new HttpMicroserviceRemoteProtocol());
-
+				
+				existingDefinition.ShouldBeEnabledOnRemote = remoteService.enabled;
 			}
 
-			existingDefinition.ShouldBeEnabledOnRemote = remoteService.enabled;
+			// overwrite existing local settings
 			existingDefinition.ImageId = remoteService.imageId;
 		}
 
@@ -98,9 +99,10 @@ public static class ProjectContextUtil
 				manifest.ServiceDefinitions.Add(existingDefinition);
 				manifest.EmbeddedMongoDbRemoteProtocols.Add(remoteStorage.id, new EmbeddedMongoDbRemoteProtocol());
 
+				existingDefinition.ShouldBeEnabledOnRemote = remoteStorage.enabled;
 			}
 			
-			existingDefinition.ShouldBeEnabledOnRemote = remoteStorage.enabled;
+			// overwrite existing settings.
 			existingDefinition.ImageId = MongoImage;
 		}
 
@@ -269,6 +271,8 @@ public static class ProjectContextUtil
 		{
 			definition.ShouldBeEnabledOnRemote = true;
 		}
+		Log.Verbose($"set beam enabled for service=[{project.relativePath}] prop=[{project.properties.Enabled}] value=[{definition.ShouldBeEnabledOnRemote}]");
+
 
 		// the project directory is just "where is the csproj" 
 		definition.ProjectDirectory = Path.GetDirectoryName(project.relativePath);


### PR DESCRIPTION
1. docker build logs set to DEBUG instead of INFO 
2. fixed a bug where a remote mongo image was attempting to build locally, which didn't make sense.
3. fixed an error where remote shouldBeEnabled was overwriting local value. 
4. removed some option flags from the deploy command
