### PR TITLE
OAPI- add missing include for TSharedPtr<FJsonObject> type

### DIFF
--- a/cli/cli/Services/UnrealSourceGenerator/UnrealSourceGenerator.cs
+++ b/cli/cli/Services/UnrealSourceGenerator/UnrealSourceGenerator.cs
@@ -1901,7 +1901,7 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 
 		public NamespacedType AsNamespacedType() => GetNamespacedTypeNameFromUnrealType(this);
 
-		public bool RequiresJsonUtils() => IsUnrealArray() || IsUnrealMap() || IsOptional() || IsUnrealUObject() || IsAnySemanticType();
+		public bool RequiresJsonUtils() => IsUnrealArray() || IsUnrealMap() || IsOptional() || IsUnrealUObject() || IsAnySemanticType() || IsUnrealJson();
 
 		#region Primitives
 


### PR DESCRIPTION
For code below it was not adding `#include "Serialization/BeamJsonUtils.h"` even when it was using `UBeamJsonUtils`.
```c++

#include "BeamableCore/Public/AutoGen/FederationInfo.h"


void UFederationInfo::BeamSerializeProperties(TUnrealJsonSerializer& Serializer) const
{
	Serializer->WriteValue(TEXT("service"), Service);
	Serializer->WriteValue(TEXT("namespace"), Namespace);
	UBeamJsonUtils::SerializeJsonObject(TEXT("settings"), Settings, Serializer);
}

void UFederationInfo::BeamSerializeProperties(TUnrealPrettyJsonSerializer& Serializer) const
{
	Serializer->WriteValue(TEXT("service"), Service);
	Serializer->WriteValue(TEXT("namespace"), Namespace);
	UBeamJsonUtils::SerializeJsonObject(TEXT("settings"), Settings, Serializer);		
}

void UFederationInfo::BeamDeserializeProperties(const TSharedPtr<FJsonObject>& Bag)
{
	Service = Bag->GetStringField(TEXT("service"));
	Namespace = Bag->GetStringField(TEXT("namespace"));
	UBeamJsonUtils::DeserializeJsonObject(TEXT("settings"), Bag, Settings, OuterOwner);
}
```