### PR TITLE
Fix issue which SearchBar wasn't being rendered when Window doesn't have enough width [3893]

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Beam Services and CLI Debugger Search Bars weren't being rendered when there isn't enough space. Now when there is no space a button will show notifying the user to resize the window.
+
 ## [2.1.3] - 2025-03-06
 ### Changed
 - Upgrade CLI to 4.1.2

--- a/client/Packages/com.beamable/Editor/BeamCli/UI/LogUtil/LogViewUtil.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/UI/LogUtil/LogViewUtil.cs
@@ -1,6 +1,7 @@
 using Beamable.Common.BeamCli.Contracts;
 using Beamable.Editor.ThirdParty.Splitter;
 using Beamable.Editor.UI;
+using Beamable.Editor.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -353,7 +354,7 @@ namespace Beamable.Editor.BeamCli.UI.LogHelpers
 					});
 				}
 
-				EditorGUILayout.Space(1, true);
+				EditorGUILayout.Space(1, false);
 
 				{ // search text field
 					EditorGUI.BeginChangeCheck();
@@ -362,7 +363,7 @@ namespace Beamable.Editor.BeamCli.UI.LogHelpers
 					var searchRect = GUILayoutUtility.GetRect(GUIContent.none, searchStyle);
 					
 					// if there isn't enough space, don't bother rendering it.
-					if (searchRect.width > 70)
+					if (searchRect.width > 30)
 					{
 						var searchClearRect = new Rect(searchRect.xMax - searchRect.height - 2, searchRect.y,
 						                               searchRect.height, searchRect.height);
@@ -393,6 +394,15 @@ namespace Beamable.Editor.BeamCli.UI.LogHelpers
 									window.Repaint();
 								});
 							}
+						}
+					}
+					else
+					{
+						var noSearchBarSpaceButton = GUILayout.Button("\u2026", new GUIStyle(EditorStyles.toolbarButton), GUILayout.MinWidth(35),  GUILayout.ExpandWidth(false));
+						if (noSearchBarSpaceButton)
+						{ 
+							Vector2 windowSize = new Vector2(Screen.width, 70);
+							PopupWindow.Show(searchRect, new GenericMessagePopup("Hidden Contents", "There is no available space to display the search bar, please resize the window.", windowSize));
 						}
 					}
 				}

--- a/client/Packages/com.beamable/Editor/Utility/GenericMessagePopup.cs
+++ b/client/Packages/com.beamable/Editor/Utility/GenericMessagePopup.cs
@@ -1,0 +1,34 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace Beamable.Editor.Utility
+{
+	public class GenericMessagePopup : PopupWindowContent
+	{
+		private readonly string _text;
+		private readonly string _title;
+		private readonly Vector2 _windowSize;
+		private Vector2 _scrollPosition;
+
+		public GenericMessagePopup(string title, string text, Vector2 windowSize)
+		{
+			_text = text;
+			_title = title;
+			_windowSize = windowSize;
+		}
+
+		public override Vector2 GetWindowSize()
+		{
+			return _windowSize;
+		}
+
+		public override void OnGUI(Rect rect)
+		{
+			_scrollPosition = GUILayout.BeginScrollView(_scrollPosition);
+			GUILayout.Label(_title, EditorStyles.boldLabel);
+			GUILayout.Space(5);
+			GUILayout.TextArea(_text);
+			GUILayout.EndScrollView();
+		}
+	}
+}

--- a/client/Packages/com.beamable/Editor/Utility/GenericMessagePopup.cs.meta
+++ b/client/Packages/com.beamable/Editor/Utility/GenericMessagePopup.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9d7691faab4600342bfcc449e60c1867
+timeCreated: 1724261331


### PR DESCRIPTION
# Ticket

https://github.com/beamable/BeamableProduct/issues/3893

# Brief Description

> It fixes the issue of there beingn't enough space for SearchBar to render.
> Adds a button when there isn't enough space for the SearchBar to notify the user to resize the window.


https://github.com/user-attachments/assets/81a99fca-e00b-4148-9a19-3fdb027ab7f0


# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:
