### PR TITLE
publish beamable.tooling.common and revert micro_

### DIFF
--- a/build/bin/release-nuget.sh
+++ b/build/bin/release-nuget.sh
@@ -30,6 +30,7 @@ then
     dotnet pack ./cli/cli --configuration Release /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
     dotnet pack ./cli/beamable.common --configuration Release --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
     dotnet pack ./cli/beamable.server.common --configuration Release --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
+    dotnet pack ./microservice/beamable.tooling.common --configuration Release --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
     dotnet pack ./microservice/unityEngineStubs --configuration Release --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
     dotnet pack ./microservice/unityenginestubs.addressables --configuration Release --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
     
@@ -39,6 +40,7 @@ else
     dotnet pack ./cli/cli --configuration Release --version-suffix=${SUFFIX-""} /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
     dotnet pack ./cli/beamable.common --configuration Release --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --version-suffix=${SUFFIX-""} /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
     dotnet pack ./cli/beamable.server.common --configuration Release --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --version-suffix=${SUFFIX-""} /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
+    dotnet pack ./microservice/beamable.tooling.common --configuration Release --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --version-suffix=${SUFFIX-""} /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
     dotnet pack ./microservice/unityEngineStubs --configuration Release --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --version-suffix=${SUFFIX-""} /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
     dotnet pack ./microservice/unityenginestubs.addressables --configuration Release --include-source -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --version-suffix=${SUFFIX-""} /p:VersionPrefix=$VERSION_PREFIX /p:InformationalVersion=$VERSION
     
