### PR TITLE
Fix: Application Closing during saving process could possibly corrupt save file

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - CID/PID Mismatch error message was too big for Unity popup. Now it uses a Beamable Custom Editor Window. [3933](https://github.com/beamable/BeamableProduct/issues/3933)
 - Improved error detection for attaching identity providers in `PlayerAccounts`.
+- Fixed issue that CloudSaving could generate corrupted save files if the application was closed during saving process.
 
 ## [2.2.0] - 2025-04-04
 ### Added

--- a/client/Packages/com.beamable/Runtime/Player/CloudSaving/Data/CloudSavingManifest.cs
+++ b/client/Packages/com.beamable/Runtime/Player/CloudSaving/Data/CloudSavingManifest.cs
@@ -7,5 +7,6 @@ namespace Beamable.Player.CloudSaving
 	public class CloudSavingManifest
 	{
 		public List<CloudSaveEntry> manifest = new();
+		public List<SavingFileEntry> savingFiles = new();
 	}
 }

--- a/client/Packages/com.beamable/Runtime/Player/CloudSaving/Data/SavingFileEntry.cs
+++ b/client/Packages/com.beamable/Runtime/Player/CloudSaving/Data/SavingFileEntry.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Beamable.Player.CloudSaving
+{
+	[Serializable]
+	public class SavingFileEntry
+	{
+		public string FileName;
+		public string ExpectedChecksum;
+	}
+}

--- a/client/Packages/com.beamable/Runtime/Player/CloudSaving/Data/SavingFileEntry.cs.meta
+++ b/client/Packages/com.beamable/Runtime/Player/CloudSaving/Data/SavingFileEntry.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: df90baae749d4758b1f3f9d536e2161d
+timeCreated: 1745506387


### PR DESCRIPTION
 This PR fixes a possible issue that can occur during the saving process. This has a higher chance of happening with larger files, as it can take more time to write them.

To fix this, the service does not overwrite the file during the write process anymore. Now the service will temporarily save the file and only move it to the final destination after the file has been completely written to disk. Also, if the application was closed before the move process, during initialization, the service will check if any saved files weren't moved to the final destination in the local manifest. Then it'll try to move the files if the file checksum matches the expected value.
