### PR TITLE
fixes #3797 - empty strings dont bother deserializing into Unit

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `Party.Invite()` no longer throws a null reference exception. [https://github.com/beamable/BeamableProduct/issues/3797](#3797)
+
 ## [2.0.0] - 2024-12-09
 
 ### Added

--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `Party.Invite()` no longer throws a null reference exception. [https://github.com/beamable/BeamableProduct/issues/3797](#3797)
+- `Party.Invite()` no longer throws a null reference exception. [#3797](https://github.com/beamable/BeamableProduct/issues/3797)
 
 ## [2.0.0] - 2024-12-09
 

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/PlatformRequester.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/PlatformRequester.cs
@@ -691,7 +691,22 @@ namespace Beamable.Api
 
 					try
 					{
-						T result = opts.parser == null ? JsonUtility.FromJson<T>(responsePayload) : opts.parser(responsePayload);
+						T result = default;
+						if (opts.parser != null)
+						{
+							result = opts.parser(responsePayload);
+						}
+						else if (typeof(T) == typeof(Unit) )
+						{
+							// don't even bother trying to interpret the response payload if our type is _Unit_. 
+							//  we don't care about the server response anyway.
+							//  btw, if the server returns `""` as a response, then the JsonUtility.FromJson call fails. 
+							result = default;
+						}
+						else
+						{
+							result = JsonUtility.FromJson<T>(responsePayload);
+						}
 						promise.CompleteSuccess(result);
 					}
 					catch (Exception ex)


### PR DESCRIPTION
internal discussion: https://disruptorbeam.slack.com/archives/C03B6BGEK3Q/p1733843716072549 

The gist is that the server returns a `""` but the Unity serializer library cannot handle that for our type `Unit`. 
I added a simple work-around to special case this type.