### PR TITLE
Remove obsolete CacheDependentMS.meta

### DIFF
--- a/client/Assets/Beamable/Microservices/CacheDependentMS.meta
+++ b/client/Assets/Beamable/Microservices/CacheDependentMS.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: dced70948156bfd458d2ae96965e4e02
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
# Brief Description

We used to have a sample microservice in `Microservices/CacheDependentMS/` but that service no longer exists. When I was searching for that service, I found the Unity meta file for its directory which momentarily misled me. This PR cleans up that misleading bit of cruft.

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
