### PR TITLE
Fix server only content deletion

### DIFF
--- a/client/Packages/com.beamable/Editor/AccountService.cs
+++ b/client/Packages/com.beamable/Editor/AccountService.cs
@@ -220,9 +220,10 @@ namespace Beamable.Editor
 				Requester.Pid = null;
 			}
 
-			// clear the existing customer data so future calls don't get the old data. 
-			Account.SetCustomerViewResponse(new CustomerViewResponse());
-			
+			// clear the existing customer data so future calls don't get the old data.
+			Account?.SetCustomerViewResponse(new CustomerViewResponse());
+
+
 			_saveHandle?.Save();
 			var __ = Cli.Command.Logout().Run();
 			var _ = InvokeUserChangeCallbacks();

--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ExplorerVisualElement/ExplorerVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ExplorerVisualElement/ExplorerVisualElement.cs
@@ -111,6 +111,8 @@ namespace Beamable.Editor.Content.Components
 
 		private void ContentListVisualElement_OnItemDelete(ContentItemDescriptor contentItemDescriptor)
 		{
+			if (contentItemDescriptor.Status == ContentModificationStatus.SERVER_ONLY) return;
+
 			_itemsToDelete.Add(contentItemDescriptor);
 			EditorDebouncer.Debounce("content-deleting-lots-of-items", () =>
 			{


### PR DESCRIPTION
If you were to delete a server only content, it would spam infinite errors until you closed Unity. Now we are checking and doing nothing for those contents.
