### PR TITLE
fixes #3422 - port collisions for local services

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `--no-filter` option to `beam listen server`
 
+### Fixed
+- `beam project stop` will stop services running in docker
+- `beam service ps`  was not working when calling it because it was trying to get the ImageId of storage objects
+- common lib handling uses `.` as a default path instead of the empty string 
+- `UpdateDockerfile` update to fix common lib handling for docker builds
+
 ## [2.0.0] - 2024-05-24
 
 ### Added

--- a/microservice/beamable.tooling.common/PortUtil.cs
+++ b/microservice/beamable.tooling.common/PortUtil.cs
@@ -1,0 +1,16 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace Beamable.Server.Common;
+
+public class PortUtil
+{
+	public static int FreeTcpPort()
+	{
+		TcpListener l = new TcpListener(IPAddress.Loopback, 0);
+		l.Start();
+		int port = ((IPEndPoint)l.LocalEndpoint).Port;
+		l.Stop();
+		return port;
+	}
+}

--- a/microservice/microservice/CHANGELOG.md
+++ b/microservice/microservice/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- `beam project stop` will stop services running in docker
+- services running locally will use adaptive port bindings to avoid port collisions

--- a/microservice/microservice/CHANGELOG.md
+++ b/microservice/microservice/CHANGELOG.md
@@ -8,5 +8,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- `beam project stop` will stop services running in docker
 - services running locally will use adaptive port bindings to avoid port collisions

--- a/microservice/microservice/dbmicroservice/LocalDebugService.cs
+++ b/microservice/microservice/dbmicroservice/LocalDebugService.cs
@@ -29,6 +29,7 @@ namespace Beamable.Server {
 		{
 			ConsoleLogger.Instance.LogLevel = LogLevel.Error;
 			_beamableService = service;
+			Log.Verbose($"Debug server starting at port={args.HealthPort}");
 			_server = new WebServer(args.HealthPort)
 				.WithWebApi("/", m => m.WithController(() => new SampleController(service, debugLogSink)));
 		}


### PR DESCRIPTION
The reason `beam project stop` wasn't working sometimes is because the debug-server for the service in question was getting destroyed due to port collisions. 

You may have seen a PORT ALREADY IN USE error sometimes when starting a service- this also fixes that. 

Also, I took the moment to fix the fact that `beam project stop` _could_ stop docker containers, but it wasn't. 