### PR TITLE
Fix - CID/PID Mismatch UI is too big for Unity popup [3933]

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+##[Unreleased]
+### Fixed
+- CID/PID Mismatch error message was too big for Unity popup. Now it uses a Beamable Custom Editor Window. [3933](https://github.com/beamable/BeamableProduct/issues/3933)
+
 ## [2.2.0] - 2025-04-04
 ### Added
 - New Implementation for CloudSavingAPI using `ICloudSavingService` as Player SDK. Accessible by `BeamContext.CloudSaving`.

--- a/client/Packages/com.beamable/Editor/BuildPreProcessor.cs
+++ b/client/Packages/com.beamable/Editor/BuildPreProcessor.cs
@@ -2,6 +2,7 @@ using Beamable.Common;
 using Beamable.Config;
 using Beamable.Content;
 using Beamable.Editor.Content;
+using Beamable.Editor.UI.OptionDialogWindow;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -62,13 +63,36 @@ namespace Beamable.Editor
 				Debug.LogWarning("Beamable wasn't able to detect if there was unpublished content, because the Beamable SDK wasn't initialized yet.");
 			}
 #endif
-
 			if (messages.Count > 0)
 			{
-				// EditorUtility.Dis
-				var title = messages.Count == 1 ? "Beamable Warning" : $"{messages.Count} Beamable Warnings";
+				string title = messages.Count == 1 ? "Beamable Warning" : $"{messages.Count} Beamable Warnings";
+				string joinMessage = string.Join("\n\n", messages);
+				var continueBuildButton = new OptionDialogWindow.ButtonInfo()
+				{
+					Name = "Continue Build",
+					OnClick = () => true,
+					Color = new Color(0.08f, 0.44f, 0.82f)
+				};
+				var cancelBuildButton = new OptionDialogWindow.ButtonInfo()
+				{
+					Name = "Abort Build",
+					OnClick = () => false,
+					Color = Color.gray,
+				};
+				var applyAndContinueButton = new OptionDialogWindow.ButtonInfo()
+				{
+					Name = "Apply Fix and Continue",
+					OnClick = () =>
+					{
+						BeamEditorContext.Default.WriteConfig();
+						return true;
+					},
+					Color = new Color(0.29f, 1f, 0.31f),
+				};
+				// if (!OptionDialogWindow.ShowModal(title, joinMessage, continueBuildButton, cancelBuildButton,
+				//                                   applyAndContinueButton))
 				if (!EditorUtility.DisplayDialog(title, string.Join("\n\n", messages), "Continue Build",
-												 "Abort Build"))
+				                                 "Abort Build"))
 				{
 					throw new BuildFailedException("Aborted build due to Beamable checks");
 				}
@@ -141,12 +165,12 @@ popup, click the 'Save Config-Defaults' button.";
 			if (!cidsMatch || !pidsMatch)
 			{
 				warningMessage = $@"BEAMABLE WARNING: CID/PID Mismatch Detected!
-The editor environment is using a cid=[{editorCid}] and pid=[{editorPid}]. These values are assigned in Toolbox.
-However, the built target will use a cid=[{runtimeCid}] and pid=[{runtimePid}]. These values are assigned in the config-defaults.txt file.
+The editor environment is using a <b>cid=[{editorCid}]</b> and <b>pid=[{editorPid}]</b>. These values are assigned in Toolbox.
+However, the built target will use a <b>cid=[{runtimeCid}]</b> and <b>pid=[{runtimePid}]</b>. These values are assigned in the config-defaults.txt file.
 These values do not match. This means that you are building the game
 for a different Beamable environment than the editor is currently using. Be careful! 
 In the Beamable Toolbox, click on the account icon, and then in the account summary
-popup, click the 'Save Config-Defaults' button.";
+popup, click the <b>'Save Config-Defaults' button.</b>";
 				Debug.LogWarning(warningMessage);
 				return false;
 			}

