### PR TITLE
fixes #3594 - logs are stored per project

### DIFF
--- a/cli/cli/App.cs
+++ b/cli/cli/App.cs
@@ -112,13 +112,17 @@ public class App
 			);
 			if (appCtx.ShouldUseLogFile && appCtx.TryGetTempLogFilePath(out var logPath))
 			{
-				var existingLogFiles = Directory.GetFiles(Path.GetDirectoryName(logPath));
-				// this is magic number... I guess its a rough estimate of a number of commands per day?
-				const int MaxNumberOfLogFilesBeforeAutoClean = 250;
-				if (existingLogFiles.Length > MaxNumberOfLogFilesBeforeAutoClean)
+				var path = Path.GetDirectoryName(logPath);
+				if (Directory.Exists(path))
 				{
-					// clean up everything older than a day
-					ClearTempLogFilesCommand.CleanLogs(TimeSpan.FromDays(1), existingLogFiles);
+					var existingLogFiles = Directory.GetFiles(path);
+					// this is magic number... I guess its a rough estimate of a number of commands per day?
+					const int MaxNumberOfLogFilesBeforeAutoClean = 250;
+					if (existingLogFiles.Length > MaxNumberOfLogFilesBeforeAutoClean)
+					{
+						// clean up everything older than a day
+						ClearTempLogFilesCommand.CleanLogs(TimeSpan.FromDays(1), existingLogFiles);
+					}
 				}
 				baseConfig.WriteTo.File(logPath, LogEventLevel.Verbose);
 			}

--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -18,8 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `net8.0` support for Standalone Microservices
 - `beam project ps --raw` includes an `executionVersion` representing the version of the Beamable SDK being used in the service
 - `oapi download` flag `--combine-into-one-document` for combining OpenAPI documents into one
+- `temp clear logs` command will clear old log files in the `.beamable/temp/logs` folder.
+
 ### Changed
 - Standalone Microservices are created with `net8.0` by default
+- CLI log files are kept in the `.beamable/temp/logs` folder and are cleared after each day if the total number of log files exceeds 250
 
 ### Fixed
 - JSON output will correctly render optional types

--- a/cli/cli/Commands/TempCommands/ClearTempLogFilesCommand.cs
+++ b/cli/cli/Commands/TempCommands/ClearTempLogFilesCommand.cs
@@ -1,4 +1,3 @@
-using HdrHistogram;
 using Serilog;
 using System.CommandLine;
 

