### PR TITLE
Change - Added support to Enum deserialization in Int32 or FString on Unreal code Gen.

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New Code Analyzer and Fixer for Microservice ID non matches the `<BeamId>` csproj property.
 - New Code Analyzer and Fixer for non-readonly static fields on Microservice classes.
 - Added support for generating FDateTime instead of FString in Unreal code generation.
+- Added support for Int32 and FString on Enum deserialization in Unreal code generation.
 - New Microservice Client Code Generator for Unity that used OAPI for the generation.
 
 ### Changed

--- a/cli/cli/Services/UnrealSourceGenerator/Declarations/UnrealEnumDeclaration.cs
+++ b/cli/cli/Services/UnrealSourceGenerator/Declarations/UnrealEnumDeclaration.cs
@@ -71,7 +71,34 @@ public:
 		ensureAlways(false); //  This should be impossible!
 		return ₢{nameof(UnrealTypeName)}₢();
 	}}	
-}};
 
+
+	UFUNCTION(BlueprintPure, meta = (DisplayName=""Serialization Index To ₢{nameof(NamespacedTypeName)}₢"", CompactNodeTitle = ""->""), Category=""Beam|₢{nameof(ServiceName)}₢|Utils|Enums"")
+	static ₢{nameof(UnrealTypeName)}₢ SerializationIndexTo₢{nameof(NamespacedTypeName)}₢(int Value)
+	{{
+		const UEnum* Enum = StaticEnum<₢{nameof(UnrealTypeName)}₢>();
+
+		return static_cast<₢{nameof(UnrealTypeName)}₢>(Enum->GetValueByIndex(Value));
+	}}	
+
+
+	static  ₢{nameof(UnrealTypeName)}₢ SerializationFieldTo₢{nameof(NamespacedTypeName)}₢(TSharedPtr<FJsonValue> Field)
+	{{
+		if (!Field)
+		{{
+			ensureAlways(false); //  This should be impossible!
+			return ₢{nameof(UnrealTypeName)}₢();
+		}}
+		
+		if (Field->Type == EJson::Number)
+		{{
+			return SerializationIndexTo₢{nameof(NamespacedTypeName)}₢(static_cast<int32>(Field->AsNumber()));
+		}}
+		else
+		{{
+			return SerializationNameTo₢{nameof(NamespacedTypeName)}₢(Field->AsString());
+		}}
+	}}
+}};
 ";
 }

--- a/cli/cli/Services/UnrealSourceGenerator/Declarations/UnrealPropertyDeclaration.cs
+++ b/cli/cli/Services/UnrealSourceGenerator/Declarations/UnrealPropertyDeclaration.cs
@@ -88,7 +88,7 @@ public struct UnrealPropertyDeclaration
 		$@"Serializer->WriteValue(TEXT(""₢{nameof(RawFieldName)}₢""), U₢{nameof(PropertyNamespacedType)}₢Library::₢{nameof(PropertyNamespacedType)}₢ToSerializationName(₢{nameof(PropertyName)}₢));";
 
 	public const string U_ENUM_U_PROPERTY_DESERIALIZE =
-		$@"₢{nameof(PropertyName)}₢ = U₢{nameof(PropertyNamespacedType)}₢Library::SerializationNameTo₢{nameof(PropertyNamespacedType)}₢(Bag->GetStringField(TEXT(""₢{nameof(RawFieldName)}₢"")));";
+		$@"₢{nameof(PropertyName)}₢ = U₢{nameof(PropertyNamespacedType)}₢Library::SerializationFieldTo₢{nameof(PropertyNamespacedType)}₢(Bag->TryGetField(TEXT(""₢{nameof(RawFieldName)}₢"")));";
 
 	public const string U_STRUCT_U_PROPERTY_SERIALIZE =
 		$@"UBeamJsonUtils::SerializeUStruct<₢{nameof(PropertyUnrealType)}₢>(""₢{nameof(RawFieldName)}₢"", ₢{nameof(PropertyName)}₢, Serializer);";


### PR DESCRIPTION
# Ticket

https://github.com/beamable/UnrealSDK/issues/113#issue-3086578554

# Brief Description

> The Unreal code gen pipeline used to support only enum deserialization in string format. Now, it supports Int32 or String.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

