### PR TITLE
fixes #3456 - beam init is useful on rerun

### DIFF
--- a/cli/cli/App.cs
+++ b/cli/cli/App.cs
@@ -247,9 +247,9 @@ public class App
 		// add global options
 		Commands.AddSingleton<DryRunOption>();
 		Commands.AddSingleton<SkipStandaloneValidationOption>();
-		Commands.AddSingleton<CidOption>();
+		Commands.AddSingleton(CidOption.Instance);
 		Commands.AddSingleton<QuietOption>();
-		Commands.AddSingleton<PidOption>();
+		Commands.AddSingleton(PidOption.Instance);
 		Commands.AddSingleton<ConfigDirOption>();
 		Commands.AddSingleton<HostOption>();
 		Commands.AddSingleton<LimitOption>();

--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - nuget package license and icon use baked files instead of links.
+- re-running `beam init` in an existing beamable workspace will prompt for new CID and PID information. [#3456](https://github.com/beamable/BeamableProduct/issues/3456)
 
 ## [3.0.2] - 2024-12-17
 

--- a/cli/cli/Commands/InitCommand.cs
+++ b/cli/cli/Commands/InitCommand.cs
@@ -7,6 +7,7 @@ using CliWrap;
 using Serilog;
 using Spectre.Console;
 using System.CommandLine;
+using System.CommandLine.Binding;
 using System.CommandLine.Invocation;
 using System.Text;
 using Command = System.CommandLine.Command;
@@ -56,8 +57,6 @@ public class InitCommand : AtomicCommand<InitCommandArgs, InitCommandResult>,
 
 		// Options to allow for re-initializing a project to a different host/cid/pid and user
 		AddOption(new HostOption(), (args, i) => args.selectedEnvironment = i);
-		AddOption(new CidOption(), (args, i) => args.cid = i);
-		AddOption(new PidOption(), (args, i) => args.pid = i);
 		AddOption(new RefreshTokenOption(), (args, i) => args.refreshToken = i);
 
 		AddOption(
@@ -162,7 +161,10 @@ public class InitCommand : AtomicCommand<InitCommandArgs, InitCommandResult>,
 	public override async Task<InitCommandResult> GetResult(InitCommandArgs args)
 	{
 		var originalPath = Path.GetFullPath(Directory.GetCurrentDirectory());
-		
+		var parseResult = args.DependencyProvider.GetService<BindingContext>().ParseResult;
+		args.cid = parseResult.GetValueForOption(CidOption.Instance);
+		args.pid = parseResult.GetValueForOption(PidOption.Instance);
+
 		_ctx = args.AppContext;
 		_configService = args.ConfigService;
 		_aliasService = args.AliasService;

--- a/cli/cli/Options/CidOption.cs
+++ b/cli/cli/Options/CidOption.cs
@@ -4,7 +4,9 @@ namespace cli;
 
 public class CidOption : ConfigurableOption
 {
-	public CidOption()
+	public static CidOption Instance { get; } = new CidOption();
+
+	private CidOption()
 		: base(Constants.CONFIG_CID, "Cid to use; will default to whatever is in the file system")
 	{ }
 }

--- a/cli/cli/Options/PidOption.cs
+++ b/cli/cli/Options/PidOption.cs
@@ -4,7 +4,9 @@ namespace cli;
 
 public class PidOption : ConfigurableOption
 {
-	public PidOption()
+	public static PidOption Instance { get; } = new PidOption();
+
+	private PidOption()
 		: base(Constants.CONFIG_PID, "Pid to use; will default to whatever is in the file system")
 	{ }
 }


### PR DESCRIPTION
When you run `beam init`; it does the same thing it used to....
When you run it _again_, if you are in an existing workspace, it will re-write the current .beamable workspace. 
Or, if you truly do want to create a new workspace in a nested format, then it will ignore the cid/pid info from the parental .beamable folder.