--- a/cli/cli/Commands/TempCommands/ClearTempLogFilesCommand.cs
+++ b/cli/cli/Commands/TempCommands/ClearTempLogFilesCommand.cs
@@ -1,0 +1,161 @@
+using HdrHistogram;
+using Serilog;
+using System.CommandLine;
+
+namespace cli.TempCommands;
+
+[Serializable]
+public class ClearTempLogFilesCommandArgs : CommandArgs
+{
+	public TimeSpan olderThan;
+}
+
+[Serializable]
+public class ClearTempLogFilesCommandOutput
+{
+	public List<string> deletedFiles = new List<string>();
+	public List<string> failedToDeleteFiles = new List<string>();
+}
+
+public class ClearTempLogFilesCommand : AtomicCommand<ClearTempLogFilesCommandArgs, ClearTempLogFilesCommandOutput>
+{
+	public ClearTempLogFilesCommand() : base("logs", "clear temp log files")
+	{
+	}
+
+	public override void Configure()
+	{
+		var olderThanOption = new Option<string>(
+			name: "--older-than",
+			description: "only clear logs older than a given value. " +
+			             "This string should be in a duration format.\n\n " +
+			             "The duration format should be a number, followed by a time unit. Valid time units " +
+			             "include seconds (s), minutes (m), hours (h), days (d), and months(mo). Please note that " +
+			             "the month unit is short-hand for 30 days. " +
+			             "Here are a few examples, \n" +
+			             "	--older-than 30m (30 minutes)\n" +
+			             "  --older-than 18mo (18 months)\n" +
+			             "  --older-than 12d (12 days)\n");
+		olderThanOption.AddAlias("-ot");
+		AddOption(olderThanOption, (args, i) =>
+		{
+			if (string.IsNullOrEmpty(i))
+			{
+				args.olderThan = TimeSpan.Zero;
+			} else if (!TryParse(i, out args.olderThan))
+			{
+				throw new CliException("Invalid --older-than value.");
+			}
+		});
+	}
+
+	public override Task<ClearTempLogFilesCommandOutput> GetResult(ClearTempLogFilesCommandArgs args)
+	{
+		return Task.FromResult(CleanLogs(args.AppContext, args.olderThan));
+	}
+
+
+	public static ClearTempLogFilesCommandOutput CleanLogs(IAppContext appCtx, TimeSpan olderThan)
+	{
+		if (!appCtx.TryGetTempLogFilePath(out var logFile))
+		{
+			throw new CliException("there is no log path available to clean");
+		}
+		var dir = Path.GetDirectoryName(Path.GetFullPath(logFile));
+		Log.Debug($"cleaning log files in dir=[{dir}]");
+
+		var entries = Directory.GetFiles(dir);
+		Log.Debug($"found {entries.Length} log files");
+
+		return CleanLogs(olderThan, entries);
+	}
+	
+	public static ClearTempLogFilesCommandOutput CleanLogs(TimeSpan olderThan, string[] entries)
+	{
+		var now = DateTime.Now;
+		var deletedFiles = new List<string>();
+		var failedFiles = new List<string>();
+		for (var i = 0; i < entries.Length; i++)
+		{
+			var timeDiff = now - File.GetLastWriteTime(entries[i]);
+			var shouldDelete = timeDiff > olderThan;
+			if (shouldDelete)
+			{
+				Log.Debug($"Deleting log file=[{entries[i]}]");
+				try
+				{
+					File.Delete(entries[i]);
+					deletedFiles.Add(entries[i]);
+				}
+				catch
+				{
+					Log.Warning($"Unable to delete log file=[{entries[i]}]");
+					failedFiles.Add(entries[i]);
+				}
+			}
+		}
+
+		return new ClearTempLogFilesCommandOutput { deletedFiles = deletedFiles, failedToDeleteFiles = failedFiles };
+	}
+	
+	public static bool TryParse(string str, out TimeSpan value)
+	{
+		value = default;
+		ReadOnlySpan<char> span = str;
+		// scan through the str looking for the first non-number character
+		int i = 0;
+		for (i = 0; i < str.Length; i++)
+		{
+			var c = span[i];
+			if (!char.IsDigit(c))
+			{
+				break;
+			}
+		}
+
+		var digitsSpan = span.Slice(0, i);
+		var unitSpan = span.Slice(i);
+
+		if (!int.TryParse(digitsSpan, out var amount))
+		{
+			return false;
+		}
+		
+		switch (unitSpan.Length)
+		{
+			case 1:
+				switch (unitSpan[0])
+				{
+					case 's':
+						value = TimeSpan.FromSeconds(amount);
+						break;
+					case 'm':
+						value = TimeSpan.FromMinutes(amount);
+						break;
+					case 'h':
+						value = TimeSpan.FromHours(amount);
+						break;
+					case 'd':
+						value = TimeSpan.FromDays(amount);
+						break;
+					default:
+						return false;
+				}
+				break;
+			case 2:
+				if (unitSpan[0] == 'm' && unitSpan[1] == 'o')
+				{
+					value = TimeSpan.FromDays(amount * 30); // TODO: rough approximation of months.
+					break;
+				}
+				else
+				{
+					return false;
+				}
+			default:
+				return false;
+		}
+		
+		return true;
+	}
+}

--- a/cli/cli/Commands/TempCommands/ClearTempLogFilesCommand.cs
+++ b/cli/cli/Commands/TempCommands/ClearTempLogFilesCommand.cs
@@ -6,7 +6,7 @@ namespace cli.TempCommands;
 [Serializable]
 public class ClearTempLogFilesCommandArgs : CommandArgs
 {
-	public TimeSpan olderThan;
+	public string olderThan;
 }
 
 [Serializable]
