### PR TITLE
DummyPurchaser and new TryGetLocalizedPrice method

### DIFF
--- a/client/Packages/com.beamable/Runtime/BeamContext.cs
+++ b/client/Packages/com.beamable/Runtime/BeamContext.cs
@@ -697,6 +697,10 @@ namespace Beamable
 					});
 					ServiceProvider.GetService<Promise<IBeamablePurchaser>>().CompleteSuccess(purchaser);
 				}
+				else
+				{
+					ServiceProvider.GetService<Promise<IBeamablePurchaser>>().CompleteSuccess(new DummyPurchaser());
+				}
 			}
 
 			void SetupEmitEvents()

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Payments/DummyPurchaser.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Payments/DummyPurchaser.cs
@@ -1,0 +1,32 @@
+using Beamable.Common;
+using Beamable.Common.Dependencies;
+
+namespace Beamable.Api.Payments
+{
+	/// <summary>
+	/// Dummy Purchaser that is used when there is no `IBeamablePurchaser` registered in BeamContext Service Provider.
+	/// </summary>
+	public class DummyPurchaser : IBeamablePurchaser
+	{
+		public PurchasingInitializationStatus InitializationStatus { get; } = PurchasingInitializationStatus.ErrorPurchasingUnavailable;
+		public Promise<Unit> Initialize(IDependencyProvider provider = null)
+		{
+			return Promise<Unit>.Successful(new Unit());
+		}
+		public string GetLocalizedPrice(string skuSymbol)
+		{
+			return string.Empty;
+		}
+
+		public bool TryGetLocalizedPrice(string skuSymbol, out string localizedPrice)
+		{
+			localizedPrice = string.Empty;
+			return false;
+		}
+
+		public Promise<CompletedTransaction> StartPurchase(string listingSymbol, string skuSymbol)
+		{
+			return Promise<CompletedTransaction>.Failed(InitializationStatus.StatusToErrorCode());
+		}
+	}
+}

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Payments/DummyPurchaser.cs.meta
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Payments/DummyPurchaser.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b02ee64b99844a1fb8ea0ed42ae06e69
+timeCreated: 1748603263

--- a/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Payments/IBeamablePurchaser.cs
+++ b/client/Packages/com.beamable/Runtime/Core/Platform/SDK/Payments/IBeamablePurchaser.cs
@@ -1,5 +1,6 @@
 using Beamable.Common;
 using Beamable.Common.Dependencies;
+using System;
 
 namespace Beamable.Api.Payments
 {
@@ -30,12 +31,25 @@ namespace Beamable.Api.Payments
 		Promise<Unit> Initialize(IDependencyProvider provider = null);
 
 		/// <summary>
-		/// Fetches the localized string from the provider.
+		/// Get the localized price string for a given SKU.
 		/// <param name="skuSymbol">
 		/// The purchase symbol for the item. This is the skuSymbol for the offer.
 		/// </param>
 		/// </summary>
+		[Obsolete("Use " + nameof(TryGetLocalizedPrice) + " Instead")]
 		string GetLocalizedPrice(string skuSymbol);
+
+		/// <summary>
+		/// Tries to get the localized price string for a given SKU.
+		/// <param name="skuSymbol">
+		/// The purchase symbol for the item. This is the skuSymbol for the offer.
+		/// </param>
+		/// <param name="localizedPrice">
+		/// Localized price value output.
+		/// </param>
+		/// <returns>bool value whether it found localized price for the given sku symbol</returns>
+		/// </summary>
+		bool TryGetLocalizedPrice(string skuSymbol, out string localizedPrice);
 
 		/// <summary>
 		/// Start a purchase through the chosen IAP implementation.

--- a/client/Packages/com.beamable/Runtime/Modules/Purchasing/UnityBeamablePurchaser.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/Purchasing/UnityBeamablePurchaser.cs
@@ -150,13 +150,17 @@ namespace Beamable.Purchasing
 		}
 
 		#region "IBeamablePurchaser"
-		/// <summary>
-		/// Get the localized price string for a given SKU.
-		/// </summary>
 		public string GetLocalizedPrice(string skuSymbol)
 		{
 			var product = _storeController?.products.WithID(skuSymbol);
 			return product?.metadata.localizedPriceString ?? "???";
+		}
+
+		public bool TryGetLocalizedPrice(string skuSymbol, out string localizedPrice)
+		{
+			var product = _storeController?.products.WithID(skuSymbol);
+			localizedPrice = product?.metadata.localizedPriceString ?? string.Empty;
+			return !string.IsNullOrEmpty(localizedPrice);
 		}
 
 		/// <summary>
@@ -461,6 +465,7 @@ namespace Beamable.Purchasing
 		[RegisterBeamableDependencies]
 		public static void RegisterServices(IDependencyBuilder builder)
 		{
+			builder.RemoveIfExists<IBeamablePurchaser>();
 			builder.AddSingleton<IBeamablePurchaser, UnityBeamablePurchaser>();
 		}
 	}


### PR DESCRIPTION
Change result:
- When no `IBeamablePurchaser` is provided it will no longer hang forever on `await BeamContext.Default.Api.BeamableIAP`. 
- we are providing new method for getting localized price, this one also right away gives information if the data was found. For old one you would need to know that it can return `???` when localized price was not found and then parse it based on that information.