### PR TITLE
fixes #3702 - purchaser doesnt add null keys

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `Party.Invite()` no longer throws a null reference exception. [#3797](https://github.com/beamable/BeamableProduct/issues/3797)
+- `UnityBeamablePurchaser` no longer adds null sku product ids into IAP catalog [#3702](https://github.com/beamable/BeamableProduct/issues/3702)
+
 
 ## [2.0.0] - 2024-12-09
 

--- a/client/Packages/com.beamable/Runtime/Modules/Purchasing/UnityBeamablePurchaser.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/Purchasing/UnityBeamablePurchaser.cs
@@ -59,14 +59,13 @@ namespace Beamable.Purchasing
 				}
 
 				
-				
 #if USE_STEAMWORKS && !UNITY_EDITOR
                 var builder = ConfigurationBuilder.Instance(new Steam.SteamPurchasingModule(_serviceProvider));
                 foreach (var sku in rsp.skus.definitions)
                 {
 				   if (sku == null) continue;
 
-                   var ids = UnityBeamablePurchaserUtil.CreateIdsFromSku(
+                   var ids = ExtractValidIdsFromSku(
 						new SkuIdPair {skuProductId = sku.productIds?.steam, storeId = Steam.SteamStore.Name,}
 				   );
 				   builder.AddProduct(sku.name, ProductType.Consumable, ids);
@@ -77,7 +76,7 @@ namespace Beamable.Purchasing
 				{
 					if (sku == null) continue;
 					
-					var ids = UnityBeamablePurchaserUtil.CreateIdsFromSku(
+					var ids = ExtractValidIdsFromSku(
 						new SkuIdPair {skuProductId = sku.productIds?.itunes, storeId = AppleAppStore.Name,},
 						new SkuIdPair {skuProductId = sku.productIds?.googleplay, storeId = GooglePlay.Name,}
 					);
@@ -90,6 +89,21 @@ namespace Beamable.Purchasing
 				// response either in OnInitialized or OnInitializeFailed.
 				UnityPurchasing.Initialize(this, builder);
 				return _initPromise;
+				
+				// Create an IDs instance from a list of Beamable SKU product id and IAP store ids.
+				// This method will only add the beamable SKU product ids that are not null or empty strings.
+				IDs ExtractValidIdsFromSku(params SkuIdPair[] skuIdPairs)
+				{
+					var ids = new IDs();
+
+					foreach (var pair in skuIdPairs)
+					{
+						if (string.IsNullOrEmpty(pair.skuProductId)) continue;
+						ids.Add(pair.skuProductId, pair.storeId);
+					}
+			
+					return ids;
+				}
 			});
 
 		}


### PR DESCRIPTION
different operating systems seem to handle the null case of a key in the `IDs` type differently. But anyway, we shouldn't be registering null keys anyway.

This PR introduces a static util function that takes a sequence of beamable product id & iap store id pairs, and converts them into the `IDs` instance whilst culling invalid keys. 