### PR TITLE
Convert bug_report and feature_request templates to use MD headings instead of bold text.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,35 +2,42 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: public-bug
+labels: ''
 assignees: ''
 
 ---
+## Describe the Bug 
 
-**Describe the bug**
 A clear and concise description of what the bug is.
 
-**To Reproduce**
-Steps to reproduce the behavior:
+## To Reproduce
+
+### Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+### Expected Behavior
+
 A clear and concise description of what you expected to happen.
 
-**Actual behavior**
+### Actual Behavior
+
 A clear and concise description of what is actually happening.
 
-**Screenshots**
+## Screenshots
+
 If applicable, add screenshots to help explain your problem.
 
-**Metadata**
-Please include,
-- SDK version,
-- Engine version,
-- Operating System
+## Metadata
 
-**Additional context**
+- SDK version: 
+- Engine version: 
+- Operating System: 
+
+## Additional Context
+
 Add any other context about the problem here.
+If there is a known workaround, describe it here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,19 +2,26 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: public-request
+labels: ''
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+## Reason for the Feature
+_Is your feature request related to a problem? Please describe._
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+## Proposed Solution/Requirements
+_Describe the solution you'd like._
+
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+## Alternatives or Workarounds
+_Describe alternatives you've considered._
+
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+## Additional Context
+
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
# Ticket

No associated issue.

# Brief Description

I think it looks nicer when issue text uses `##`-style headings rather than `**`-style bold text for sections. The added pragmatic bonus is that headings can be anchor-linked to call attention to a particular section when referring to issues by URL.

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