@@ -67,6 +69,9 @@ else
     
     dotnet nuget push ./cli/beamable.server.common/nupkg/Beamable.Server.Common.${VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${NUGET_TOOLS_KEY}
     dotnet nuget push ./cli/beamable.server.common/nupkg/Beamable.Server.Common.${VERSION}.snupkg --source https://api.nuget.org/v3/index.json --api-key ${NUGET_TOOLS_KEY}
+
+    dotnet nuget push ./microservice/beamable.tooling.common/nupkg/Beamable.Tooling.Common.${VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${NUGET_TOOLS_KEY}
+    dotnet nuget push ./microservice/beamable.tooling.common/nupkg/Beamable.Tooling.Common.${VERSION}.snupkg --source https://api.nuget.org/v3/index.json --api-key ${NUGET_TOOLS_KEY}
 
     dotnet nuget push ./microservice/unityEngineStubs/nupkg/Beamable.UnityEngine.${VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${NUGET_TOOLS_KEY}
     dotnet nuget push ./microservice/unityEngineStubs/nupkg/Beamable.UnityEngine.${VERSION}.snupkg --source https://api.nuget.org/v3/index.json --api-key ${NUGET_TOOLS_KEY}

--- a/cli/cli/Commands/Profiling/RunNBomberCommand.cs
+++ b/cli/cli/Commands/Profiling/RunNBomberCommand.cs
@@ -50,7 +50,7 @@ public class RunNBomberCommand : AppCommand<RunNBomberCommandArgs>
 		var prefix = args.includePrefix ? MachineHelper.GetUniqueDeviceId() : "";
 		var host = args.AppContext.Host;
 
-		var url = $"{host}/basic/{cid}.{pid}.{args.service}/{args.method}";
+		var url = $"{host}/basic/{cid}.{pid}.micro_{args.service}/{args.method}";
 		var scope = $"{cid}.{pid}";
 
 		if (string.IsNullOrWhiteSpace(args.jsonFilePath))

--- a/cli/cli/Services/BeamoLocalSystem_RemoteCommunication.cs
+++ b/cli/cli/Services/BeamoLocalSystem_RemoteCommunication.cs
@@ -122,7 +122,7 @@ public partial class BeamoLocalSystem
 
 	private async Promise<string> RetryRequest(string containerName, string serviceName, string routingHeader)
 	{
-		var url = $"/basic/{_beamableRequester.Cid}.{_beamableRequester.Pid}.{serviceName}/admin/Metadata";
+		var url = $"/basic/{_beamableRequester.Cid}.{_beamableRequester.Pid}.micro_{serviceName}/admin/Metadata";
 		var requester = (CliRequester)_beamableRequester;
 
 		var isRunning = false;

--- a/client/Packages/com.beamable.server/Runtime/MicroserviceClient.cs
+++ b/client/Packages/com.beamable.server/Runtime/MicroserviceClient.cs
@@ -315,7 +315,7 @@ namespace Beamable.Server
 
 		public static string CreateUrl(string cid, string pid, string serviceName, string endpoint)
 		{
-			var path = $"{serviceName}/{endpoint}";
+			var path = $"micro_{serviceName}/{endpoint}";
 			var url = $"/basic/{cid}.{pid}.{path}";
 			return url; ///basic/123.testpid.micro_test/test
 		}

--- a/microservice/beamable.tooling.common/TypeExtensions.cs
+++ b/microservice/beamable.tooling.common/TypeExtensions.cs
@@ -1,0 +1,9 @@
+namespace Beamable.Server.Common;
+
+public static class TypeExtensions
+{
+	public static bool IsAssignableTo(this Type type, Type other)
+	{
+		return other.IsAssignableFrom(type);
+	}
+}

--- a/microservice/beamable.tooling.common/beamable.tooling.common.csproj
+++ b/microservice/beamable.tooling.common/beamable.tooling.common.csproj
@@ -1,7 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+
+        <PackageId>Beamable.Tooling.Common</PackageId>
+        <Authors>Beamable Team</Authors>
+        <Company>Beamable</Company>
+        <PackageTags>Beamable;Game Server;Unity;Unreal;Games;Microservice</PackageTags>
+        <PackageProjectUrl>https://beamable.com</PackageProjectUrl>
+        <PackageIconUrl>https://beamable.com/wp-content/uploads/2024/01/kY9wLmfZ_400x400.jpg</PackageIconUrl>
+        <PackageReleaseNotes>https://beamable.github.io/changes/</PackageReleaseNotes>
+        <PackageLicenseUrl>https://beamable.com/license</PackageLicenseUrl>
+        <Description>
+            The Beamable.Tooling.Common package contains standard Beamable code shared between the CLI and the Microservices
+        </Description>
+        <VersionPrefix>$(VersionPrefix)</VersionPrefix>
+        <PackageOutputPath>./nupkg</PackageOutputPath>
+
+
+        <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>11</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
@@ -14,6 +30,7 @@
       <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.3.2" />
       <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
       <PackageReference Include="Serilog" Version="2.10.0" />
+      <PackageReference Include="System.Text.Json" Version="8.0.4"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/microservice/microservice/microservice.csproj
+++ b/microservice/microservice/microservice.csproj
@@ -50,28 +50,22 @@
     <PackageReference Include="MongoDB.Driver" Version="2.15.1"/>
   </ItemGroup>
   
-  <ItemGroup Label="Internal Beamable References">
-    <ProjectReference Include="..\beamable.tooling.common\beamable.tooling.common.csproj" PrivateAssets="All"/>
-  </ItemGroup>
-  
   <ItemGroup Label="Public Beamable References">
     <ProjectReference Include="..\..\cli\beamable.common\beamable.common.csproj"/>
     <ProjectReference Include="..\..\cli\beamable.server.common\beamable.server.common.csproj"/>
     <ProjectReference Include="..\unityenginestubs.addressables\unityenginestubs.addressables.csproj"/>
     <ProjectReference Include="..\unityEngineStubs\unityenginestubs.csproj"/>
+    <ProjectReference Include="..\beamable.tooling.common\beamable.tooling.common.csproj"/>
   </ItemGroup>
 
   <ItemGroup Label="Pack Internal Beamable References: Net6.0">
     <None Include="Targets/Beamable.Microservice.Runtime.*" PackagePath="build/net6.0" Pack="True"/>
-    <None Include="$(OutputPath)/net6.0/beamable.tooling.common*" PackagePath="lib/net6.0" Pack="True"/>
   </ItemGroup>
   <ItemGroup Label="Pack Internal Beamable References: Net7.0">
     <None Include="Targets/Beamable.Microservice.Runtime.*" PackagePath="build/net7.0" Pack="True"/>
-    <None Include="$(OutputPath)/net7.0/beamable.tooling.common*" PackagePath="lib/net7.0" Pack="True"/>
   </ItemGroup>
   <ItemGroup Label="Pack Internal Beamable References: Net8.0">
     <None Include="Targets/Beamable.Microservice.Runtime.*" PackagePath="build/net8.0" Pack="True"/>
-    <None Include="$(OutputPath)/net8.0/beamable.tooling.common*" PackagePath="lib/net8.0" Pack="True"/>
   </ItemGroup>
   
 

--- a/microservice/microserviceTests/microservice/NamedSerializationMicroservice.cs
+++ b/microservice/microserviceTests/microservice/NamedSerializationMicroservice.cs
@@ -4,7 +4,7 @@ using Beamable.Server;
 
 namespace microserviceTests.microservice
 {
-   [Microservice("micro_named", EnableEagerContentLoading = false)]
+   [Microservice("named", EnableEagerContentLoading = false)]
    public class NamedSerializationMicroservice : Microservice
    {
       public static MicroserviceFactory<NamedSerializationMicroservice> Factory => () => new NamedSerializationMicroservice();

--- a/microservice/microserviceTests/microservice/ServiceWithDependency.cs
+++ b/microservice/microserviceTests/microservice/ServiceWithDependency.cs
@@ -3,7 +3,7 @@ using Beamable.Server;
 
 namespace microserviceTests.microservice
 {
-   [Microservice("micro_serviceWithDeps", EnableEagerContentLoading = false)]
+   [Microservice("serviceWithDeps", EnableEagerContentLoading = false)]
    public class ServiceWithDependency : Microservice
    {
       public IBeamableServices Services { get; }

--- a/microservice/microserviceTests/microservice/SimpleMicroservice.cs
+++ b/microservice/microserviceTests/microservice/SimpleMicroservice.cs
@@ -18,7 +18,7 @@ using UnityEngine;
 
 namespace microserviceTests.microservice
 {
-   [Microservice("micro_simple", EnableEagerContentLoading = false)]
+   [Microservice("simple", EnableEagerContentLoading = false)]
    public class SimpleMicroserviceNonLegacy : Microservice
    {
       public static MicroserviceFactory<SimpleMicroserviceNonLegacy> Factory => () => new SimpleMicroserviceNonLegacy();
@@ -36,7 +36,7 @@ namespace microserviceTests.microservice
 
    }
 
-   [Microservice("micro_simple_no_updates", DisableAllBeamableEvents = true, EnableEagerContentLoading = false)]
+   [Microservice("simple_no_updates", DisableAllBeamableEvents = true, EnableEagerContentLoading = false)]
    public class SimpleMicroserviceWithNoEvents : Microservice
    {
 	   public static MicroserviceFactory<SimpleMicroserviceWithNoEvents> Factory => () => new SimpleMicroserviceWithNoEvents();
@@ -71,7 +71,7 @@ namespace microserviceTests.microservice
 	   }
    }
 
-   [Microservice("micro_simple", UseLegacySerialization = true, EnableEagerContentLoading = false)]
+   [Microservice("simple", UseLegacySerialization = true, EnableEagerContentLoading = false)]
    public class SimpleMicroservice : Microservice
    {
       public static MicroserviceFactory<SimpleMicroservice> Factory => () => new SimpleMicroservice();

--- a/microservice/microserviceTests/microservice/dbmicroservice/BeamableMicroServiceTests/StatTests.cs
+++ b/microservice/microserviceTests/microservice/dbmicroservice/BeamableMicroServiceTests/StatTests.cs
@@ -9,7 +9,7 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
 	public class StatTests : CommonTest
 	{
 
-		[Microservice("micro_statservice", EnableEagerContentLoading = false)]
+		[Microservice("statservice", EnableEagerContentLoading = false)]
 		public class StatMicroservice : Microservice
 		{
 			[ClientCallable]


### PR DESCRIPTION
This publishes the beamable.tooling.common library so that we can sneak away into the sunset and not have to privately bundle that package into the microservice nuget package. 

It also brings back the micro_ string for backwards compat. 

There is a known issue on internal slack regarding the scheduler support.
https://disruptorbeam.slack.com/archives/C03B6BGEK3Q/p1724775930632399