### PR TITLE
[issue/3529] Also copy dlls from assembly references to docker context

### DIFF
--- a/cli/cli/App.cs
+++ b/cli/cli/App.cs
@@ -364,6 +364,7 @@ public class App
 		Commands.AddSubCommand<ServicesGenerateLocalManifestCommand, ServicesGenerateLocalManifestCommandArgs, ServicesCommand>();
 		Commands.AddSubCommand<ServicesGenerateTarballCommand, ServicesGenerateTarballCommandArgs, ServicesCommand>();
 		Commands.AddSubCommand<ServicesBuildCommand, ServicesBuildCommandArgs, ServicesCommand>();
+		Commands.AddSubCommand<ServicesUpdateDockerfileCommand, ServicesUpdateDockerfileCommandArgs, ServicesCommand>();
 		// content commands
 		
 		Commands.AddRootCommand<ContentCommand>();

--- a/cli/cli/Commands/Services/ServicesUpdateDockerfileCommand.cs
+++ b/cli/cli/Commands/Services/ServicesUpdateDockerfileCommand.cs
@@ -11,6 +11,8 @@ public class ServicesUpdateDockerfileCommandArgs : CommandArgs
 
 public class ServicesUpdateDockerfileCommand : AppCommand<ServicesUpdateDockerfileCommandArgs>, IEmptyResult
 {
+	public override bool IsForInternalUse => true;
+	
 	public ServicesUpdateDockerfileCommand() : base("update-dockerfile", "Updates the Dockerfile for the specified service")
 	{
 	}

--- a/cli/cli/Commands/Services/ServicesUpdateDockerfileCommand.cs
+++ b/cli/cli/Commands/Services/ServicesUpdateDockerfileCommand.cs
@@ -1,0 +1,41 @@
+using cli.Services;
+using Serilog;
+using System.CommandLine;
+
+namespace cli;
+
+public class ServicesUpdateDockerfileCommandArgs : CommandArgs
+{
+	public string ServiceName;
+}
+
+public class ServicesUpdateDockerfileCommand : AppCommand<ServicesUpdateDockerfileCommandArgs>, IEmptyResult
+{
+	public ServicesUpdateDockerfileCommand() : base("update-dockerfile", "Updates the Dockerfile for the specified service")
+	{
+	}
+
+	public override void Configure()
+	{
+		AddArgument(new Argument<string>("ServiceName", description: "The name of the microservice to udpate the Dockerfile"),
+			(args, i) => args.ServiceName = i);
+	}
+
+	public override async Task Handle(ServicesUpdateDockerfileCommandArgs args)
+	{
+		if (!args.BeamoLocalSystem.BeamoManifest.TryGetDefinition(args.ServiceName, out var serviceDefinition))
+		{
+			Log.Error($"The service {args.ServiceName} does not have a definition in the manifest");
+			return;
+		}
+
+		if (serviceDefinition.Protocol != BeamoProtocolType.HttpMicroservice)
+		{
+			Log.Error($"The service {args.ServiceName} is not a HttpMicroservice");
+			return;
+		}
+
+		await args.BeamoLocalSystem.UpdateDockerFile(serviceDefinition);
+		Log.Information($"The service {args.ServiceName} Dockerfile has ben updated!");
+	}
+}

--- a/cli/cli/Services/BeamoLocalSystem.cs
+++ b/cli/cli/Services/BeamoLocalSystem.cs
@@ -380,6 +380,14 @@ COPY {serviceFileTag} /subsrc/{servicePathTag}";
 			newText = newText.Replace(endTag, replacementFile.Replace(servicePathTag, path).Replace(serviceFileTag, file).Replace('\\', '/').Insert(0, Environment.NewLine));
 		}
 
+		//Add all dll files in the project
+		var allDlls = ProjectContextUtil.GetAllIncludedDlls(definition, _configService);
+		foreach (var dll in allDlls)
+		{
+			var path = Path.GetDirectoryName(dll);
+			newText = newText.Replace(endTag, replacementFile.Replace(servicePathTag, path).Replace(serviceFileTag, dll).Replace('\\', '/').Insert(0, Environment.NewLine));
+		}
+
 		//Copy the services files
 		Log.Verbose($"adding service files projPath=[{projectDir}]");
 

--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/CsharpProjectUtil.cs
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/CsharpProjectUtil.cs
@@ -92,7 +92,6 @@ namespace Beamable.Server.Editor.Usam
 					var oldContent = File.ReadAllText(fileName);
 					if (oldContent.Equals(content))
 					{
-						Debug.Log($"Skipping assembly {assembly.name} because it does not have any changes");
 						continue;
 					}
 				}
@@ -158,7 +157,10 @@ namespace Beamable.Server.Editor.Usam
 			foreach (var dll in assembly.compiledAssemblyReferences)
 			{
 				if (!dll.StartsWith(projectRoot)) continue;
-				yield return dll.Substring(projectRoot.Length + 1);
+				var dllPath = dll.Substring(projectRoot.Length + 1);
+				var dllName = Path.GetFileName(dllPath);
+				if (!IsValidReference(dllName)) continue;
+				yield return dllPath;
 			}
 
 			yield break;


### PR DESCRIPTION
# Ticket

resolves #3529 

# Brief Description

Filter dlls that we cannot copy from Unity to our deployed microservices and also copy all other dlls that are referenced, which is done recursively through all referenced projects of that service.


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
