### PR TITLE
fix for ssl issues in private cloud

### DIFF
--- a/client/Packages/com.beamable/Editor/BeamEditor.cs
+++ b/client/Packages/com.beamable/Editor/BeamEditor.cs
@@ -156,22 +156,20 @@ namespace Beamable
 
 		static BeamEditor()
 		{
-			// temp removed to test. 
-			// if (!HasDependencies())
-			// {
-			// 	AssetDatabase.Refresh();
-			// 	_dependenciesLoadPromise = ImportDependencies();
-			// 	_dependenciesLoadPromise.Then(_ =>
-			// 	{
-			// 		EditorUtility.RequestScriptReload();
-			// 		AssetDatabase.Refresh();
-			// 		Initialize();
-			// 	}).Error(_ =>
-			// 	{
-			// 		Initialize();
-			// 	});
-			// }
-			// else
+			if (!HasDependencies())
+			{
+				_dependenciesLoadPromise = ImportDependencies();
+				_dependenciesLoadPromise.Then(_ =>
+				{
+					EditorUtility.RequestScriptReload();
+					AssetDatabase.Refresh();
+					Initialize();
+				}).Error(_ =>
+				{
+					Initialize();
+				});
+			}
+			else
 			{
 				Initialize();
 			}
@@ -370,7 +368,7 @@ namespace Beamable
 
 		public static async Promise ImportDependencies()
 		{
-			AddressableAssetSettingsDefaultObject.GetSettings(true);
+			AddressableAssetSettingsDefaultObject.GetSettings(false);
 			await TextMeshProImporter.ImportEssentials();
 		}
 		

--- a/microservice/microservice/CHANGELOG.md
+++ b/microservice/microservice/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Content preloading uses configured host string in SSL logic, rather than hard coding "beamable.com"
+
 ## [4.1.0] - 2025-02-20
 
 ### Fixed

--- a/microservice/microservice/dbmicroservice/IContentResolver.cs
+++ b/microservice/microservice/dbmicroservice/IContentResolver.cs
@@ -1,8 +1,6 @@
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Beamable.Common;
-using System;
-using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
@@ -16,18 +14,30 @@ namespace Beamable.Server
    public class DefaultContentResolver : IContentResolver
    {
 	   private HttpClient client;
+	   private string _suffixFilter;
 
-	   public DefaultContentResolver()
+	   public DefaultContentResolver(IMicroserviceArgs args)
 	   {
+		   if (string.IsNullOrEmpty(args?.Host) || args.Host.Contains("localhost"))
+		   {
+			   _suffixFilter = ".beamable.com";
+		   } else
+		   {
+			   var hostLike = args.Host.Replace("dev.api", "dev-api");
+			   _suffixFilter = "." + string.Join(".", hostLike
+				   .Split(".")
+				   .Skip(1));
+		   }
+		   
 		   var handler = new HttpClientHandler();
 		   handler.ServerCertificateCustomValidationCallback = ServerCertificateCustomValidationCallback;
 		   client = new HttpClient(handler);
 	   }
 
-	   private bool ServerCertificateCustomValidationCallback(HttpRequestMessage msg, X509Certificate2 cert, X509Chain chain, SslPolicyErrors errors)
+	   public bool ServerCertificateCustomValidationCallback(HttpRequestMessage msg, X509Certificate2 cert, X509Chain chain, SslPolicyErrors errors)
 	   {
 		   // the URI must start with the Beamable URI, otherwise an invalid URI may have been passed in, and this resolver is only valid for Beamable content.
-		   var isBeamableAddr = msg.RequestUri.Host.EndsWith(".beamable.com");
+		   var isBeamableAddr = msg.RequestUri.Host.EndsWith(_suffixFilter);
 		   return isBeamableAddr;
 	   }
 

--- a/microservice/microserviceTests/microservice/Content/SSLResolverTests.cs
+++ b/microservice/microserviceTests/microservice/Content/SSLResolverTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Net.Http;
+using Beamable.Server;
+using NUnit.Framework;
+
+namespace microserviceTests.microservice.Content;
+
+public class SSLResolverTests
+{
+    // our dev environment has this annoying setup :( 
+    [TestCase(true, "dev.api.beamable.com", "dev-content.beamable.com")]
+    [TestCase(false, "dev.api.beamable.com", "somewhere.else.com")]
+
+    [TestCase(true, null, "content.beamable.com")]
+    [TestCase(false, null, "somewhere.else.com")]
+    
+    [TestCase(true, "localhost", "content.beamable.com")]
+    [TestCase(false, "localhost", "somewhere.else.com")]
+
+    [TestCase(true, "api.beamable.com", "content.beamable.com")]
+    [TestCase(false, "api.beamable.com", "somewhere.else.com")]
+
+    [TestCase(true, "custom.domain.land", "content.domain.land")]
+    [TestCase(false, "custom.domain.land", "somewhere.else.com")]
+    
+    [TestCase(true, "prod-api.studiogames.services", "prod-content.studiogames.services")]
+    [TestCase(false, "prod-api.studiogames.services", "somewhere.else.com")]
+
+    [TestCase(true, "prod-api.studiogames.services", "prod.content.studiogames.services")]
+    [TestCase(false, "prod-api.studiogames.services", "somewhere.else.com")]
+    public void NoSslForHost(bool expected, string host, string request)
+    {
+        var resolver = new DefaultContentResolver(new TestArgs
+        {
+            Host = host
+        });
+        var result = resolver.ServerCertificateCustomValidationCallback(new HttpRequestMessage
+        {
+            RequestUri = new Uri("https://" + request)
+        }, null, null, default);
+        
+        Assert.That(expected, Is.EqualTo(result), $"{request} should {(expected ? "not" : "")} care about SSL against host=[{host}]");
+    }
+}


### PR DESCRIPTION
In a private cloud setup, the hardcoded "*.beamable.com" was not correctly applying the ssl precheck to the private cloud's actual. 

I made sure these tests reflect our prod and dev environments. 