--- a/client/Packages/com.beamable/Editor/BuildPreProcessor.cs
+++ b/client/Packages/com.beamable/Editor/BuildPreProcessor.cs
@@ -134,22 +134,20 @@ namespace Beamable.Editor
 
 			if (string.IsNullOrEmpty(runtimeCid))
 			{
-				var error = $@"BEAMABLE ERROR: No CID was detected!
+				var error = $@"BEAMABLE ERROR: No <b>CID</b> was detected!
 Without a CID, the Beamable SDK will not be able to connect to any Beamable Cloud. 
 Please make sure you have a config-defaults.txt file in Assets/Beamable/Resources. 
-In the Beamable Toolbox, click on the account icon, and then in the account summary
-popup, click the 'Save Config-Defaults' button.";
+In the Unity Editor window in top-right corner, click on the Beamable Menu, then go to the Select Realm submenu and click the <b>Save to config-defaults</b> option.";
 				Debug.LogError(error);
 				throw new BuildFailedException(error);
 			}
 
 			if (string.IsNullOrEmpty(runtimePid))
 			{
-				var error = $@"BEAMABLE ERROR: No PID was detected!
+				var error = $@"BEAMABLE ERROR: No <b>PID</b> was detected!
 Without a PID, the Beamable SDK will not be able to connect to any Beamable Cloud. 
 Please make sure you have a config-defaults.txt file in Assets/Beamable/Resources. 
-In the Beamable Toolbox, click on the account icon, and then in the account summary
-popup, click the 'Save Config-Defaults' button.";
+In the Unity Editor window in top-right corner, click on the Beamable Menu, then go to the Select Realm submenu and click the <b>Save to config-defaults</b> option.";
 				Debug.LogError(error);
 				throw new BuildFailedException(error);
 			}
@@ -163,12 +161,11 @@ popup, click the 'Save Config-Defaults' button.";
 			if (!cidsMatch || !pidsMatch)
 			{
 				warningMessage = $@"BEAMABLE WARNING: CID/PID Mismatch Detected!
-The editor environment is using a <b>cid=[{editorCid}]</b> and <b>pid=[{editorPid}]</b>. These values are assigned in Toolbox.
-However, the built target will use a <b>cid=[{runtimeCid}]</b> and <b>pid=[{runtimePid}]</b>. These values are assigned in the config-defaults.txt file.
+The editor environment is using a <b>cid=[{{editorCid}}]</b> and <b>pid=[{{editorPid}}]</b>. These values are accessible from Beamable Menu (top-right corner) in the Select Realm section.
+However, the built target will use a <b>cid=[{{runtimeCid}}]</b> and <b>pid=[{{runtimePid}}]</b>. These values are assigned in the config-defaults.txt file.
 These values do not match. This means that you are building the game
 for a different Beamable environment than the editor is currently using. Be careful! 
-In the Beamable Toolbox, click on the account icon, and then in the account summary
-popup, click the <b>'Save Config-Defaults' button.</b>";
+In the Unity Editor window in top-right corner, click on the Beamable Menu, then go to the Select Realm submenu and click the <b>Save to config-defaults</b> option.";
 				Debug.LogWarning(warningMessage);
 				return false;
 			}

--- a/client/Packages/com.beamable/Editor/BuildPreProcessor.cs
+++ b/client/Packages/com.beamable/Editor/BuildPreProcessor.cs
@@ -81,7 +81,7 @@ namespace Beamable.Editor
 				};
 				var applyAndContinueButton = new OptionDialogWindow.ButtonInfo()
 				{
-					Name = "Apply Fix and Continue",
+					Name = "Apply Editor Values and Continue",
 					OnClick = () =>
 					{
 						BeamEditorContext.Default.WriteConfig();
@@ -89,10 +89,8 @@ namespace Beamable.Editor
 					},
 					Color = new Color(0.29f, 1f, 0.31f),
 				};
-				// if (!OptionDialogWindow.ShowModal(title, joinMessage, continueBuildButton, cancelBuildButton,
-				//                                   applyAndContinueButton))
-				if (!EditorUtility.DisplayDialog(title, string.Join("\n\n", messages), "Continue Build",
-				                                 "Abort Build"))
+				if (!OptionDialogWindow.ShowModal(title, joinMessage, continueBuildButton, cancelBuildButton,
+				                                   applyAndContinueButton))
 				{
 					throw new BuildFailedException("Aborted build due to Beamable checks");
 				}

