### PR TITLE
Ensure that "Disconnect" is called prior to calling DoConnect

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Added custom property drawer to federations in `SimGameType` scriptable objects. [#3628](https://github.com/beamable/BeamableProduct/issues/3628)
+- `WebSocketConnection` will ensure proper disconnect/reconnect when switching players
 
 
 ## [2.0.2] - 2024-12-17


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-XXXX

# Brief Description

The changes I had made before worked when attempting to reconnect a broken connection but when the SDK switches users via the `ChangeAuthorizedPlayer` call, `Connect()` is called again before any call to `Disconnect()`. This new bit of code protects against seeing the `OnOpen` event action twice in that situation.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
