### PR TITLE
Unreal CLI init flow generation fix

### DIFF
--- a/cli/cli/Utils/MachineHelper.cs
+++ b/cli/cli/Utils/MachineHelper.cs
@@ -69,7 +69,7 @@ public class MachineHelper
 		processStartInfo.FileName = "powershell.exe";
 		processStartInfo.Arguments = $"-Command \"{command}\"";
 		processStartInfo.Environment["DOTNET_CLI_UI_LANGUAGE"] = "en";
-		processStartInfo.WorkingDirectory = directory;
+		processStartInfo.WorkingDirectory = Path.GetFullPath(directory);
 		processStartInfo.UseShellExecute = false;
 		processStartInfo.RedirectStandardOutput = true;
 		processStartInfo.RedirectStandardError = true;


### PR DESCRIPTION
I was getting strange error in beam_init_game_maker script. 
```
beam_init_game_maker.sh "F:/UnrealSDK"                                                                                                                                                          12/04/24 15:01:24 PM
Found .uproject: ./SuperGame.uproject
Installing the SDK in your project: SuperGame
Narzędzie „beamable.tools” jest aktualne (wersja „3.0.0-PREVIEW.RC6”, plik manifestu F:\SuperGame\.config\dotnet-tools.json).
Beamable Tools are installed. To call them use "dotnet beam" from any directory under your Unreal project root.
Already installed BeamableCore plugin. Removing it so we can re-install it.

Installed BeamableCore plugin.

Nazwa pliku, nazwa katalogu lub składnia etykiety woluminu jest niepoprawna. (The file name, directory name, or volume label syntax is invalid.)
Installed Beamable SDK successfully.
```
It should not be a blocking release bug since it is possible to generate the project files manually.