### PR TITLE
Fix assemblies definition scripts not being copied to docker

### DIFF
--- a/cli/cli/Services/ConfigService.cs
+++ b/cli/cli/Services/ConfigService.cs
@@ -88,7 +88,15 @@ public class ConfigService
 	/// <returns>A path relative to the docker build context path</returns>
 	public string GetRelativeToDockerBuildContextPath(string path)
 	{
-		return Path.GetRelativePath(GetAbsoluteDockerBuildContextPath(), path);
+		string absoluteContextPath = GetAbsoluteDockerBuildContextPath();
+		return Path.GetRelativePath(absoluteContextPath, path);
+	}
+
+	public string GetPathFromRelativeToService(string path, string servicePath)
+	{
+		var relativePath = Path.GetDirectoryName(path);
+		var fullPath = Path.Combine(servicePath, relativePath);
+		return GetRelativeToDockerBuildContextPath(fullPath);
 	}
 
 	/// <summary>

--- a/client/Packages/com.beamable.server/Editor/UI2/Configs/BeamableMicroservicesSettingsProvider.cs
+++ b/client/Packages/com.beamable.server/Editor/UI2/Configs/BeamableMicroservicesSettingsProvider.cs
@@ -67,7 +67,7 @@ namespace Beamable.Editor.Microservice.UI2.Configs
 		public override void OnGUI(string searchContext)
 		{
 			EditorGUILayout.Separator();
-			EditorGUILayout.PropertyField(_customSettings.FindProperty("serviceDefinitions"), Styles.definitions);
+			EditorGUILayout.PropertyField(_customSettings.FindProperty("assemblyReferences"), Styles.definitions);
 
 
 			if (GUILayout.Button("Save changes", GUILayout.Width(100)))

--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/CodeService.cs
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/CodeService.cs
@@ -57,6 +57,8 @@ namespace Beamable.Server.Editor.Usam
 		public static string LibrariesPathsDirectory => Path.GetDirectoryName(LibrariesPathsFilePath);
 		public static string ServicesDefinitionsDirectory => Path.GetDirectoryName(ServicesDefinitionsFilePath);
 
+		private bool _isBeamableDev;
+
 		public CodeService(IDependencyProvider provider, BeamCommands cli, BeamableDispatcher dispatcher, DotnetService dotnetService)
 		{
 			_provider = provider;
@@ -895,7 +897,8 @@ namespace Beamable.Server.Editor.Usam
 			{
 				name = service,
 				serviceDirectory = StandaloneMicroservicesPath,
-				sln = slnPath
+				sln = slnPath,
+				beamableDev = BeamableEnvironment.IsBeamableDeveloper
 			};
 			var command = _cli.ProjectNewService(args);
 			await command.Run();

--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/CsharpProjectUtil.cs
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/CsharpProjectUtil.cs
@@ -118,7 +118,7 @@ namespace Beamable.Server.Editor.Usam
 												assemblyReferences.Select(
 													x => GenerateProjectReferenceEntry(x, csProjDir)));
 
-			var sdkVersion = BeamableEnvironment.SdkVersion;
+			var sdkVersion = BeamableEnvironment.NugetPackageVersion;
 
 
 

--- a/client/Packages/com.beamable/Runtime/Environment/BeamableEnvironment.cs
+++ b/client/Packages/com.beamable/Runtime/Environment/BeamableEnvironment.cs
@@ -92,6 +92,11 @@ namespace Beamable
 		/// The version of Beamable nuget packages that this Beamable SDK requires
 		/// </summary>
 		public static string NugetPackageVersion => VersionData.nugetPackageVersion;
+
+		/// <summary>
+		/// Returns if the SDK is being run in a beamable developer environment
+		/// </summary>
+		public static bool IsBeamableDeveloper => VersionData.nugetPackageVersion.Contains("0.0.123");
 		
 		
 		/// <summary>

--- a/templates/BeamService/BeamService.csproj
+++ b/templates/BeamService/BeamService.csproj
@@ -10,11 +10,11 @@
 
     <!-- These are special Beamable parameters that we use to keep the beamable packages in-sync to the CLI version your project is using. -->
     <!-- This makes it so your microservices are auto-updated whenever you update the CLI installed in your project. -->
-    <PropertyGroup Label="Beamable Version">
-        <DotNetConfigPath Condition="'$(DotNetConfigPath)' == '' AND $(DOTNET_RUNNING_IN_CONTAINER)!=true">$([MSBuild]::GetDirectoryNameOfFileAbove("$(MSBuildProjectDirectory)/..", ".config/dotnet-tools.json"))</DotNetConfigPath>
+    <PropertyGroup Label="Beamable Version" Condition="$(DOTNET_RUNNING_IN_CONTAINER)!=true">
+        <DotNetConfigPath Condition="'$(DotNetConfigPath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove("$(MSBuildProjectDirectory)/..", ".config/dotnet-tools.json"))</DotNetConfigPath>
         <DotNetConfig Condition="'$(DotNetConfig)' == ''">$([System.IO.File]::ReadAllText("$(DotNetConfigPath)/.config/dotnet-tools.json"))</DotNetConfig>
         <!-- Extracts the version number from the first tool defined in 'dotnet-tools.json' that starts with "beamable". -->
-        <BeamableVersion Condition="'$(BeamableVersion)' == '' AND $(DOTNET_RUNNING_IN_CONTAINER)!=true">$([System.Text.RegularExpressions.Regex]::Match("$(DotNetConfig)", "beamable.*?\"([0-9]+\.[0-9]+\.[0-9]+.*?)\",", RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace).Groups[1].Value)</BeamableVersion>
+        <BeamableVersion Condition="'$(BeamableVersion)' == ''">$([System.Text.RegularExpressions.Regex]::Match("$(DotNetConfig)", "beamable.*?\"([0-9]+\.[0-9]+\.[0-9]+.*?)\",", RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace).Groups[1].Value)</BeamableVersion>
         <!-- When running from inside docker, this gets injected via the Dockerfile at build-time. -->
     </PropertyGroup>
     

--- a/templates/BeamService/Dockerfile-BeamableDev
+++ b/templates/BeamService/Dockerfile-BeamableDev
@@ -21,16 +21,16 @@ RUN dotnet publish ${BEAM_CSPROJ_PATH} -p:BeamableVersion=${BEAM_VERSION} -c rel
 
 # use the dotnet runtime as the final stage
 FROM mcr.microsoft.com/dotnet/runtime:6.0-alpine
-WORKDIR /subapp
+WORKDIR /beamApp
 
 # expose the health port
 EXPOSE 6565 
 
 # copy the built program
-COPY --from=build-env /subapp .
+COPY --from=build-env /beamApp .
 
 # when starting the container, run dotnet with the built dll
-ENTRYPOINT ["dotnet", "/subapp/BeamService.dll"]
+ENTRYPOINT ["dotnet", "/beamApp/BeamService.dll"]
 
 # Swap entrypoints if the container is exploding and you want to keep it alive indefinitely so you can go look into it.
 #ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/templates/BeamStorage/BeamStorage.csproj
+++ b/templates/BeamStorage/BeamStorage.csproj
@@ -11,11 +11,11 @@
 
     <!-- These are special Beamable parameters that we use to keep the beamable packages in-sync to the CLI version your project is using. -->
     <!-- This makes it so your microservices are auto-updated whenever you update the CLI installed in your project. -->
-    <PropertyGroup Label="Beamable Version">
-        <DotNetConfigPath Condition="'$(DotNetConfigPath)' == '' AND $(DOTNET_RUNNING_IN_CONTAINER)!=true">$([MSBuild]::GetDirectoryNameOfFileAbove("$(MSBuildProjectDirectory)/..", ".config/dotnet-tools.json"))</DotNetConfigPath>
-        <DotNetConfig Condition="'$(DotNetConfig)' == '' AND $(DOTNET_RUNNING_IN_CONTAINER)!=true">$([System.IO.File]::ReadAllText("$(DotNetConfigPath)/.config/dotnet-tools.json"))</DotNetConfig>
+    <PropertyGroup Label="Beamable Version" Condition="$(DOTNET_RUNNING_IN_CONTAINER)!=true">
+        <DotNetConfigPath Condition="'$(DotNetConfigPath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove("$(MSBuildProjectDirectory)/..", ".config/dotnet-tools.json"))</DotNetConfigPath>
+        <DotNetConfig Condition="'$(DotNetConfig)' == ''">$([System.IO.File]::ReadAllText("$(DotNetConfigPath)/.config/dotnet-tools.json"))</DotNetConfig>
         <!-- Extracts the version number from the first tool defined in 'dotnet-tools.json' that starts with "beamable". -->
-        <BeamableVersion Condition="'$(BeamableVersion)' == '' AND $(DOTNET_RUNNING_IN_CONTAINER)!=true">$([System.Text.RegularExpressions.Regex]::Match("$(DotNetConfig)", "beamable.*?\"([0-9]+\.[0-9]+\.[0-9]+.*?)\",", RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace).Groups[1].Value)</BeamableVersion>
+        <BeamableVersion Condition="'$(BeamableVersion)' == ''">$([System.Text.RegularExpressions.Regex]::Match("$(DotNetConfig)", "beamable.*?\"([0-9]+\.[0-9]+\.[0-9]+.*?)\",", RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace).Groups[1].Value)</BeamableVersion>
         <!-- When running from inside docker, this gets injected via the Dockerfile at build-time. -->
     </PropertyGroup>
     

--- a/templates/CommonLibrary/CommonLibrary.csproj
+++ b/templates/CommonLibrary/CommonLibrary.csproj
@@ -11,11 +11,11 @@
 
     <!-- These are special Beamable parameters that we use to keep the beamable packages in-sync to the CLI version your project is using. -->
     <!-- This makes it so your microservices are auto-updated whenever you update the CLI installed in your project. -->
-    <PropertyGroup Label="Beamable Version">
-        <DotNetConfigPath Condition="'$(DotNetConfigPath)' == '' AND $(DOTNET_RUNNING_IN_CONTAINER)!=true">$([MSBuild]::GetDirectoryNameOfFileAbove("$(MSBuildProjectDirectory)/..", ".config/dotnet-tools.json"))</DotNetConfigPath>
-        <DotNetConfig Condition="'$(DotNetConfig)' == '' AND $(DOTNET_RUNNING_IN_CONTAINER)!=true">$([System.IO.File]::ReadAllText("$(DotNetConfigPath)/.config/dotnet-tools.json"))</DotNetConfig>
+    <PropertyGroup Label="Beamable Version" Condition="$(DOTNET_RUNNING_IN_CONTAINER)!=true">
+        <DotNetConfigPath Condition="'$(DotNetConfigPath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove("$(MSBuildProjectDirectory)/..", ".config/dotnet-tools.json"))</DotNetConfigPath>
+        <DotNetConfig Condition="'$(DotNetConfig)' == ''">$([System.IO.File]::ReadAllText("$(DotNetConfigPath)/.config/dotnet-tools.json"))</DotNetConfig>
         <!-- Extracts the version number from the first tool defined in 'dotnet-tools.json' that starts with "beamable". -->
-        <BeamableVersion Condition="'$(BeamableVersion)' == '' AND $(DOTNET_RUNNING_IN_CONTAINER)!=true">$([System.Text.RegularExpressions.Regex]::Match("$(DotNetConfig)", "beamable.*?\"([0-9]+\.[0-9]+\.[0-9]+.*?)\",", RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace).Groups[1].Value)</BeamableVersion>
+        <BeamableVersion Condition="'$(BeamableVersion)' == ''">$([System.Text.RegularExpressions.Regex]::Match("$(DotNetConfig)", "beamable.*?\"([0-9]+\.[0-9]+\.[0-9]+.*?)\",", RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace).Groups[1].Value)</BeamableVersion>
         <!-- When running from inside docker, this gets injected via the Dockerfile at build-time. -->
     </PropertyGroup>
     


### PR DESCRIPTION
This makes running services that reference assembly definitions in USAM to work on docker, which also enables it to be correctly published. There are some fixes in our templates for development purposes as well.
