### PR TITLE
fixes #3644 - logs and skipManifest

### DIFF
--- a/cli/cli/CommandContext.cs
+++ b/cli/cli/CommandContext.cs
@@ -24,6 +24,15 @@ public interface IResultProvider
 	public IDataReporterService Reporter { get; set; }
 }
 
+/// <summary>
+/// when a command implements this interface, the CLI app framework will not attempt to initialize beamoLocal.
+/// If this happens, the command SHOULD NOT use _ANYTHING_ in the beamoLocalManifest; otherwise nulls ahoy.
+/// </summary>
+public interface ISkipManifest
+{
+	
+}
+
 public interface IResultSteam<TChannel, TData> : IResultProvider
 	where TChannel : IResultChannel, new()
 {

--- a/cli/cli/Commands/Config/ConfigCommand.cs
+++ b/cli/cli/Commands/Config/ConfigCommand.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace cli;
 
-public class ConfigCommand : AtomicCommand<ConfigCommandArgs, ConfigCommandResult>
+public class ConfigCommand : AtomicCommand<ConfigCommandArgs, ConfigCommandResult>, ISkipManifest
 {
 	public ConfigCommand() : base("config", "List the current beamable configuration")
 	{

--- a/cli/cli/Commands/InitCommand.cs
+++ b/cli/cli/Commands/InitCommand.cs
@@ -23,7 +23,8 @@ public class InitCommandArgs : LoginCommandArgs
 
 public class InitCommand : AtomicCommand<InitCommandArgs, InitCommandResult>,
 	IStandaloneCommand,
-	IHaveRedirectionConcerns<InitCommandArgs>
+	IHaveRedirectionConcerns<InitCommandArgs>,
+	ISkipManifest
 {
 	private readonly LoginCommand _loginCommand;
 	private IRealmsApi _realmsApi;

--- a/cli/cli/Commands/Version/VersionCommand.cs
+++ b/cli/cli/Commands/Version/VersionCommand.cs
@@ -14,7 +14,7 @@ public class VersionResults
 }
 
 
-public class VersionCommand : AtomicCommand<VersionCommandArgs, VersionResults>, IStandaloneCommand
+public class VersionCommand : AtomicCommand<VersionCommandArgs, VersionResults>, IStandaloneCommand, ISkipManifest
 {
 	public VersionCommand() : base("version", "Commands for managing the CLI version")
 	{

--- a/microservice/microservice/dbmicroservice/MicroserviceBootstrapper.cs
+++ b/microservice/microservice/dbmicroservice/MicroserviceBootstrapper.cs
@@ -570,13 +570,13 @@ namespace Beamable.Server
 	        //TODO: These events are still not working for some reason
 	        process.ErrorDataReceived += (sender, args) =>
 	        {
-				Log.Information($"Generate env process (error): [{args.Data}]");
+				Log.Verbose($"Generate env process (error): [{args.Data}]");
 				if(!string.IsNullOrEmpty(args.Data)) sublogs += args.Data;
 	        };
 
 	        process.OutputDataReceived += (sender, args) =>
 	        {
-		        Log.Information($"Generate env process (log): [{args.Data}]");
+		        Log.Verbose($"Generate env process (log): [{args.Data}]");
 		        if(!string.IsNullOrEmpty(args.Data)) result += args.Data;
 	        };
 

--- a/microservice/microservice/dbmicroservice/MicroserviceBootstrapper.cs
+++ b/microservice/microservice/dbmicroservice/MicroserviceBootstrapper.cs
@@ -606,15 +606,14 @@ namespace Beamable.Server
 	        // Might be necessary due to stupid .NET thing that causes the Out/Err callbacks to trigger a bit after the process closes.
 	        await exitSignal;
 	        await Task.Delay(100);
-	        
-	        Log.Information($"Read StdOut: {result}");
-	        Log.Information($"Read StdErr: {sublogs}");
-	        Log.Information($"Awaited Exit!");
-			
+
+	     
 	        if (process.ExitCode != 0)
 	        {
+		        Log.Error($"generate-env output:\n{sublogs}");
 		        throw new Exception($"Failed to generate-env message=[{result}] sub-logs=[{sublogs}]");
 	        }
+	        Log.Information($"environment:\n{result}");
 	        
 	        var parsedOutput = JsonConvert.DeserializeObject<ReportDataPoint<GenerateEnvFileOutput>>(result);
 	        if (parsedOutput.type != "stream")


### PR DESCRIPTION
two things, 

1. the Log.Info calls are a bit aggressive in my opinion. We can use Verbose instead, and the engine integrations will still pick them up.
2. adds an interface that lets us skip manifest initialization on some commands. This showed up from a convo w/Pedro. We need to use this interface _sparingly_, but for commands we _KNOW_ have _zero_ chance of using the beamoManifest, it seems silly to waste networking. 