### PR TITLE
New method for switching realms in runtime

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Beam.SwitchToPid` method as a replacement for `Beam.ChangePid` with extra functionality- if the passed PID is the same as the current one no action is performed.
+
 ### Fixed
 - `Party.Invite()` no longer throws a null reference exception. [#3797](https://github.com/beamable/BeamableProduct/issues/3797)
 - `UnityBeamablePurchaser` no longer adds null sku product ids into IAP catalog [#3702](https://github.com/beamable/BeamableProduct/issues/3702)
@@ -16,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Added custom property drawer to federations in `SimGameType` scriptable objects. [#3628](https://github.com/beamable/BeamableProduct/issues/3628)
 - `WebSocketConnection` will ensure proper disconnect/reconnect when switching players
-
+- `Beam.ChangePid` marked as Obsolete
 
 ## [2.0.2] - 2024-12-17
 

--- a/client/Packages/com.beamable/Runtime/Beam.cs
+++ b/client/Packages/com.beamable/Runtime/Beam.cs
@@ -409,8 +409,30 @@ namespace Beamable
 		/// When the next <see cref="BeamContext"/> loads, it will use the same CID as before, but the
 		/// PID will be the value given to this function.
 		/// </summary>
+		/// <remarks>
+		/// If the passed PID is the same as the current one no action is performed.
+		/// </remarks>
 		/// <param name="pid">a valid Beamable PID for the current CID.</param>
 		/// <param name="sceneQualifier">The string should either be a scene name, or the stringified int of a scene build index.</param>
+		/// <returns>An enum with information if PID change was performed.</returns>
+		public static async Promise<SwitchPidResult> SwitchToPid(string pid, string sceneQualifier = "0")
+		{
+			if (RuntimeConfigProvider.Pid.Equals(pid))
+				return SwitchPidResult.NoAction;
+			await StopAllContexts();
+			RuntimeConfigProvider.Pid = pid;
+			await ResetToScene(sceneQualifier);
+			return SwitchPidResult.SwitchedToNewPid;
+		}
+
+		/// <summary>
+		/// Changes the current PID value for the game, and resets the game to the given scene defined by <see cref="sceneQualifier"/>.
+		/// When the next <see cref="BeamContext"/> loads, it will use the same CID as before, but the
+		/// PID will be the value given to this function.
+		/// </summary>
+		/// <param name="pid">a valid Beamable PID for the current CID.</param>
+		/// <param name="sceneQualifier">The string should either be a scene name, or the stringified int of a scene build index.</param>
+		[Obsolete("Method is obsolete, please use SwitchToPid instead.")]
 		public static async Promise ChangePid(string pid, string sceneQualifier = "0")
 		{
 			await StopAllContexts();
@@ -504,5 +526,11 @@ namespace Beamable
 
 			return loadAction;
 		}
+	}
+
+	public enum SwitchPidResult
+	{
+		NoAction,
+		SwitchedToNewPid,
 	}
 }

--- a/client/Packages/com.beamable/Runtime/Beam.cs
+++ b/client/Packages/com.beamable/Runtime/Beam.cs
@@ -414,7 +414,7 @@ namespace Beamable
 		/// </remarks>
 		/// <param name="pid">a valid Beamable PID for the current CID.</param>
 		/// <param name="sceneQualifier">The string should either be a scene name, or the stringified int of a scene build index.</param>
-		/// <returns>An enum with information if PID change was performed.</returns>
+		/// <returns><see cref="SwitchPidResult"/> An enum with information if PID change was performed.</returns>
 		public static async Promise<SwitchPidResult> SwitchToPid(string pid, string sceneQualifier = "0")
 		{
 			if (RuntimeConfigProvider.Pid.Equals(pid))
@@ -528,9 +528,18 @@ namespace Beamable
 		}
 	}
 
+	/// <summary>
+	/// Return type of the <see cref="Beam.SwitchToPid"/> method.
+	/// </summary>
 	public enum SwitchPidResult
 	{
+		/// <summary>
+		/// The PID passed to the method was the same as the active PID and no action was performed.
+		/// </summary>
 		NoAction,
+		/// <summary>
+		/// Beam stopped all <see cref="BeamContext"/> instances and switched to the new PID.
+		/// </summary>
 		SwitchedToNewPid,
 	}
 }


### PR DESCRIPTION
One of our customers ended up in endless loading loop because of the fact that `Beam.ChangePid` method is not checking if the realm they wanted switch to isn't already active. I was thinking about that case and I think this new method would be a improved way to handle that case. I didn't want to change return type in the old one so it would not end up being breaking change.