### PR TITLE
Fix - Multiple federation ids not showing for content editor #3943

### DIFF
--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -5,17 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-### Fixed
-- Issue that caused multiple federations ids to not show for content editor inspector.
-
-## [2.2.0] - 2025-04-03
+## [2.2.0] - 2025-04-04
 ### Changed
 - Opening Microservice solution will create a `.slnf` file and only show projects which are not readonly
 
 ### Fixed
 - _Beam Services_ window's service selector dropdown has correct height on Windows
 - `Lightbeam.Lootbox.SharedCode` doesn't through rouge assembly not found errors anymore. [3944](https://github.com/beamable/BeamableProduct/issues/3944)
+- Issue that caused multiple federations ids to not show for content editor inspector.
 
 ## [2.1.4] - 2025-03-26
 

--- a/client/Packages/com.beamable.server/CHANGELOG.md
+++ b/client/Packages/com.beamable.server/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Issue that caused multiple federations ids to not show for content editor inspector.
+
 ## [2.2.0] - 2025-04-03
 ### Changed
 - Opening Microservice solution will create a `.slnf` file and only show projects which are not readonly

--- a/client/Packages/com.beamable.server/Editor/ThirdParty/FederationPropertyDrawer.cs
+++ b/client/Packages/com.beamable.server/Editor/ThirdParty/FederationPropertyDrawer.cs
@@ -30,10 +30,9 @@ namespace Beamable.Server.Editor
 		{
 			var usamService = BeamEditorContext.Default.ServiceScope.GetService<UsamService>();
 
-			if (_filteredServiceEntries == null)
-			{
-				_filteredServiceEntries = usamService.latestManifest.services.FindAll(s => s.federations.Count > 0).ToList();
-			}
+			
+			_filteredServiceEntries = usamService.latestManifest.services.FindAll(s => s.federations.Count > 0).ToList();
+			
 
 			if (_filteredServiceEntries.Count == 0)
 			{
@@ -106,7 +105,6 @@ namespace Beamable.Server.Editor
 					if(_allowedInterfaces.Contains(federation.interfaceName))
 					{
 						_options.Add(new FederationOption { Microservice = descriptor.beamoId, Namespace = federation.federationId });
-						break;
 					}
 				}
 			}


### PR DESCRIPTION
# Ticket

[3943](https://github.com/beamable/BeamableProduct/issues/3943)

# Brief Description

FederationPropertyDrawer wasn't adding more than one federation implementation for the same Service. Also, it was caching the _filteredServiceEntries, so if the user changed a federation it would not properly apply the changes.