### PR TITLE
fixes #3347 - use indented json on backpatch

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- config files use indented JSON
+
 ## [1.19.17] - 2024-04-04
 ### Changed
 - `BEAM_DOCKER_URI` environment variable will override docker connection uri

--- a/cli/cli/Services/ConfigService.cs
+++ b/cli/cli/Services/ConfigService.cs
@@ -72,7 +72,7 @@ public class ConfigService
 	public void SaveDataFile<T>(string fileName, T data)
 	{
 		if (!fileName.EndsWith(".json")) fileName += ".json";
-		var json = JsonConvert.SerializeObject(data,
+		var json = JsonConvert.SerializeObject(data, Formatting.Indented,
 			new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.Auto });
 		var dir = Path.Combine(ConfigFilePath, fileName);
 		File.WriteAllText(dir, json);
@@ -178,7 +178,7 @@ public class ConfigService
 	{
 		if (string.IsNullOrEmpty(ConfigFilePath))
 			throw new CliException("No beamable project exists. Please use beam init");
-		var json = JsonConvert.SerializeObject(_config);
+		var json = JsonConvert.SerializeObject(_config, Formatting.Indented);
 		if (!Directory.Exists(ConfigFilePath))
 		{
 			Directory.CreateDirectory(ConfigFilePath);
@@ -232,7 +232,7 @@ public class ConfigService
 	public void SaveTokenToFile(IAccessToken response)
 	{
 		string fullPath = Path.Combine(ConfigFilePath, Constants.CONFIG_TOKEN_FILE_NAME);
-		var json = JsonConvert.SerializeObject(response);
+		var json = JsonConvert.SerializeObject(response, Formatting.Indented);
 		File.WriteAllText(fullPath, json);
 	}
 

--- a/cli/tests/Examples/Init/BeamInitFlows.cs
+++ b/cli/tests/Examples/Init/BeamInitFlows.cs
@@ -83,7 +83,11 @@ public class BeamInitFlows : CLITest
 		Assert.That(File.Exists(".beamable/config-defaults.json"), "there must be a config defaults file after beam init.");
 
 		// the contents of the file should contain the given cid and pid.
-		var configDefaultsStr = File.ReadAllText(".beamable/config-defaults.json");
+		var configDefaultsStr = File.ReadAllText(".beamable/config-defaults.json")
+			.ReplaceLineEndings("")
+			.Replace("  \"", "\"")
+			.Replace(": \"", ":\"")
+			;
 		var expectedJson = $@"{{""host"":""https://api.beamable.com"",""cid"":""{cid}"",""pid"":""{pid}""}}";
 		Assert.AreEqual(expectedJson, configDefaultsStr, "The config-defaults file should contain the cid and pid.");
 	}

--- a/cli/tests/Examples/Project/BeamProjectFlows.cs
+++ b/cli/tests/Examples/Project/BeamProjectFlows.cs
@@ -43,7 +43,7 @@ public class BeamProjectFlows : CLITestExtensions
 
 		// the contents of the file beamoId should be equal to the name of the service created
 		string localManifestTextContent = File.ReadAllText($"{serviceName}/.beamable/beamoLocalManifest.json");
-		Assert.That(localManifestTextContent.Contains($"\"BeamoId\":\"{serviceName}\""));
+		Assert.That(localManifestTextContent.Contains($"\"BeamoId\": \"{serviceName}\""));
 
 		#endregion
 	}


### PR DESCRIPTION
On old versions of the CLI, we should pretty-print the json config files :shrug: 