### PR TITLE
Open portal on user realm

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Open portal on user realm, don't force the editor one.
 
 ## [2.1.3] - 2025-03-10
 

--- a/client/Packages/com.beamable/Editor/Modules/Account/PortalCommand.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Account/PortalCommand.cs
@@ -1,6 +1,5 @@
 ﻿using Beamable.Common;
 using Beamable.ConsoleCommands;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace Beamable.Editor.Modules.Account
@@ -20,16 +19,19 @@ namespace Beamable.Editor.Modules.Account
 		{
 			_ctx.OnReady.Then(_ =>
 			{
-				var DBID = _ctx.PlayerId;
-				Debug.Log($"Current user: {DBID}");
-				GetPortalUrl(DBID).Then(Application.OpenURL);
+				var playerId = _ctx.PlayerId;
+				Debug.Log($"Current user: {playerId}");
+				Application.OpenURL(GetPortalUrl());
 			});
 			return "Opening portal..";
 		}
-		private Promise<string> GetPortalUrl(long DBID)
+
+		private string GetPortalUrl()
 		{
 			var api = BeamEditorContext.Default;
-			return Promise<string>.Successful($"{BeamableEnvironment.PortalUrl}/{api.CurrentCustomer.Alias}/games/{api.ProductionRealm.Pid}/realms/{api.CurrentRealm.Pid}/players/{DBID}?refresh_token={api.Requester.Token.RefreshToken}");
+			string url =
+				$"{BeamableEnvironment.PortalUrl}/{_ctx.Cid}/games/{api.ProductionRealm.Pid}/realms/{_ctx.Pid}/players/{_ctx.PlayerId}?refresh_token={api.Requester.Token.RefreshToken}";
+			return url;
 		}
 	}
 }


### PR DESCRIPTION
Open Portal command does not respect the customer realm, so if user context is on different realm than the one selected in editor it still uses the one selected in editor.

Fixes #3936 