### PR TITLE
Add custom way to have more invalid assemblies

### DIFF
--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/AssemblyUtil.cs
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/AssemblyUtil.cs
@@ -16,8 +16,6 @@ namespace Beamable.Server.Editor.Usam
 		private HashSet<Assembly> _referencedAssemblies = new HashSet<Assembly>();
 		public Dictionary<string, string> beamoIdToClientHintPath = new Dictionary<string, string>();
 
-		private string[] _invalidAssemblyPrefixes = new string[] { "UnityEngine.", "UnityEditor." };
-
 		public HashSet<Assembly> ReferencedAssemblies => _referencedAssemblies;
 		public Assembly[] AllAssemblies => _assemblies;
 

--- a/client/Packages/com.beamable.server/Editor/Usam/Editor/CsharpProjectUtil.cs
+++ b/client/Packages/com.beamable.server/Editor/Usam/Editor/CsharpProjectUtil.cs
@@ -88,6 +88,8 @@ namespace Beamable.Server.Editor.Usam
 		private const string invalidAssembliesFilePath =
 			"Packages/com.beamable.server/Editor/invalid-assemblies.txt";
 
+		private const string customInvalidAssembliesPath = "Assets/Beamable/Resources/custom-invalid-assemblies.txt";
+
 		/// <summary>
 		/// AssemblyUtil.Reload(); must be called before this
 		/// </summary>
@@ -197,6 +199,12 @@ namespace Beamable.Server.Editor.Usam
 		public static bool IsValidReference(string referenceName)
 		{
 			var invalidReferences = File.ReadAllLines(invalidAssembliesFilePath);
+
+			if (File.Exists(customInvalidAssembliesPath))
+			{
+				var customInvalidRefs = File.ReadAllLines(customInvalidAssembliesPath);
+				invalidReferences = invalidReferences.Concat(customInvalidRefs).ToArray();
+			}
 			
 			foreach (var invalidRef in invalidReferences)
 			{


### PR DESCRIPTION
Now you can put more invalid assemblies in the file `Assets/Beamable/Resources/custom-invalid-assemblies.txt`
