### PR TITLE
fixes #3916 - content renaming in Unity 6

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Renaming Content in Unity 6 works [3916](https://github.
+  com/beamable/BeamableProduct/issues/3916)
+
 ## [2.1.0] - 2025-02-24
 
 ### Added

--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ContentVisualElement/ContentVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ContentVisualElement/ContentVisualElement.cs
@@ -210,7 +210,11 @@ namespace Beamable.Editor.Content.Components
 
 		private void NameLabel_OnKeydown(KeyDownEvent evt)
 		{
+			#if UNITY_6000_0_OR_NEWER
+			// unity 6 doesn't need to stop the propagation, otherwise the renaming doesn't work
+			#else
 			evt.StopPropagation();
+			#endif
 			switch (evt.keyCode)
 			{
 				case KeyCode.Escape:
@@ -230,7 +234,12 @@ namespace Beamable.Editor.Content.Components
 
 		private void NameLabel_OnBlur(BlurEvent evt)
 		{
+			#if UNITY_6000_0_OR_NEWER
+			CheckName();
+			CommitName();
+			#else
 			evt.StopPropagation();
+			#endif
 		}
 
 		private void CommitName()

--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ContentVisualElement/ContentVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ContentVisualElement/ContentVisualElement.cs
@@ -210,9 +210,8 @@ namespace Beamable.Editor.Content.Components
 
 		private void NameLabel_OnKeydown(KeyDownEvent evt)
 		{
-			#if UNITY_6000_0_OR_NEWER
 			// unity 6 doesn't need to stop the propagation, otherwise the renaming doesn't work
-			#else
+			#if !UNITY_6000_0_OR_NEWER
 			evt.StopPropagation();
 			#endif
 			switch (evt.keyCode)


### PR DESCRIPTION
Seems like they changed how event propagation works between unity versions. 