### PR TITLE
Fix/double asmdefs

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2024-12-13
+
+### Fixed
+  - Fix .gitignore not being created when passing cid/pid to the Init command
+
 ## [3.0.1] - 2024-12-09
 
 ### Fixed

--- a/cli/cli/Commands/InitCommand.cs
+++ b/cli/cli/Commands/InitCommand.cs
@@ -180,10 +180,13 @@ public class InitCommand : AtomicCommand<InitCommandArgs, InitCommandResult>,
 
 	private async Task<bool> GetPidAndAuth(InitCommandArgs args, string cid, string host)
 	{
+		// [Tech_debt] This is quite hard to read, lots of duplication calls, could use some refactor, also it does way more stuff
+		//  then just returning the pid and auth
 		if (!string.IsNullOrEmpty(_ctx.Pid) && string.IsNullOrEmpty(args.pid))
 		{
 			_ctx.Set(cid, _ctx.Pid, host);
 			_configService.SetBeamableDirectory(_ctx.WorkingDirectory);
+			_configService.CreateIgnoreFile();
 			_configService.FlushConfig();
 
 			var didLogin = await Login(args);
@@ -202,6 +205,7 @@ public class InitCommand : AtomicCommand<InitCommandArgs, InitCommandResult>,
 			{
 				_configService.SetBeamableDirectory(_ctx.WorkingDirectory);
 				_configService.SetConfigString(Constants.CONFIG_PID, args.pid);
+				_configService.CreateIgnoreFile();
 				_configService.FlushConfig();
 			}
 			else

--- a/cli/cli/Commands/InitCommand.cs
+++ b/cli/cli/Commands/InitCommand.cs
@@ -186,8 +186,8 @@ public class InitCommand : AtomicCommand<InitCommandArgs, InitCommandResult>,
 		{
 			_ctx.Set(cid, _ctx.Pid, host);
 			_configService.SetBeamableDirectory(_ctx.WorkingDirectory);
-			_configService.CreateIgnoreFile();
 			_configService.FlushConfig();
+			_configService.CreateIgnoreFile();
 
 			var didLogin = await Login(args);
 
@@ -205,8 +205,8 @@ public class InitCommand : AtomicCommand<InitCommandArgs, InitCommandResult>,
 			{
 				_configService.SetBeamableDirectory(_ctx.WorkingDirectory);
 				_configService.SetConfigString(Constants.CONFIG_PID, args.pid);
-				_configService.CreateIgnoreFile();
 				_configService.FlushConfig();
+				_configService.CreateIgnoreFile();
 			}
 			else
 			{

--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2024-12-13
+
+### Fixed
+ - Throwing error when migrating microservice that references Assembly Definition Assets that has more matches to it's name
 
 ## [2.0.0] - 2024-12-11
 


### PR DESCRIPTION
# Ticket

resolves #3821 #3820

# Brief Description

- Fix .gitignore not being created when passing cid/pid to the Init command
- Throwing error when migrating microservice that references Assembly Definition Assets that has more matches to it's name

