### PR TITLE
Fix flawed websocket retry logic

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `Party.Invite()` no longer throws a null reference exception. [#3797](https://github.com/beamable/BeamableProduct/issues/3797)
+- `WebSocketConnection` no longer throws `WebSocketConnectionException` during normal reconnect flows
+- `WebSocketConnection` will use the most recent JWT to attempt reconnection
 
 ## [2.0.0] - 2024-12-09
 

--- a/client/Packages/com.beamable/Runtime/3rdParty/WebSocket/WebSocket.cs
+++ b/client/Packages/com.beamable/Runtime/3rdParty/WebSocket/WebSocket.cs
@@ -497,6 +497,7 @@ namespace Beamable.Endel
 					if (m_Socket != null)
 					{
 						m_TokenSource.Cancel();
+						m_TokenSource.Dispose();
 						m_Socket.Dispose();
 					}
 				}

--- a/client/Packages/com.beamable/Runtime/BeamContext.cs
+++ b/client/Packages/com.beamable/Runtime/BeamContext.cs
@@ -596,7 +596,7 @@ namespace Beamable
 			// Need to get this in order to subscribe the message callbacks.
 			var _ = _serviceScope.GetService<BeamableSubscriptionManager>();
 			var connection = _serviceScope.GetService<IBeamableConnection>();
-			await connection.Connect(socketUri, _beamableApiRequester.Token);
+			await connection.Connect(socketUri, _beamableApiRequester);
 		}
 
 

--- a/client/Packages/com.beamable/Runtime/BeamContext.cs
+++ b/client/Packages/com.beamable/Runtime/BeamContext.cs
@@ -596,7 +596,7 @@ namespace Beamable
 			// Need to get this in order to subscribe the message callbacks.
 			var _ = _serviceScope.GetService<BeamableSubscriptionManager>();
 			var connection = _serviceScope.GetService<IBeamableConnection>();
-			await connection.Connect(socketUri, _beamableApiRequester);
+			await connection.Connect(socketUri);
 		}
 
 

--- a/client/Packages/com.beamable/Runtime/Connection/IBeamableConnection.cs
+++ b/client/Packages/com.beamable/Runtime/Connection/IBeamableConnection.cs
@@ -13,7 +13,7 @@ namespace Beamable.Connection
 		event Action<string> Error;
 		event Action Close;
 
-		Promise Connect(string address, IBeamableApiRequester token);
+		Promise Connect(string address);
 		Promise Disconnect();
 	}
 }

--- a/client/Packages/com.beamable/Runtime/Connection/IBeamableConnection.cs
+++ b/client/Packages/com.beamable/Runtime/Connection/IBeamableConnection.cs
@@ -1,6 +1,7 @@
 using Beamable.Api;
 using Beamable.Common;
 using Beamable.Common.Dependencies;
+using Core.Platform.SDK;
 using System;
 
 namespace Beamable.Connection
@@ -12,7 +13,7 @@ namespace Beamable.Connection
 		event Action<string> Error;
 		event Action Close;
 
-		Promise Connect(string address, AccessToken token);
+		Promise Connect(string address, IBeamableApiRequester token);
 		Promise Disconnect();
 	}
 }

--- a/client/Packages/com.beamable/Runtime/Connection/WebSocketConnection.cs
+++ b/client/Packages/com.beamable/Runtime/Connection/WebSocketConnection.cs
@@ -86,7 +86,7 @@ namespace Beamable.Connection
 			{
 				{"Authorization", $"Bearer {token}"}
 			};
-			_webSocket = new WebSocket(address, subprotocols, headers, coroutineService);
+			_webSocket = new WebSocket(address, subprotocols, headers, _coroutineService);
 #else
 			if(!string.IsNullOrWhiteSpace(token))
 			{

--- a/client/Packages/com.beamable/Runtime/Connection/WebSocketConnection.cs
+++ b/client/Packages/com.beamable/Runtime/Connection/WebSocketConnection.cs
@@ -43,7 +43,6 @@ namespace Beamable.Connection
 		{
 			_connectAddress = $"{address}/connect";
 			_apiRequester = requester;
-			CreateWebSocket();
 			// This is a bit gross but the underlying library doesn't complete the connect task until the connection
 			// is closed.
 			DoConnect();
@@ -68,11 +67,11 @@ namespace Beamable.Connection
 #endif
 		}
 
-		private Promise DoConnect()
+		private void DoConnect()
 		{
+			CreateWebSocket();
 			_onConnectPromise = new Promise();
 			Task _ = _webSocket.Connect();
-			return _onConnectPromise;
 		}
 
 		private void CreateWebSocket()
@@ -172,9 +171,7 @@ namespace Beamable.Connection
 						_delay = Mathf.Clamp(_delay, MIN_DELAY, MAX_DELAY);
 						_retrying = true;
 
-						// Throw away old websocket and create a new one
-						CreateWebSocket();
-						await DoConnect();
+						DoConnect();
 					}
 
 				}

--- a/client/Packages/com.beamable/Runtime/Connection/WebSocketConnection.cs
+++ b/client/Packages/com.beamable/Runtime/Connection/WebSocketConnection.cs
@@ -28,21 +28,21 @@ namespace Beamable.Connection
 		private bool _retrying;
 		private int _delay;
 		private WebSocket _webSocket;
+		private readonly IBeamableApiRequester _apiRequester;
 		private readonly CoroutineService _coroutineService;
 		private IEnumerator _dispatchMessagesRoutine;
 		private Promise _onConnectPromise;
-		private IBeamableApiRequester _apiRequester;
 		private string _connectAddress;
 
-		public WebSocketConnection(CoroutineService coroutineService)
+		public WebSocketConnection(IBeamableApiRequester apiRequester, CoroutineService coroutineService)
 		{
+			_apiRequester = apiRequester;
 			_coroutineService = coroutineService;
 		}
 
-		public Promise Connect(string address, IBeamableApiRequester requester)
+		public Promise Connect(string address)
 		{
 			_connectAddress = $"{address}/connect";
-			_apiRequester = requester;
 			// This is a bit gross but the underlying library doesn't complete the connect task until the connection
 			// is closed.
 			DoConnect();

--- a/client/Packages/com.beamable/Runtime/Connection/WebSocketConnection.cs
+++ b/client/Packages/com.beamable/Runtime/Connection/WebSocketConnection.cs
@@ -162,6 +162,9 @@ namespace Beamable.Connection
 					{
 						PlatformLogger.Log($"<b>[WebSocketConnection]</b> Ungraceful close of websocket. Reconnecting!");
 
+						// Let's make sure that we get a fresh new JWT before attempting to reconnect.
+						await _apiRequester.RefreshToken();
+
 						if (_retrying)
 						{
 							PlatformLogger.Log($"<b>[WebSocketConnection]</b> Retrying connection in {_delay / 1000} seconds");


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-XXXX

# Brief Description
When we've turned on our notifications replacement for some of our larger customers, they've noticed in their client exception tracking systems a dramatic increase in `WebsocketConnectionException` from their players. Upon some investigation, I found that there were a number of reasons why this happens.
- Api service rolls
- Background/Resume game on mobile device after a minute. The normal reconnect flow would throw the exception but connect just fine
- After 20 minutes, if the websocket connection drops, it will never be able to reconnect because the token the websocket uses to reconnect was the original one rather than one that has been refreshed and replaced in BeamableApiRequester
This PR addresses those 3 cases.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
