### PR TITLE
fixes #3581 - deprecated content

### DIFF
--- a/cli/beamable.common/Runtime/Api/Inventory/IInventoryApi.cs
+++ b/cli/beamable.common/Runtime/Api/Inventory/IInventoryApi.cs
@@ -290,6 +290,12 @@ namespace Beamable.Common.Api.Inventory
 		public long Id;
 
 		/// <summary>
+		/// If the content type is deleted from beamable, then the content is considered deprecated.
+		/// The items may still exist in the inventory.
+		/// </summary>
+		public bool IsContentDeprecated => ItemContent.IsDeprecated;
+
+		/// <summary>
 		/// The timestamp of when the item was added to the player inventory.
 		/// </summary>
 		public long CreatedAt;

--- a/cli/beamable.common/Runtime/Api/Inventory/InventoryApi.cs
+++ b/cli/beamable.common/Runtime/Api/Inventory/InventoryApi.cs
@@ -6,6 +6,7 @@ using Beamable.Serialization.SmallerJSON;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
 
 namespace Beamable.Common.Api.Inventory
 {
@@ -242,9 +243,21 @@ namespace Beamable.Common.Api.Inventory
 			{
 				return ContentApi.Instance
 					.FlatMap(service => service.GetContent<TContent>(new ItemRef(kvp.Key)))
+					.Recover(ex =>
+					{
+						if (ex is ContentNotFoundException)
+						{
+							return null;
+						}
+						throw ex;
+					})
 					.Map(content =>
 					{
-
+						if (content == null)
+						{
+							content = ScriptableObject.CreateInstance<TContent>();
+							content.SetIdAndVersion(kvp.Key, Constants.Features.Content.CONTENT_DEPRECATED);
+						}
 						return kvp.Value
 							.Select(item => new InventoryObject<TContent>
 							{

--- a/cli/beamable.common/Runtime/Constants/Implementations/ContentConstants.cs
+++ b/cli/beamable.common/Runtime/Constants/Implementations/ContentConstants.cs
@@ -19,6 +19,7 @@ namespace Beamable.Common
 				public static readonly string BAKED_CONTENT_FILE_PATH = Path.Combine(BEAMABLE_RESOURCES_PATH, BAKED_FILE_RESOURCE_PATH);
 				public static readonly string BAKED_MANIFEST_RESOURCE_PATH = "bakedManifest";
 				public static readonly string BAKED_MANIFEST_FILE_PATH = Path.Combine(BEAMABLE_RESOURCES_PATH, BAKED_MANIFEST_RESOURCE_PATH);
+				public const string CONTENT_DEPRECATED = "deprecated";
 			}
 		}
 	}

--- a/cli/beamable.common/Runtime/Content/ContentObject.cs
+++ b/cli/beamable.common/Runtime/Content/ContentObject.cs
@@ -223,7 +223,7 @@ namespace Beamable.Common.Content
 		public string Created { get; private set; }
 		public long LastChanged { get; set; }
 		public ContentCorruptedException ContentException { get; set; }
-
+		public bool IsDeprecated => Version == Constants.Features.Content.CONTENT_DEPRECATED;
 		/// <summary>
 		/// Set the &id and &version
 		/// </summary>

--- a/microservice/microservice/CHANGELOG.md
+++ b/microservice/microservice/CHANGELOG.md
@@ -14,3 +14,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - services running locally will use adaptive port bindings to avoid port collisions
+- calling `Context.Services.Inventory.GetItems()` will no longer break when items reference deleted content


### PR DESCRIPTION
it used to be the case that this function would explode if the content no longer existed in the manifest. Now that exception is allowed to propagate as an item with a link to "deprecated" content