### PR TITLE
Improve IAP error handling

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed issue that CloudSaving could generate corrupted save files if the application was closed during saving process.
 - Fixed incorrect `MailMessage` `expires` field parsing.
-- Fixed issue with `WebSocketConnection` not sending updates after reconnection. 
+- Fixed issue with `WebSocketConnection` not sending updates after reconnection.
+- Improve IAP error detection.
 
 ### Change
 - Able to use the new Client Code Generator from CLI that uses OpenAPI instead of the old one that uses Reflection

--- a/client/Packages/com.beamable/Runtime/Modules/Purchasing/UnityBeamablePurchaser.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/Purchasing/UnityBeamablePurchaser.cs
@@ -391,7 +391,15 @@ namespace Beamable.Purchasing
 
 				if (err == null)
 				{
-					return;
+					var platformException = ex as PlatformRequesterException;
+					if (platformException != null)
+					{
+						err = new ErrorCode(platformException.Error);
+					}
+					else
+					{
+						return;
+					}
 				}
 
 				var retryable = err.Code >= 500 || err.Code == 429 || err.Code == 0;   // Server error or rate limiting or network error


### PR DESCRIPTION
When Exception cannot be casted to ErrorCode, try casting to `PlatformRequesterException` first.