### PR TITLE
Minor Content Window improvements

### DIFF
--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ContentListVisualElement/ContentListVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ContentListVisualElement/ContentListVisualElement.cs
@@ -35,11 +35,6 @@ namespace Beamable.Editor.Content.Components
 		/// </summary>
 		private int ListViewItemHeight = 24;
 
-		/// <summary>
-		/// Indicates index when nothing is selected in the <see cref="ListView"/>
-		/// </summary>
-		private const int NullIndex = -1;
-
 		public ContentDataModel Model { get; set; }
 
 		private VisualElement _mainVisualElement;

--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ContentListVisualElement/ContentListVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ContentListVisualElement/ContentListVisualElement.cs
@@ -74,11 +74,10 @@ namespace Beamable.Editor.Content.Components
 
 			EditorApplication.delayCall += () => { _headerVisualElement.EmitFlexValues(); };
 
-			//List
 			_listView = CreateListView();
 			_mainVisualElement.Add(_listView);
 
-			Model.OnSelectedContentChanged += list => UpdateListViewSelection(list.ToArray());
+			Model.OnSelectedContentChanged += UpdateListViewSelection;
 			Model.OnFilteredContentsChanged += Model_OnFilteredContentChanged;
 			Model.OnContentDeleted += Model_OnContentDeleted;
 			Model.OnManifestChanged += ManifestChanged;
@@ -266,9 +265,9 @@ namespace Beamable.Editor.Content.Components
 			EditorGUIUtility.PingObject(unityObject.GetInstanceID());
 		}
 
-		private void UpdateListViewSelection(params ContentItemDescriptor[] contentItemDescriptors)
+		private void UpdateListViewSelection(IList<ContentItemDescriptor> contentItemDescriptors)
 		{
-			if (contentItemDescriptors == null || contentItemDescriptors.Length == 0)
+			if (contentItemDescriptors == null || contentItemDescriptors.Count == 0)
 			{
 				_listView.ClearSelection();
 			}
@@ -285,7 +284,10 @@ namespace Beamable.Editor.Content.Components
 
 		private void ContentVisualElement_OnRightMouseButtonClicked(ContentItemDescriptor contentItemDescriptor)
 		{
-			UpdateListViewSelection(contentItemDescriptor);
+			if(!Model.SelectedContents.Contains(contentItemDescriptor))
+			{
+				UpdateListViewSelection(new[] {contentItemDescriptor});
+			}
 		}
 
 		private void AddCreateItemMenu(ContextualMenuPopulateEvent evt)

--- a/client/Packages/com.beamable/Editor/UI/Content/Components/ContentListVisualElement/ContentListVisualElement.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Components/ContentListVisualElement/ContentListVisualElement.cs
@@ -38,7 +38,7 @@ namespace Beamable.Editor.Content.Components
 		/// <summary>
 		/// Indicates index when nothing is selected in the <see cref="ListView"/>
 		/// </summary>
-		private int NullIndex = -1;
+		private const int NullIndex = -1;
 
 		public ContentDataModel Model { get; set; }
 
@@ -78,7 +78,7 @@ namespace Beamable.Editor.Content.Components
 			_listView = CreateListView();
 			_mainVisualElement.Add(_listView);
 
-			Model.OnSelectedContentChanged += Model_OnSelectedContentChanged;
+			Model.OnSelectedContentChanged += list => UpdateListViewSelection(list.ToArray());
 			Model.OnFilteredContentsChanged += Model_OnFilteredContentChanged;
 			Model.OnContentDeleted += Model_OnContentDeleted;
 			Model.OnManifestChanged += ManifestChanged;
@@ -219,7 +219,7 @@ namespace Beamable.Editor.Content.Components
 			//a click on an item does NOT call this handler - srivello
 			if (target.name.Contains("ContentViewport"))
 			{
-				SetSelectedIndexSafe(NullIndex);
+				SelectItemInInspectorWindow();
 			}
 		}
 
@@ -266,46 +266,15 @@ namespace Beamable.Editor.Content.Components
 			EditorGUIUtility.PingObject(unityObject.GetInstanceID());
 		}
 
