### PR TITLE
Fix Soft Crash on Android and iOS when trying to delete CloudSaving tmp folder.

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Fixed
+- Fixed game crash on Android and iOS whenever a error occurred on `CloudSavingService`.
+
+### Changed
+ - Updated logs on `CloudSavingService.HandleRequest` for better understanding of possible errors regarding manifest keys that doesn't match the server.
+
 ## [2.1.2] - 2025-03-05
 ### Added
 - Added new method (`ForceUploadSave`) on `CloudSavingService` to force upload local save to cloud.

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/CloudSaving/CloudSavingService.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/CloudSaving/CloudSavingService.cs
@@ -535,7 +535,8 @@ namespace Beamable.Api.CloudSaving
 					}
 					else
 					{
-						Debug.LogWarning($"Key in manifest does not match a value on the server, Key {kv.Value}");
+						string availableKeys = string.Join(" | ", s3Response.Keys);
+						Debug.LogWarning($"Key in manifest does not match a value on the server, Key {kv.Value}. Available Keys are: {availableKeys}");
 					}
 				}
 
@@ -547,7 +548,14 @@ namespace Beamable.Api.CloudSaving
 				return Promise.ExecuteInBatch(10, promiseList.Values.ToList()).Map(_ => PromiseBase.Unit);
 			}).Error(delete =>
 			{
-				Directory.Delete(localCloudDataPath.temp, true);
+				#if UNITY_ANDROID || UNITY_IOS
+				Debug.LogWarning($"Temp Folder cannot be deleted on {Application.platform}, skipping it.");
+				#else
+				if (Directory.Exists(localCloudDataPath.temp))
+				{
+					Directory.Delete(localCloudDataPath.temp, true);
+				}
+				#endif
 			});
 		}
 


### PR DESCRIPTION
# Ticket

No ticket at the moment

# Brief Description

 - Disable tmp folder deletion for Android and iOS as it is inside Application.persistentDataPath, it cannot [be deleted by the system, only by the user](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/Application-persistentDataPath.html#:~:text=When%20you%20publish%20on%20iOS,not%20by%20any%20app%20updates.).
 - Changed error log when a key in the manifest does not match the server. 

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?
