### PR TITLE
fixes #4019 - ignore beamo Ids

### DIFF
--- a/cli/cli/App.cs
+++ b/cli/cli/App.cs
@@ -253,6 +253,7 @@ public class App
 		Commands.AddSingleton<SkipStandaloneValidationOption>();
 		Commands.AddSingleton(PreferRemoteFederationOption.Instance);
 		Commands.AddSingleton(CidOption.Instance);
+		Commands.AddSingleton(IgnoreBeamoIdsOption.Instance);
 		Commands.AddSingleton<QuietOption>();
 		Commands.AddSingleton(PidOption.Instance);
 		Commands.AddSingleton<ConfigDirOption>();
@@ -284,6 +285,7 @@ public class App
 			root.AddGlobalOption(provider.GetRequiredService<RefreshTokenOption>());
 			root.AddGlobalOption(provider.GetRequiredService<LogOption>());
 			root.AddGlobalOption(provider.GetRequiredService<NoForwardingOption>());
+			root.AddGlobalOption(IgnoreBeamoIdsOption.Instance);
 			root.AddGlobalOption(PreferRemoteFederationOption.Instance);
 			root.AddGlobalOption(AllHelpOption.Instance);;
 			root.AddGlobalOption(UnmaskLogsOption.Instance);

--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.0] - 2025-05-05
+### Added
+- `.beamignore` files may be used to ignore services and storages from the `beam deploy` commands. 
+- Hidden `--ignore-beam-ids` option can be used to ignore beam ids similar in addition to `.beamignore` files. [#4019](https://github.com/beamable/BeamableProduct/issues/4019)
+
+### Fixed
+- `beam deploy` commands no longer attempt to build non-existent source when `--merge` flag is used.
+
 ## [4.2.0] - 2025-04-04
 ### Changed
 - `beam deploy` commands use solution level building instead of per-project [#3952](https://github.com/beamable/BeamableProduct/issues/3952)

--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.0] - 2025-05-05
+## [4.3.0] - 2025-05-07
 ### Added
 - `.beamignore` files may be used to ignore services and storages from the `beam deploy` commands. 
 - Hidden `--ignore-beam-ids` option can be used to ignore beam ids similar in addition to `.beamignore` files. [#4019](https://github.com/beamable/BeamableProduct/issues/4019)

--- a/cli/cli/Commands/Services/ServicesBuildCommand.cs
+++ b/cli/cli/Commands/Services/ServicesBuildCommand.cs
@@ -206,12 +206,6 @@ public class ServicesBuildCommand : AppCommand<ServicesBuildCommandArgs>
 		}
 	}
 