-		/// <summary>
-		/// Set the selected <see cref="ListView"/> item like this.
-		/// This prevents an infinite UI loop.
-		/// </summary>
-		/// <param name="index"></param>
-		private void SetSelectedIndexSafe(int index)
+		private void UpdateListViewSelection(params ContentItemDescriptor[] contentItemDescriptors)
 		{
-			if (_listView.selectedIndex != index && index >= 0 && index < _listView.itemsSource.Count)
+			if (contentItemDescriptors == null || contentItemDescriptors.Length == 0)
 			{
-				_listView.selectedIndex = index;
-			}
-		}
-
-		/// <summary>
-		/// Lookup the <see cref="ContentVisualElement"/> by the <see cref="ContentItemDescriptor"/>
-		/// </summary>
-		/// <param name="contentItemDescriptor"></param>
-		/// <returns></returns>
-		private ContentVisualElement GetVisualItemByData(ContentItemDescriptor contentItemDescriptor)
-		{
-			List<VisualElement> visualElements = _listView.Children().ToList();
-
-			return (ContentVisualElement)visualElements.Find((VisualElement visualElement) =>
-			{
-				ContentVisualElement nextContentVisualElement = (ContentVisualElement)visualElement;
-				return string.Equals(nextContentVisualElement.ContentItemDescriptor?.Id, contentItemDescriptor?.Id);
-			});
-		}
-
-		private void Model_OnSelectedContentChanged(IList<ContentItemDescriptor> contentItemDescriptors)
-		{
-			var x = contentItemDescriptors.FirstOrDefault<ContentItemDescriptor>();
-
-			if (x == null)
-			{
-				SetSelectedIndexSafe(NullIndex);
+				_listView.ClearSelection();
 			}
 			else
 			{
-				SetSelectedIndexSafe(_listView.itemsSource.IndexOf(x));
+				_listView.SetSelection(contentItemDescriptors.Select(_listView.itemsSource.IndexOf));
 			}
 		}
 
@@ -316,12 +285,7 @@ namespace Beamable.Editor.Content.Components
 
 		private void ContentVisualElement_OnRightMouseButtonClicked(ContentItemDescriptor contentItemDescriptor)
 		{
-			// Update selection to match the right clicked item
-			if (!(Model.SelectedContents?.Contains(contentItemDescriptor) ?? false))
-			{
-				var index = _listView.itemsSource.IndexOf(contentItemDescriptor);
-				SetSelectedIndexSafe(index);
-			}
+			UpdateListViewSelection(contentItemDescriptor);
 		}
 
 		private void AddCreateItemMenu(ContextualMenuPopulateEvent evt)

--- a/client/Packages/com.beamable/Editor/UI/Content/Models/ContentDataModel.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Models/ContentDataModel.cs
@@ -410,11 +410,7 @@ namespace Beamable.Editor.Content.Models
 
 				OnSelectedContentTypesChanged?.Invoke(_selectedContentTypes);
 
-				//  ******************************************************
-				//  NOTE: Every time the SelectedContentTypes is SET,
-				//        the SelectedContents is CLEARED
-				//  ******************************************************
-				ClearSelectedContents();
+				SelectedContents = SelectedContents.Where(_filteredContent.Contains).ToList();
 			}
 			get
 			{

--- a/client/Packages/com.beamable/Editor/UI/Content/Models/ContentDataModel.cs
+++ b/client/Packages/com.beamable/Editor/UI/Content/Models/ContentDataModel.cs
@@ -243,12 +243,23 @@ namespace Beamable.Editor.Content.Models
 
 		}
 
-		private IList<ContentItemDescriptor> _selectedContent;
+		private IList<ContentItemDescriptor> _selectedContent = new List<ContentItemDescriptor>();
 		public IList<ContentItemDescriptor> SelectedContents
 		{
 			set
 			{
-				_selectedContent = value;
+				if (value == null || _selectedContent == null)
+				{
+					_selectedContent = new List<ContentItemDescriptor>();
+				}
+				else if (_selectedContent.SequenceEqual(value))
+				{
+					return;
+				}
+				else
+				{
+					_selectedContent = value;
+				}
 
 				if (IsDebugging)
 				{
@@ -262,12 +273,7 @@ namespace Beamable.Editor.Content.Models
 
 				OnSelectedContentChanged?.Invoke(_selectedContent);
 			}
-			get
-			{
-				_selectedContent = _selectedContent ?? new List<ContentItemDescriptor>();
-
-				return _selectedContent;
-			}
+			get => _selectedContent;
 		}
 
 		public void ClearSelectedContents()
@@ -295,7 +301,6 @@ namespace Beamable.Editor.Content.Models
 			}
 		}
 
-		private List<ContentItemDescriptor> _filteredContents = new List<ContentItemDescriptor>();
 		public List<ContentItemDescriptor> FilteredContents => _filteredContent;
 
 		public void RefreshFilteredContents()


### PR DESCRIPTION
I know that there is a upcoming redesign, but before that happens I wanted to fix some pain points with selecting content in current window.

It was especially annoying when you had one item selected, then you switched content group to other where is only one content, new content is selected in the list, but in inspector you still have old content and in order to switch to new content you need to go to `Show all` and then select new content again. Now this issue is gone. As bonus, it tries to preserve selected content on filter change, but only for content that matches new filter.

https://github.com/user-attachments/assets/4371deb8-685d-4ae5-b7cc-1a30a6c12a3d