--- a/client/Packages/com.beamable/Editor/UI/OptionDialogWindow.meta
+++ b/client/Packages/com.beamable/Editor/UI/OptionDialogWindow.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ae163822233b27743a1c07d40d32ab0f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Packages/com.beamable/Editor/UI/OptionDialogWindow/OptionDialogWindow.cs
+++ b/client/Packages/com.beamable/Editor/UI/OptionDialogWindow/OptionDialogWindow.cs
@@ -1,0 +1,90 @@
+using Beamable.Editor.Util;
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace Beamable.Editor.UI.OptionDialogWindow
+{
+	public class OptionDialogWindow : EditorWindow
+	{
+		private string _message;
+		private ButtonInfo[] _buttons;
+		
+		Vector2 _textScrollPosition;
+		Vector2 _buttonsScrollPosition;
+
+		private Action<bool> _onClose;
+		
+		public static bool ShowModal(string title,
+		                                   string message,
+		                                   params ButtonInfo[] buttons)
+		{
+			bool modalResult = false;
+			
+			var window = CreateInstance<OptionDialogWindow>();
+			window._message = message;
+			window._buttons = buttons;
+			window._onClose = onCloseResult => modalResult = onCloseResult;
+			window.titleContent = new GUIContent(title);
+			window.position = new Rect(Screen.width / 2f, Screen.height / 2f, 600, 400);
+			window.ShowModalUtility();
+			return modalResult;
+		}
+
+		private void OnGUI()
+		{
+			DrawMessage();
+			DrawButtons();
+		}
+
+		private void DrawMessage()
+		{
+			_textScrollPosition = EditorGUILayout.BeginScrollView(_textScrollPosition);
+			var textStyle = new GUIStyle(EditorStyles.wordWrappedLabel)
+			{
+				richText = true,
+				fontSize = 12,
+				alignment = TextAnchor.UpperLeft,
+				padding = new RectOffset(10, 10, 10, 10),
+			};
+			EditorGUILayout.LabelField(_message, textStyle);
+			EditorGUILayout.EndScrollView();
+			GUILayout.FlexibleSpace();
+		}
+		
+		private void DrawButtons()
+		{
+			_buttonsScrollPosition = EditorGUILayout.BeginScrollView(_buttonsScrollPosition, false,false, GUILayout.Height(50));
+			GUILayout.FlexibleSpace();
+			EditorGUILayout.BeginHorizontal();
+			GUILayout.FlexibleSpace();
+			
+			foreach (var btnInfo in _buttons)
+			{
+				float buttonSize = GUI.skin.button.CalcSize(new GUIContent(btnInfo.Name)).x + 30f;
+
+				GUIStyle buttonStyle = BeamGUI.ColorizeButton(btnInfo.Color, 0.3f);
+				
+				if (GUILayout.Button(btnInfo.Name, buttonStyle,GUILayout.Width(buttonSize), GUILayout.Height(40)))
+				{
+					bool res = btnInfo.OnClick == null || btnInfo.OnClick.Invoke();
+					_onClose(res);
+					Close();
+				}
+			}
+			GUILayout.FlexibleSpace();
+			EditorGUILayout.EndHorizontal();
+			GUILayout.FlexibleSpace();
+			EditorGUILayout.EndScrollView();
+			GUILayout.Space(10);
+			
+		}
+
+		public class ButtonInfo
+		{
+			public string Name;
+			public Func<bool> OnClick;
+			public Color Color = Color.white;
+		}
+	}
+}

--- a/client/Packages/com.beamable/Editor/UI/OptionDialogWindow/OptionDialogWindow.cs.meta
+++ b/client/Packages/com.beamable/Editor/UI/OptionDialogWindow/OptionDialogWindow.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ec8e5f1dd1379884eb7791f488c95d28
+timeCreated: 1657194994


### PR DESCRIPTION
# Ticket

[3933](https://github.com/beamable/BeamableProduct/issues/3933)

# Brief Description

Adds a new OptionDialogWindow to handle modal option selection for any Editor Code.

Fixes the BuildPreProcessor Build Warning Message by using `OptionDialogWindow` instead of the `EditorUtility.DisplayDialog`.