### PR TITLE
Issue/3479

### DIFF
--- a/cli/beamable.common/Targets/Beamable.Common.Targets
+++ b/cli/beamable.common/Targets/Beamable.Common.Targets
@@ -3,6 +3,6 @@
     <!-- Move the built dll to the linked projects -->
     <Target Name="share-code" AfterTargets="Build" Condition="$(CopyToLinkedProjects)==true AND $(DOTNET_RUNNING_IN_CONTAINER)!=true">
         <Message Text="Generating code for other projects" Importance="high" />
-        <Exec Command="$(BeamableDotnetPath) $(BeamableTool) project share-code $(OutDir)/$(AssemblyName).dll --dep-prefix-blacklist Newtonsoft,Unity.Beamable,UnityEngine,Unity.Addressables,System --no-redirect" />
+        <Exec Command="$(BeamableDotnetPath) $(BeamableTool) project share-code $(OutDir)/$(AssemblyName).dll --dep-prefix-blacklist Newtonsoft,Unity.Beamable,UnityEngine,Unity.Addressables,System" />
     </Target>
 </Project>

--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/CodeService.cs
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/CodeService.cs
@@ -790,8 +790,8 @@ namespace Beamable.Server.Editor.Usam
 				contents; // TODO: is there a better way to check if the solution file needs to be regenerated? This feels like it could become a bottleneck.
 			if (areDifferent)
 			{
-				// force the sln file to be re-generated, by deleting it. // TODO: we'll need to "unlock" the file in certain VCS
-				File.Delete(slnPath);
+				// Write over the sln file adding the hidden microservices/storages. // TODO: we'll need to "unlock" the file in certain VCS
+				File.WriteAllText(slnPath, generatedContent);
 				UnityEditor.Compilation.CompilationPipeline.RequestScriptCompilation();
 			}
 		}

--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/SolutionPostProcessor.cs
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/SolutionPostProcessor.cs
@@ -71,7 +71,9 @@ EndProject";
 				File.WriteAllText(path, content);
 			});
 
-			return content;
+			var oldContent = File.ReadAllText(path);
+
+			return oldContent; //return old content and let the above promise write the new content later on, so we don't flick the sln
 		}
 
 

--- a/microservice/microservice/Targets/Beamable.Microservice.Runtime.targets
+++ b/microservice/microservice/Targets/Beamable.Microservice.Runtime.targets
@@ -9,7 +9,7 @@
     <!-- After the build completes, we should auto-generate client code to any linked projects -->
     <Target Name="generate-client" AfterTargets="Build" Condition="$(GenerateClientCode)==true AND $(DOTNET_RUNNING_IN_CONTAINER)!=true">
         <Message Text="Generating client files..." Importance="high" />
-        <Exec Command="$(BeamableDotnetPath) $(BeamableTool) project generate-client $(OutDir)/$(AssemblyName).dll --output-links --no-redirect $(Beam_GenerateClient_Args)" EnvironmentVariables="BEAM_DOTNET_MSBUILD_PATH=$(BEAM_DOTNET_MSBUILD_PATH)"/>
+        <Exec Command="$(BeamableDotnetPath) $(BeamableTool) project generate-client $(OutDir)/$(AssemblyName).dll --output-links $(Beam_GenerateClient_Args)" EnvironmentVariables="BEAM_DOTNET_MSBUILD_PATH=$(BEAM_DOTNET_MSBUILD_PATH)"/>
     </Target>
 
 </Project>


### PR DESCRIPTION
# Ticket

resolves #3479 

# Brief Description

We were deleting the solution file and letting the `OnGeneratedSlnSolution` handle it later, however deleting the file makes it get written by Unity without our modifications, since that callback only runs _after_ it was created, so the flickering would always happen. Now we are just rewriting the content that was already in that file when the callback is called and at the same time we are starting a promise that gets the new generated content and inject our stuff. We are also always injecting our projects when the editor gets initialized, because a domain reload doesn't mean that the `OnGeneratedSlnSolution` will be called at all. This information was retrieved looking at this code:
https://github.com/needle-mirror/com.unity.ide.rider/blob/master/Rider/Editor/ProjectGeneration/ProjectGeneration.cs



# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
