### PR TITLE
Add ToString method to OptionalString for easy print debugging.

### DIFF
--- a/cli/beamable.common/Runtime/Content/Optionals.cs
+++ b/cli/beamable.common/Runtime/Content/Optionals.cs
@@ -468,6 +468,11 @@ namespace Beamable.Common.Content
 
 
 		public bool HasNonEmptyValue => HasValue && !string.IsNullOrEmpty(Value);
+
+		public new string ToString()
+		{
+			return HasNonEmptyValue ? $"OptionalString[{Value}]" : "OptionalString[None]";
+		}
 	}
 
 	[System.Serializable]

--- a/cli/beamable.common/Runtime/Content/Optionals.cs
+++ b/cli/beamable.common/Runtime/Content/Optionals.cs
@@ -471,7 +471,11 @@ namespace Beamable.Common.Content
 
 		public new string ToString()
 		{
-			return HasNonEmptyValue ? $"OptionalString[{Value}]" : "OptionalString[None]";
+			if (!HasValue)
+			{
+				return "OptionalString[]";
+			}
+			return Value == null ? "OptionalString[null]" : $"OptionalString[\"{Value}\"]";
 		}
 	}
 

--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Revise the categorization of all Blueprint nodes to enhance discoverability.
+- `OptionalString` overrides `.ToString()` for easier print debugging.
 
 ### Fixed
 - Fixed an issue in which running `beam deploy release` when CID was an alias resulted in an error in execution.


### PR DESCRIPTION
# Ticket

No ticket, this is just a small thing that I tripped over during other debugging.

# Brief Description

Adds a type-specific ToString method to `OptionalString` so that it is easy to render optional strings in Debug.Log statements and the like.

# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
