### PR TITLE
docs for 4.0

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.0]
+## [4.0.0] - Unreleased
 
 ### Added
 - `project run` command includes `--require-process-id` option that will cause microservices to exit when given process terminates. [#3839](https://github.com/beamable/BeamableProduct/issues/3839)

--- a/cli/cli/Docs/Commands/init.md
+++ b/cli/cli/Docs/Commands/init.md
@@ -4,6 +4,8 @@ The {{title}} command is used for initializing a `.beamable` folder. A `.beamabl
 contextual information to later invocations of the CLI. The folder has Beamable connection strings and
 authorization information that can be used later.
 
+This command can also be used to change the CID/PID of an existing `.beamable` folder.
+
 # Arg_path
 
 By default, the {{title}} command creates a `.beamable` folder in the current directory. 

--- a/cli/cli/Docs/Guides/2_Upgrading.md
+++ b/cli/cli/Docs/Guides/2_Upgrading.md
@@ -28,8 +28,8 @@ releases.
 #### Removed `net6.0` and `net7.0` support
 Unfortunately, `net6.0` and `net7.0` have reached their [End-Of-Life phases](https://devblogs.microsoft.com/dotnet/dotnet-6-end-of-support/). 
 The CLI 4.0 release officially drops Beamable support for these EOL dotnet 
-versions. As such, when you update your projects, you must update your `.
-csproj` files to use `net8.0`. 
+versions. As such, when you update your projects, you must update your
+`.csproj` files to use `net8.0`. 
 
 In all your `.csproj` files, find the line with the `<TargetFramework>` 
 declaration, 

--- a/cli/cli/Docs/Guides/2_Upgrading.md
+++ b/cli/cli/Docs/Guides/2_Upgrading.md
@@ -21,6 +21,48 @@ The Beamable CLI may include changes between versions that require developer int
 
 These are ordered with the latest versions towards the top, and the older versions toward the bottom of the document. **When jumping multiple versions (A.A.A -> C.C.C), apply the migrations without skipping steps (A.A.A -> B.B.B -> C.C.C).**
 
+### From 3.0.1 to 4.0.0
+The upgrade from 3.0.x to 4.0.0 is relatively simple compared to other major 
+releases. 
+
+#### Removed `net6.0` and `net7.0` support
+Unfortunately, `net6.0` and `net7.0` have reached their [End-Of-Life phases](https://devblogs.microsoft.com/dotnet/dotnet-6-end-of-support/). 
+The CLI 4.0 release officially drops Beamable support for these EOL dotnet 
+versions. As such, when you update your projects, you must update your `.
+csproj` files to use `net8.0`. 
+
+In all your `.csproj` files, find the line with the `<TargetFramework>` 
+declaration, 
+
+```xml
+<TargetFramework>net6.0</TargetFramework>
+```
+
+And update it to
+```xml
+<TargetFramework>net8.0</TargetFramework>
+```
+
+> 📘 Update Dotnet SDK
+>
+> As of CLI 4.0.0, you must have dotnet8 SDK installed on your development 
+> machines, instead of the dotnet6 SDK. 
+
+#### `MongoDb.Driver` package vulnerability 
+Previous versions of Beamable relied on version 2.15.1 of the `MongoDb.
+Driver` nuget package. If your project does not include any storage objects, 
+you can ignore this step. However, if you do have storage objects, then 
+those projects likely include this reference in the `.csproj` files, 
+
+```xml
+<PackageReference Include="MongoDB.Driver" Version="2.15.1"/>
+```
+
+If your storage object does not include direct references to the `MongoDB.
+Driver`, you can simply delete this line, and the correct version will be 
+included automatically by referencing the `Beamable.Microservice.Runtime` 
+package. You can also change the version number to exactly `2.19.2`.  
+
 ### From 2.0.2 to 3.0.1
 The upgrade from 2.0.x to 3.0.1 brings a few critical updates to the `csproj` file, how the Beam CLI tool is managed, and the version of `dotnet`. 
 
@@ -120,13 +162,22 @@ In every `csproj` file for **Microservices**, **MicroStorages**, and **Common Li
 </PropertyGroup>
 ```
 
-Then, we recommend you upgrade the `TargetFramework` to `.net8.0`:
+If the project is targeting `net6.0` or `net7.0`, then, we recommend you 
+upgrade the `TargetFramework` to `.net8.0`.
 ```xml
 <PropertyGroup Label="Dotnet Settings">  
   <!-- net8.0 is the LTS version until 2026. To update your net version, update the <TargetFramework> when Beamable announces support. -->  
   <TargetFramework>net8.0</TargetFramework>  
 </PropertyGroup>
 ```
+
+> 📘 Don't update `netstandard2.1` to `net8.0`
+>
+> Be careful not to update common projects from `netstandard2.1` to `net8.0`.
+> The `netstandard2.1` target produces `.dll` files that can be copied 
+> directly into a wide variety of engines, such as Unity. However, `net8.0` 
+> binaries are not compatible with Unity. 
+
 
 ##### Microservices
 For every Microservice project replace all `PackageReference` elements that reference a `Beamable.` with the following two references:
@@ -159,15 +210,7 @@ Then, add the following to the `Beamable Settings` `Property Group`. Please repl
 ##### Common Libraries
 For every Common Library project, replace all `PackageReference` elements that reference a `Beamable.` with the following reference:
 ```xml
-<PackageReference Include="Beamable.Microservice.Runtime" Version="$(BeamableVersion)" />
-```
-
-Then, also add the following to the `Beamable Settings` `Property Group`:
-```xml
-<PropertyGroup Label="Beamable Settings">  
-  <!-- All Microservices must have the value, "service" -->  
-  <BeamProjectType>service</BeamProjectType>          
-</PropertyGroup>
+<PackageReference Include="Beamable.Common" Version="$(BeamableVersion)" />
 ```
 
 #### Microservice Code Changes - `partial` and `FederationId` 

--- a/cli/cli/Docs/Guides/9_MIcroservice-Federation.md
+++ b/cli/cli/Docs/Guides/9_MIcroservice-Federation.md
@@ -22,10 +22,12 @@ dotnet beam project new service HelloWorld
 
 Microservice _Federation_ is the ability to inject custom server logic in the middle of existing Beamable server functionality. Federation can be used to add custom behaviour to your game like supporting external identity auth providers, using a block chain as the backing data provider for player inventory, managing how match making works, and more. 
 
-There are 3 types of federation. All of these federations have C# interfaces that define the types of functions that they require. 
+There are 4 types of federation. All of these federations have C# interfaces 
+that define the types of functions that they require. 
 1. `IFederatedLogin`
 2. `IFederatedInventory`
 3. `IFederatedGameServer`
+4. `IFederatedPlayerInit`
 
 A Microservice supports these federations when both of the following requirements are true.
 1. The `Microservice` class includes the associated federation interface.

--- a/microservice/microservice/CHANGELOG.md
+++ b/microservice/microservice/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.0] - Unreleased
+## [4.0.0] - Unreleased
 
 ### Added
 - Providing `BEAM_REQUIRE_PROCESS_ID` environment variable will cause microservice to quit when configured process terminates. [#3839](https://github.com/beamable/BeamableProduct/issues/3839)
@@ -13,10 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `CallableFlags` to all `Callable` attributes. You can now use this to opt-out of client-code generation for specific `Callables` (mostly used for hiding `AdminOnlyCallables` from client source). 
 
 ### Changed
-- Updated internal mongo driver reference to Nuget 2.19.2
+- Updated MongoDb.Driver reference to 2.19.2 in accordance with [known security vulnerability](https://github.com/advisories/GHSA-7j9m-j397-g4wx)
 
 ### Removed
-- Nuget packages no longer support net6.0
+- No longer support net6.0
 
 ## [3.0.1] - 2024-12-09
 


### PR DESCRIPTION
CLI 3.1 becomes CLI 4.0, due to major version changes. 

I updated the CL and the migration guide. 
I also made some updates for the 2.x to 3.x guide that were suggested awhile ago. 