### PR TITLE
fixes window dotnet install

### DIFF
--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCliUtil.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCliUtil.cs
@@ -56,11 +56,7 @@ namespace Beamable.Editor.BeamCli
 
 				if (USE_GLOBAL)
 				{
-#if UNITY_EDITOR_WIN
-                return System.Environment.ExpandEnvironmentVariables("%USERPROFILE%\\.dotnet\\tools");
-#else
 					return Path.Combine(DotnetUtil.DOTNET_GLOBAL_PATH, "tools");
-#endif
 				}
 				const string CLI_LIBRARY = "Library/BeamableEditor/BeamCLI";
 				return Path.Combine(CLI_LIBRARY, CLI_VERSION);
@@ -83,11 +79,9 @@ namespace Beamable.Editor.BeamCli
 		}
 
 		const string SRC_BEAM = "BUILDED_BEAM";
-#if UNITY_EDITOR_WIN
-       private const string EXEC = "beam.exe";
-#else
+
 		private const string EXEC = "beam";
-#endif
+
 
 		[System.Diagnostics.Conditional("SPEW_ALL")]
 		static void VerboseLog(string log)

--- a/client/Packages/com.beamable/Editor/Dotnet/DotnetUtil_Install.cs
+++ b/client/Packages/com.beamable/Editor/Dotnet/DotnetUtil_Install.cs
@@ -102,7 +102,7 @@ namespace Beamable.Editor.Dotnet
 				process.StartInfo.Arguments = $"-c '{command}'";
 #else
 				process.StartInfo.FileName = "powershell.exe";
-				process.StartInfo.Arguments = "-ExecutionPolicy Bypass -File \"" + DotnetInstallScriptPath + $"\" -InstallDir \"{DOTNET_LIBRARY_PATH}\" -NoPath -Channel {version}"; //  "/C " + command + " > " + commandoutputfile + "'"; // TODO: I haven't tested this since refactor.
+				process.StartInfo.Arguments = "-ExecutionPolicy Bypass -File \"" + DotnetInstallScriptPath + $"\" -InstallDir \"{DOTNET_LIBRARY_PATH}\" -NoPath -Version {version}"; //  "/C " + command + " > " + commandoutputfile + "'"; // TODO: I haven't tested this since refactor.
 #endif
 				// Configure the process using the StartInfo properties.
 				process.StartInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Normal;


### PR DESCRIPTION
the windows version of the install string was using `Channel` instead of `Version`. Oops.
![image](https://github.com/user-attachments/assets/9020b517-7be2-4813-8657-f263983fad99)


Also, now that we execute `beam` as `dotnet beam`; we don't need to append the `.exe` for windows. 