@@ -38,19 +38,21 @@ public class ClearTempLogFilesCommand : AtomicCommand<ClearTempLogFilesCommandAr
 		olderThanOption.AddAlias("-ot");
 		AddOption(olderThanOption, (args, i) =>
 		{
-			if (string.IsNullOrEmpty(i))
-			{
-				args.olderThan = TimeSpan.Zero;
-			} else if (!TryParse(i, out args.olderThan))
-			{
-				throw new CliException("Invalid --older-than value.");
-			}
+			args.olderThan = i;
 		});
 	}
 
 	public override Task<ClearTempLogFilesCommandOutput> GetResult(ClearTempLogFilesCommandArgs args)
 	{
-		return Task.FromResult(CleanLogs(args.AppContext, args.olderThan));
+		TimeSpan olderThan = default;
+		if (string.IsNullOrEmpty(args.olderThan))
+		{
+			olderThan = TimeSpan.Zero;
+		} else if (!TryParse(args.olderThan, out olderThan))
+		{
+			throw new CliException("Invalid --older-than value.");
+		}
+		return Task.FromResult(CleanLogs(args.AppContext, olderThan));
 	}
 
 

--- a/cli/cli/Commands/TempCommands/ClearTempLogFilesCommand.cs
+++ b/cli/cli/Commands/TempCommands/ClearTempLogFilesCommand.cs
@@ -26,7 +26,7 @@ public class ClearTempLogFilesCommand : AtomicCommand<ClearTempLogFilesCommandAr
 	{
 		var olderThanOption = new Option<string>(
 			name: "--older-than",
-			description: "only clear logs older than a given value. " +
+			description: "Only clear logs older than a given value. " +
 			             "This string should be in a duration format.\n\n " +
 			             "The duration format should be a number, followed by a time unit. Valid time units " +
 			             "include seconds (s), minutes (m), hours (h), days (d), and months(mo). Please note that " +

--- a/cli/cli/Commands/TempCommands/ClearTempLogFilesCommand.cs
+++ b/cli/cli/Commands/TempCommands/ClearTempLogFilesCommand.cs
@@ -18,7 +18,7 @@ public class ClearTempLogFilesCommandOutput
 
 public class ClearTempLogFilesCommand : AtomicCommand<ClearTempLogFilesCommandArgs, ClearTempLogFilesCommandOutput>
 {
-	public ClearTempLogFilesCommand() : base("logs", "clear temp log files")
+	public ClearTempLogFilesCommand() : base("logs", "Clear temp log files")
 	{
 	}
 

--- a/cli/cli/Commands/TempCommands/TempCommandGroup.cs
+++ b/cli/cli/Commands/TempCommands/TempCommandGroup.cs
@@ -5,7 +5,7 @@ namespace cli.TempCommands;
 
 public class TempCommandGroup : CommandGroup
 {
-	public TempCommandGroup() : base("temp", "commands for the .beamable temp folder")
+	public TempCommandGroup() : base("temp", "Commands for the .beamable temp folder")
 	{
 	}
 }
@@ -16,7 +16,7 @@ public class TempClearArgs : CommandArgs
 }
 public class TempClearCommandGroup : CommandGroup<TempClearArgs>
 {
-	public TempClearCommandGroup() : base("clear", "commands to clear files in the temp folder")
+	public TempClearCommandGroup() : base("clear", "Commands to clear files in the temp folder")
 	{
 	}
 

--- a/cli/cli/Commands/TempCommands/TempCommandGroup.cs
+++ b/cli/cli/Commands/TempCommands/TempCommandGroup.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection;
+using System.CommandLine.Help;
+
+namespace cli.TempCommands;
+
+public class TempCommandGroup : CommandGroup
+{
+	public TempCommandGroup() : base("temp", "commands for the .beamable temp folder")
+	{
+	}
+}
+
+public class TempClearArgs : CommandArgs
+{
+	
+}
+public class TempClearCommandGroup : CommandGroup<TempClearArgs>
+{
+	public TempClearCommandGroup() : base("clear", "commands to clear files in the temp folder")
+	{
+	}
+
+	public override void Configure()
+	{
+		
+	}
+
+	public override Task Handle(TempClearArgs args)
+	{
+		var helpBuilder = args.Provider.GetService<HelpBuilder>();
+		helpBuilder.Write(this, Console.Error);
+		return Task.CompletedTask;
+	}
+}

--- a/cli/cli/Services/ConfigService.cs
+++ b/cli/cli/Services/ConfigService.cs
@@ -43,6 +43,16 @@ public class ConfigService
 		_configDirOption = configDirOption;
 	}
 
+	public void SetupBasePath(BindingContext bindingContext)
+	{
+		if (!TryGetSetting(out _dir, bindingContext, _configDirOption))
+		{
+			_dir = Directory.GetCurrentDirectory();
+		}
+		DirectoryExists = TryToFindBeamableConfigFolder(out var configPath);
+		ConfigDirectoryPath = configPath;
+	}
+	
 	public void Init(BindingContext bindingContext)
 	{
 		if (!TryGetSetting(out _dir, bindingContext, _configDirOption))
@@ -257,8 +267,6 @@ public class ConfigService
 		if (string.IsNullOrEmpty(value))
 		{
 			_ = _environment.TryGetFromOption(option, out value);
-			CliSerilogProvider.Instance.Debug(
-				$"Trying to get option={option.GetType().Name} from Env Vars! Value Found={value}");
 		}
 
 		var hasValue = !string.IsNullOrEmpty(value);

--- a/cli/cli/Services/IAppContext.cs
+++ b/cli/cli/Services/IAppContext.cs
@@ -39,7 +39,7 @@ public interface IAppContext
 	public IAccessToken Token { get; }
 	public string RefreshToken { get; }
 	bool ShouldUseLogFile { get; }
-	string TempLogFilePath { get;  }
+	bool TryGetTempLogFilePath(out string logFile);
 	bool ShouldMaskLogs { get; }
 	bool ShouldEmitLogs { get; }
 	
@@ -121,7 +121,23 @@ public class DefaultAppContext : IAppContext
 	}
 
 	public bool ShouldUseLogFile => !_consoleContext.ParseResult.GetValueForOption(_noLogFileOption);
-	public string TempLogFilePath => Path.Combine(Path.GetTempPath(), "beamCliLog.txt");
+	// public string TempLogFilePath => Path.Combine(Path.GetTempPath(), "beamCliLog.txt");
+	
+	static DateTimeOffset _logTime = DateTimeOffset.Now;
+
+	public bool TryGetTempLogFilePath(out string logFile)
+	{
+		logFile = null;
+		if (string.IsNullOrEmpty(_configService.ConfigDirectoryPath))
+		{
+			// there is no .beamable folder
+			return false;
+		}
+		logFile = _configService.GetRelativeToBeamableFolderPath(
+			$".beamable/temp/logs/beamCliLog-{_logTime.ToFileTime()}");
+		return true;
+	}
+	
 	public bool ShouldMaskLogs => !_consoleContext.ParseResult.GetValueForOption(_unmaskLogsOption);
 	public bool ShouldEmitLogs => _consoleContext.ParseResult.GetValueForOption(EmitLogsOption.Instance);
 

--- a/cli/cli/Services/IAppContext.cs
+++ b/cli/cli/Services/IAppContext.cs
@@ -121,8 +121,7 @@ public class DefaultAppContext : IAppContext
 	}
 
 	public bool ShouldUseLogFile => !_consoleContext.ParseResult.GetValueForOption(_noLogFileOption);
-	// public string TempLogFilePath => Path.Combine(Path.GetTempPath(), "beamCliLog.txt");
-	
+
 	static DateTimeOffset _logTime = DateTimeOffset.Now;
 
 	public bool TryGetTempLogFilePath(out string logFile)

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCommand.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCommand.cs
@@ -62,6 +62,7 @@ namespace Beamable.Editor.BeamCli.Commands
 				skipStandaloneValidation = true,
 				dotnetPath = Path.GetFullPath(DotnetUtil.DotnetPath),
 				quiet = true,
+				noLogFile = true,
 				raw = true,
 				emitLogStreams = true
 			};


### PR DESCRIPTION
Now, if the command is logging to a file, it'll pick a file location in the `.beamable/temp/logs` folder. Also, if there is no `.beamable` folder, the command won't log to a file as a backup. 

There is a new command, `beam temp clear logs` that will clear old log files. It accepts an `--older-than` flag. 
If a new log file is going to be created, then the CLI will check the rough size of the logs simply by checking file count; and if there are "a lot" of logs, then it'll destroy any logs older than 1 day. This is to hand-waive through some general fuzzyness of "not being too bloated". 

The Unity Integration also now passes the `--no-log-file`, because it shouldn't need the log file backup. 