-	public static async Task BuildAllLocalSource()
-	{
-		// create a temp solution file... 
-		
-	}
-
 	public static async Task<BuildImageSourceOutput> BuildLocalSource(
 		IDependencyProvider provider, 
 		string id, 

--- a/cli/cli/Commands/Services/ServicesGenerateLocalManifestCommand.cs
+++ b/cli/cli/Commands/Services/ServicesGenerateLocalManifestCommand.cs
@@ -28,7 +28,7 @@ public class ServicesGenerateLocalManifestCommand : AtomicCommand<ServicesGenera
 
 	public override async Task<ServicesGenerateLocalManifestCommandOutput> GetResult(ServicesGenerateLocalManifestCommandArgs args)
 	{
-		var manifest = await ProjectContextUtil.GenerateLocalManifest( args.AppContext.DotnetPath,  args.BeamoService, args.ConfigService);
+		var manifest = await ProjectContextUtil.GenerateLocalManifest( args.AppContext.DotnetPath,  args.BeamoService, args.ConfigService, args.AppContext.IgnoreBeamoIds);
 		return new ServicesGenerateLocalManifestCommandOutput
 		{
 			manifest = manifest

--- a/cli/cli/Options/IgnoreBeamoIdsOption.cs
+++ b/cli/cli/Options/IgnoreBeamoIdsOption.cs
@@ -1,0 +1,21 @@
+using System.CommandLine;
+
+namespace cli.Options;
+
+public class IgnoreBeamoIdsOption : Option<List<string>>
+{
+    public static IgnoreBeamoIdsOption Instance { get; } = new IgnoreBeamoIdsOption();
+    
+    private IgnoreBeamoIdsOption() : base(
+        name: "--ignore-beam-ids", 
+        description: "A set of beam ids that should be excluded from the local " +
+                     "source code scans. When a beam id is ignored, it cannot be " +
+                     "deployed or understood by the CLI. The final set of ignored " +
+                     "beam ids is the summation of this option AND any .beamignore files " +
+                     "found in the .beamable folder")
+    {
+        AllowMultipleArgumentsPerToken = true;
+        IsHidden = true;
+        Arity = ArgumentArity.ZeroOrMore;
+    }
+}

--- a/cli/cli/Services/BeamoLocalSystem.cs
+++ b/cli/cli/Services/BeamoLocalSystem.cs
@@ -111,7 +111,7 @@ public partial class BeamoLocalSystem
 		}
 		
 		
-		BeamoManifest = await ProjectContextUtil.GenerateLocalManifest(_ctx.DotnetPath, _beamo, _configService, useCache: useManifestCache, fetchServerManifest);
+		BeamoManifest = await ProjectContextUtil.GenerateLocalManifest(_ctx.DotnetPath, _beamo, _configService, _ctx.IgnoreBeamoIds, useCache: useManifestCache, fetchServerManifest);
 	}
 	
 	private static Uri GetLocalDockerEndpoint(ConfigService config)
@@ -485,6 +485,12 @@ public class BeamoLocalManifest
 	/// </summary>
 	public List<BeamoServiceDefinition> ServiceDefinitions;
 
+	/// <summary>
+	/// This list contains the concatenation of all found `.beamignore` files in the workspace.
+	/// Each element is a beamoId. 
+	/// </summary>
+	public HashSet<string> LocallyIgnoredBeamoIds;
+	
 	/// <summary>
 	/// These are map individual <see cref="BeamoServiceDefinition.BeamoId"/>s to their protocol data. Since we don't allow changing protocols we don't ever need to move the services' protocol data between these.
 	/// </summary>

--- a/cli/cli/Services/IAppContext.cs
+++ b/cli/cli/Services/IAppContext.cs
@@ -36,6 +36,7 @@ public interface IAppContext
 	public bool ShowRawOutput { get; }
 	public bool ShowPrettyOutput { get; }
 	public string DotnetPath { get; }
+	public HashSet<string> IgnoreBeamoIds { get; }
 	public string WorkingDirectory { get; }
 	public IAccessToken Token { get; }
 	public string RefreshToken { get; }
@@ -101,6 +102,7 @@ public class DefaultAppContext : IAppContext
 
 	public string DotnetPath { get; private set; }
 	public string DockerPath { get; private set; }
+	public HashSet<string> IgnoreBeamoIds { get; private set; }
 
 
 	/// <inheritdoc cref="IAppContext.ExecutingVersion"/>
@@ -191,6 +193,8 @@ public class DefaultAppContext : IAppContext
 		_skipValidationOption = skipValidationOption;
 		_dotnetPathOption = dotnetPathOption;
 		DockerPath = consoleContext.ParseResult.GetValueForOption(dockerPathOption);
+		IgnoreBeamoIds =
+			new HashSet<string>(consoleContext.ParseResult.GetValueForOption(IgnoreBeamoIdsOption.Instance));
 	}
 
 	void SetupOutputStrategy()


### PR DESCRIPTION
You can use the `--ignore-beam-ids` option, or have `.beamignore` files in your codebase to ignore beamoIds from being detected in the local manifest. 

Additionally, the `deploy` commands will ignore these ids when creating the replacement manifest.