### PR TITLE
fixes #3839 - adds pid based self-destruct to microservices

### DIFF
--- a/cli/beamable.common/Runtime/Constants/Constants.cs
+++ b/cli/beamable.common/Runtime/Constants/Constants.cs
@@ -164,6 +164,7 @@
 			public const string BEAM_PATH = "BEAM_PATH";
 			public const string BEAM_DOTNET_PATH = "BEAM_DOTNET_PATH";
 			public const string BEAM_DOTNET_MSBUILD_PATH = "BEAM_DOTNET_MSBUILD_PATH";
+			public const string BEAM_REQUIRE_PROCESS_ID = "BEAM_REQUIRE_PROCESS_ID";
 		}
 	}
 }

--- a/cli/cli/App.cs
+++ b/cli/cli/App.cs
@@ -6,6 +6,7 @@ using Beamable.Common.Api.Realms;
 using Beamable.Common.BeamCli;
 using Beamable.Common.Dependencies;
 using Beamable.Common.Semantics;
+using Beamable.Common.Util;
 using cli.CliServerCommand;
 using cli.Commands.Project;
 using cli.Commands.Project.Deps;
@@ -607,7 +608,7 @@ public class App
 
 				
 			});
-			var executingVersion = VersionService.GetNugetPackagesForExecutingCliVersion();
+			var executingVersion = BeamAssemblyVersionUtil.GetVersion<App>();
 
 			defaultLayout.Insert(0, (ctx) =>
 			{

--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.0]
 
+### Added
+- `project run` command includes `--require-process-id` option that will cause microservices to exit when given process terminates. [#3839](https://github.com/beamable/BeamableProduct/issues/3839)
+
 ### Fixed
 - Fixed issue in `unreal init` command that could cause the Target file to fail being modified.
 

--- a/microservice/microservice/CHANGELOG.md
+++ b/microservice/microservice/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - Unreleased
+
+### Added
+- Providing `BEAM_REQUIRE_PROCESS_ID` environment variable will cause microservice to quit when configured process terminates. [#3839](https://github.com/beamable/BeamableProduct/issues/3839)
+
 ## [3.0.1] - 2024-12-09
+
+### Fixed
 - Fixed issue that caused the OAPI Generation to fail with an exception if you put `BeamGenerateSchema` on a type that was already used in a `Callable` signature.
   - This implies that you can now reuse `BeamGenerateSchema` types for both custom notifications AND `Callable` signatures.
 

--- a/microservice/microservice/dbmicroservice/MicroserviceArgs.cs
+++ b/microservice/microservice/dbmicroservice/MicroserviceArgs.cs
@@ -43,6 +43,7 @@ namespace Beamable.Server
 		public string MetadataUrl { get; }
 		public string RefreshToken { get; }
 		public long AccountId { get; }
+		public int RequireProcessId { get; }
 	}
 
 	public enum LogOutputType
@@ -88,6 +89,7 @@ namespace Beamable.Server
 		public string MetadataUrl { get; set; }
 		public string RefreshToken { get; set; }
 		public long AccountId { get; set; }
+		public int RequireProcessId { get; set; }
 	}
 
 	public static class MicroserviceArgsExtensions
@@ -130,7 +132,8 @@ namespace Beamable.Server
 				LogOutputPath = args.LogOutputPath,
 				EnableDangerousDeflateOptions = args.EnableDangerousDeflateOptions,
 				MetadataUrl = args.MetadataUrl,
-				AccountId = args.AccountId
+				AccountId = args.AccountId,
+				RequireProcessId = args.RequireProcessId
 			};
 			configurator?.Invoke(next);
 			return next;
@@ -198,6 +201,9 @@ namespace Beamable.Server
 		}
 
 		public long AccountId => GetLongFromEnvironmentVariable("USER_ACCOUNT_ID", 0);
+
+		public int RequireProcessId =>
+			GetIntFromEnvironmentVariable(Beamable.Common.Constants.EnvironmentVariables.BEAM_REQUIRE_PROCESS_ID, 0);
 
 		public string Host => Environment.GetEnvironmentVariable("HOST");
 		public string Secret => Environment.GetEnvironmentVariable("SECRET");

--- a/microservice/microserviceTests/microservice/TestArgs.cs
+++ b/microservice/microserviceTests/microservice/TestArgs.cs
@@ -128,5 +128,6 @@ namespace microserviceTests.microservice
       public string MetadataUrl { get; }
 	  public string RefreshToken { get; }
 	  public long AccountId => 0;
+	  public int RequireProcessId { get; }
    }
 }


### PR DESCRIPTION
There is a new ENV var in the C#MS framework that when present locally, kicks off a monitor loop checking for the process existence- when the process no longer exists, the microservice terminates. 

You'll see logs like this,
```
[Info] Quitting because required process no longer exists

[Debug] Shutdown started... 0 tasks running.

[Debug] sending request 
{"id":-8,"method":"delete","path":"gateway/provider","from":null,"body":{"type":"basic","name":"micro_Fishsticks","beamoName":null,"routingKey":null,"startedById":null}
}
```

The CLI sets this ENV var based on the existence of a new option flag. 