### PR TITLE
[issue/3510] Handle errors when creating services and storages

### DIFF
--- a/client/Packages/com.beamable.server/Editor/UI/Components/CreateServiceVisualElement/CreateServiceVisualElement.cs
+++ b/client/Packages/com.beamable.server/Editor/UI/Components/CreateServiceVisualElement/CreateServiceVisualElement.cs
@@ -126,7 +126,12 @@ namespace Beamable.Editor.Microservice.UI.Components
 		private async Promise CreateService(string serviceName, List<IBeamoServiceDefinition> additionalReferences = null)
 		{
 			var codeService = BeamEditorContext.Default.ServiceScope.GetService<CodeService>();
-			await codeService.CreateService(serviceName, ServiceType, additionalReferences);
+			await codeService.CreateService(serviceName, ServiceType, additionalReferences, errorCallback: () =>
+			{
+				Root.RemoveFromHierarchy();
+				OnClose?.Invoke();
+			});
+
 			OnCreateServiceFinished?.Invoke();
 		}
 


### PR DESCRIPTION
# Ticket

resolves #3510 

# Brief Description

Starts handling errors when creating microservices and storages from USAM. This basically uses the `OnError` event stream of the commands to know that an error happened, and then throw an exception that will be caught by the UI which will update it correctly this time.


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
