### PR TITLE
fixed #3865 config window gui exceptions

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Entering or exiting Playmode while viewing the Config section in the _Beam 
+  Services_ window no longer causes UI exceptions [#3865](https://github.com/beamable/BeamableProduct/issues/3865)
+
 ## [2.0.1]  - 2024-12-17
 
 ### Fixed

--- a/client/Packages/com.beamable.server/Editor/UI2/UsamWindow/UsamWindow_Settings.cs
+++ b/client/Packages/com.beamable.server/Editor/UI2/UsamWindow/UsamWindow_Settings.cs
@@ -28,7 +28,21 @@ namespace Beamable.Editor.Microservice.UI2
 
 		void ReserializeSettings()
 		{
-			if (hasSerializedSettingsYet) return;
+
+			if (hasSerializedSettingsYet)
+			{
+				if (HasInvalidTargetObjects())
+				{
+					hasSerializedSettingsYet = false;
+				}
+				else
+				{
+					// we already serialized, AND the targetObjects appear to still be valid.
+					return;
+				}
+			}
+			
+			
 			// annoying, Unity's own SerializedObject type is not inherently serializable; so it needs to get
 			//  re-serialized over and over again as we domain relaod. 
 			serviceSettings.Clear();
@@ -48,6 +62,28 @@ namespace Beamable.Editor.Microservice.UI2
 			}
 
 			hasSerializedSettingsYet = true;
+
+			bool HasInvalidTargetObjects()
+			{
+				// double check that the serializedObjects we have are still intact.
+				//  they may have null'd out during a Playmode transition. 
+				foreach (var serializedObject in serviceSettings)
+				{
+					if (serializedObject.targetObject == null)
+					{
+						return true;
+					}
+				}
+				foreach (var serializedObject in storageSettings)
+				{
+					if (serializedObject.targetObject == null)
+					{
+						return true;
+					}
+				}
+
+				return false;
+			}
 		}
 		
 		void DrawSettings()
@@ -175,6 +211,7 @@ namespace Beamable.Editor.Microservice.UI2
 				if (settings == null)
 				{
 					EditorGUILayout.LabelField("Please refresh this page.");
+					EditorGUILayout.EndVertical();
 					return;
 				}
 
@@ -315,6 +352,7 @@ namespace Beamable.Editor.Microservice.UI2
 			if (settings == null)
 			{
 				EditorGUILayout.LabelField("Please refresh this page.");
+				EditorGUILayout.EndVertical();
 				return;
 			}
 


### PR DESCRIPTION
two real issues here, 
1. we had an early `return` in one of the UI helper methods that wasn't calling the required `EndVertical()` function, so that was the cause of the error.
2. the _intent_ of the UI is to flag the fact that the serialized objects are broken; so I added some code earlier up that will check if the objects are null, and if so, re-initialize them.