### PR TITLE
fixes #3582 change docker dns to use more common host.docker.internal

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - JSON output will correctly render optional types
+- DockerHub 4.31 is supported via microservices using `host.docker.internal` instead of `gateway.docker.internal` to communicate to `localhost`
 
 ## [2.0.1] - 2024-06-17
 

--- a/cli/cli/Services/BeamoLocalSystem_HttpMicroservice.cs
+++ b/cli/cli/Services/BeamoLocalSystem_HttpMicroservice.cs
@@ -21,7 +21,7 @@ public partial class BeamoLocalSystem
 	private const string HTTM_MICROSERVICE_CONTAINER_PORT = "6565";
 	
 	public async Task<List<DockerEnvironmentVariable>> GetLocalConnectionStrings(BeamoLocalManifest localManifest,
-		string host = "gateway.docker.internal")
+		string host = "host.docker.internal")
 	{
 		var output = new List<DockerEnvironmentVariable>();
 		foreach (var local in localManifest.EmbeddedMongoDbLocalProtocols)
@@ -71,7 +71,7 @@ public partial class BeamoLocalSystem
 	}
 
 	public async Task<DockerEnvironmentVariable> GetLocalConnectionString(BeamoLocalManifest localManifest,
-		string storageName, string host = "gateway.docker.internal")
+		string storageName, string host = "host.docker.internal")
 	{
 		if (!localManifest.EmbeddedMongoDbLocalProtocols.TryGetValue(storageName, out var localStorage))
 		{

--- a/client/Packages/com.beamable.server/Editor/DockerCommands/RunImageCommand.cs
+++ b/client/Packages/com.beamable.server/Editor/DockerCommands/RunImageCommand.cs
@@ -89,7 +89,7 @@ namespace Beamable.Server.Editor.DockerCommands
 				[ENV_ME_CONFIG_MONGODB_ENABLE_ADMIN] = "true",
 				[ENV_ME_CONFIG_SITE_COOKIESECRET] = Guid.NewGuid().ToString(),
 				[ENV_ME_CONFIG_SITE_SESSIONSECRET] = Guid.NewGuid().ToString(),
-				[ENV_MONGO_SERVER] = $"mongodb://{config.LocalInitUser}:{config.LocalInitPass}@gateway.docker.internal:{config.LocalDataPort}"
+				[ENV_MONGO_SERVER] = $"mongodb://{config.LocalInitUser}:{config.LocalInitPass}@host.docker.internal:{config.LocalDataPort}"
 			};
 			Ports = new Dictionary<uint, uint>
 			{

--- a/client/Packages/com.beamable.server/Editor/ReflectionCache/UserSystems/MicroserviceReflectionCache.cs
+++ b/client/Packages/com.beamable.server/Editor/ReflectionCache/UserSystems/MicroserviceReflectionCache.cs
@@ -1117,7 +1117,7 @@ namespace Beamable.Server.Editor
 				{
 					var config = MicroserviceConfiguration.Instance.GetStorageEntry(storage.Name);
 					return
-						$"mongodb://{config.LocalInitUser}:{config.LocalInitPass}@gateway.docker.internal:{config.LocalDataPort}";
+						$"mongodb://{config.LocalInitUser}:{config.LocalInitPass}@host.docker.internal:{config.LocalDataPort}";
 				}
 				else
 				{


### PR DESCRIPTION
Docker seems to have gotten rid of the ability to use `gateway.docker.internal` without custom settings. 
https://disruptorbeam.slack.com/archives/C19GUHW4D/p1725908254680369

Oh well.