### PR TITLE
Expanded SendCurrency method's XMLDoc to clarify withdrawal behavior.

### DIFF
--- a/cli/beamable.server.common/SharedRuntime/Api/Inventory/IMicroserviceInventoryApi.cs
+++ b/cli/beamable.server.common/SharedRuntime/Api/Inventory/IMicroserviceInventoryApi.cs
@@ -19,11 +19,21 @@ namespace Beamable.Server.Api.Inventory
 	public interface IMicroserviceInventoryApi : IInventoryApi
 	{
 		/// <summary>
-		/// Send multiple currencies to different user.
+		/// Send one or more currencies to different user. The currencies will
+		/// be withdrawn from the current player and deposited to the recipient
+		/// player. If the donor player does not have enough of any of the
+		/// specified currencies, the whole transaction will be terminated with
+		/// no effect.
+		/// The recipient player must be a different player from the donor (the
+		/// current player according to the Beamable context); trying to transfer
+		/// currencies to the same player who is donating is an error.
+		/// Transaction IDs are normally assigned by Beamable services internally;
+		/// omit the transaction argument unless you have a need to manage the
+		/// transaction IDs externally.
 		/// </summary>
 		/// <param name="currencies">A dictionary where the keys are content IDs of the currency, and the values are the amount of currency to send</param>
 		/// <param name="recipientPlayer">Target user identifier.</param>
-		/// <param name="transaction">An inventory transaction ID. Leave this argument empty.</param>
+		/// <param name="transaction">(optional) An inventory transaction ID. In the vast majority of cases you should leave this argument empty.</param>
 		/// <returns>A <see cref="Promise{T}"/> representing the network call.</returns>
 		Promise SendCurrency(Dictionary<string, long> currencies, long recipientPlayer, string transaction = null);
 	}


### PR DESCRIPTION
# Ticket

https://github.com/beamable/BeamableProduct/issues/3683

# Brief Description

Expanded SendCurrency's inline documentation to more clearly describe its behavior.

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit.