### PR TITLE
New ServiceLock to prevent multiples Services that share the same API

### DIFF
--- a/client/Packages/com.beamable/Runtime/Beam.cs
+++ b/client/Packages/com.beamable/Runtime/Beam.cs
@@ -276,6 +276,7 @@ namespace Beamable
 			DependencyBuilder.AddScopedStorage<PlayerLeaderboards, OfflineCacheStorageLayer>();
 			DependencyBuilder.AddScoped<PlayerAccounts>();
 			DependencyBuilder.AddScopedStorage<PlayerInventory, OfflineCacheStorageLayer>();
+			DependencyBuilder.AddSingleton<ServiceLock>();
 			DependencyBuilder.AddScoped<ICloudSavingService, PlayerCloudSaving>();
 			DependencyBuilder.AddSingleton<OfflineCacheStorageLayer>();
 			DependencyBuilder.AddScoped<PlayerCurrencyGroup>(p => p.GetService<PlayerInventory>().Currencies);

--- a/client/Packages/com.beamable/Runtime/Core/Utility.meta
+++ b/client/Packages/com.beamable/Runtime/Core/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b37eed0d46bbafa45b47999f8d413efd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Packages/com.beamable/Runtime/Core/Utility/Beamable.Utility.asmdef
+++ b/client/Packages/com.beamable/Runtime/Core/Utility/Beamable.Utility.asmdef
@@ -6,17 +6,9 @@
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "Facebook.Unity.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [
-        {
-            "name": "com.unity.mobile.notifications",
-            "expression": "[2,3]",
-            "define": "NOTIFICATIONS_PACKAGE"
-        }
-    ],
+    "versionDefines": [],
     "noEngineReferences": false
 }

--- a/client/Packages/com.beamable/Runtime/Core/Utility/Beamable.Utility.asmdef
+++ b/client/Packages/com.beamable/Runtime/Core/Utility/Beamable.Utility.asmdef
@@ -1,20 +1,7 @@
 {
-    "name": "Beamable.Platform",
+    "name": "Beamable.Utility",
     "rootNamespace": "",
-    "references": [
-        "PubNub",
-        "Beamable.Config",
-        "Beamable.Coroutines",
-        "Beamable.JsonSerializable",
-        "Beamable.Pooling",
-        "Beamable.Service",
-        "Beamable.SmallerJSON",
-        "Beamable.ConsoleCommands",
-        "Unity.Beamable.Runtime.Common",
-        "Google.Play.Games",
-        "Unity.Notifications.iOS",
-        "Beamable.Utility"
-    ],
+    "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,

--- a/client/Packages/com.beamable/Runtime/Core/Utility/Beamable.Utility.asmdef.meta
+++ b/client/Packages/com.beamable/Runtime/Core/Utility/Beamable.Utility.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a1c3f5e8b7a49584d8766b0b8244c5a4
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Packages/com.beamable/Runtime/Core/Utility/ServiceLock.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Utility/ServiceLock.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ServiceLock
+{
+	public const string CloudSavingServiceName = "cloud_saving_service";
+	
+	public Dictionary<string, string> _serviceLocker = new();
+	
+	public bool AttemptToLock(string serviceName, string implementationName)
+	{
+		bool isLocked = _serviceLocker.TryGetValue(serviceName, out string implementation);
+		if (!isLocked || implementation == implementationName)
+		{
+			Debug.Log($"Locking {implementationName} as the current CloudSaving service.");
+			_serviceLocker[serviceName] = implementationName;
+			return true;
+		}
+
+		Debug.LogWarning($"Attempting to Use {implementationName} as the CloudSaving service but {implementation} is already being used.");
+		return false;
+	}
+}

--- a/client/Packages/com.beamable/Runtime/Core/Utility/ServiceLock.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Utility/ServiceLock.cs
@@ -12,7 +12,6 @@ public class ServiceLock
 		bool isLocked = _serviceLocker.TryGetValue(serviceName, out string implementation);
 		if (!isLocked || implementation == implementationName)
 		{
-			Debug.Log($"Locking {implementationName} as the current CloudSaving service.");
 			_serviceLocker[serviceName] = implementationName;
 			return true;
 		}

--- a/client/Packages/com.beamable/Runtime/Core/Utility/ServiceLock.cs.meta
+++ b/client/Packages/com.beamable/Runtime/Core/Utility/ServiceLock.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d11ebfbf9c450904b88d36f13b9aacd4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Packages/com.beamable/Runtime/Unity.Beamable.asmdef
+++ b/client/Packages/com.beamable/Runtime/Unity.Beamable.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "Unity.Beamable",
+    "rootNamespace": "",
     "references": [
         "Beamable.Config",
         "Beamable.ConsoleCommands",
@@ -17,14 +18,16 @@
         "VirtualList",
         "Beamable.UnityUIExtensions",
         "Unity.Beamable.Purchasing",
-        "Beamable.Endel.NativeWebsocket"
+        "Beamable.Endel.NativeWebsocket",
+        "Beamable.Utility"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
New ServiceLock class that locks the usage of a service to a specific service implementation. Blocking the other usages to not being initialized.

This PR adds its usage to the CloudSaving feature for `PlayerCloudSaving` and `CloudSavingService`