### PR TITLE
Fix - Open API Generator Fixed for Both Unreal and Unity.

### DIFF
--- a/cli/cli/Services/UnityOpenApiSourceGenerator/OpenApiClientCodeGenerator.cs
+++ b/cli/cli/Services/UnityOpenApiSourceGenerator/OpenApiClientCodeGenerator.cs
@@ -455,7 +455,7 @@ namespace Beamable.Server.Generator
 			var mapToUse = OpenApiUtils.OpenApiCSharpNameMap; // Default to short names
 			string valueToFind = !string.IsNullOrEmpty(schema.Format) ? schema.Format : schema.Type;
 
-			if (mapToUse.TryGetValue(valueToFind, out string typeValue))
+			if (!string.IsNullOrEmpty(valueToFind) && mapToUse.TryGetValue(valueToFind, out string typeValue))
 			{
 				return typeValue;
 			}
@@ -489,7 +489,8 @@ namespace Beamable.Server.Generator
 
 		private string GetFullTypeName(OpenApiSchema schema, string typeName)
 		{
-			if (OpenApiUtils.OpenApiCSharpFullNameMap.TryGetValue(schema.Format ?? schema.Type, out string fullName))
+			string schemaFormat = schema.Format ?? schema.Type;
+			if (!string.IsNullOrEmpty(schemaFormat) && OpenApiUtils.OpenApiCSharpFullNameMap.TryGetValue(schemaFormat, out string fullName))
 			{
 				return fullName;
 			}
@@ -560,7 +561,7 @@ namespace Beamable.Server.Generator
 			sb.Append(nameBase.Contains("{0}")
 				? string.Format(nameBase, parameterClassName)
 				: nameBase);
-			return sb.ToString().Replace(".", "_");
+			return sb.ToString().Replace(".", "_").Replace(",","_").Replace(" ", "");
 		}
 
 		private string GetCSharpCodeString()

--- a/cli/cli/Services/UnrealSourceGenerator/UnrealSourceGenerator.cs
+++ b/cli/cli/Services/UnrealSourceGenerator/UnrealSourceGenerator.cs
@@ -18,7 +18,7 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 {
 	// Start of Special-Cased Types
 	public static readonly UnrealType UNREAL_STRING = new("FString");
-	public static readonly UnrealType UNREAL_BYTE = new("int8");
+	public static readonly UnrealType UNREAL_BYTE = new("uint8");
 	public static readonly UnrealType UNREAL_SHORT = new("int16");
 	public static readonly UnrealType UNREAL_INT = new("int32");
 	public static readonly UnrealType UNREAL_LONG = new("int64");
@@ -30,7 +30,7 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 	public static readonly UnrealType UNREAL_JSON = new("TSharedPtr<FJsonObject>");
 	public static readonly UnrealType UNREAL_OPTIONAL = new("FOptional");
 	public static readonly UnrealType UNREAL_OPTIONAL_STRING = new($"{UNREAL_OPTIONAL}String");
-	public static readonly UnrealType UNREAL_OPTIONAL_BYTE = new($"{UNREAL_OPTIONAL}Int8");
+	public static readonly UnrealType UNREAL_OPTIONAL_BYTE = new($"{UNREAL_OPTIONAL}UInt8");
 	public static readonly UnrealType UNREAL_OPTIONAL_SHORT = new($"{UNREAL_OPTIONAL}Int16");
 	public static readonly UnrealType UNREAL_OPTIONAL_INT = new($"{UNREAL_OPTIONAL}Int32");
 	public static readonly UnrealType UNREAL_OPTIONAL_LONG = new($"{UNREAL_OPTIONAL}Int64");
@@ -2443,7 +2443,12 @@ public class UnrealSourceGenerator : SwaggerService.ISourceGenerator
 	/// <summary>
 	/// Makes a UnrealType from a NamespacedType that the caller knows should become a F_____.
 	/// </summary>
-	private static UnrealType MakeUnrealUEnumTypeFromNamespacedType(NamespacedType referenceId) => new($"EBeam{referenceId.AsStr.Capitalize()}");
+	private static UnrealType MakeUnrealUEnumTypeFromNamespacedType(NamespacedType referenceId)
+	{
+		var prefix = genType != GenerationType.Microservice ? "EBeam" : "E";
+		string enumName = referenceId.AsStr.Replace(".", "").Capitalize();
+		return new UnrealType($"{prefix}{enumName}");
+	}
 
 	/// <summary>
 	/// Checks if the given schema should be interpreted a CSV-Response's Row schema. 

--- a/microservice/beamable.tooling.common/OpenAPI/SchemaGenerator.cs
+++ b/microservice/beamable.tooling.common/OpenAPI/SchemaGenerator.cs
@@ -51,6 +51,7 @@ public class SchemaGenerator
 			shouldEmit &= curr.IsSerializable;
 			shouldEmit &= !curr.IsArray;
 			shouldEmit &= curr != typeof(string);
+			shouldEmit &= !typeof(Optional).IsAssignableFrom(curr);
 			if (shouldEmit)
 			{
 				yield return curr; // add the current type to the final set of types.
@@ -175,7 +176,16 @@ public class SchemaGenerator
 				{
 					Type = "object",
 					AdditionalPropertiesAllowed = true,
-					AdditionalProperties = Convert(x.GetGenericArguments()[1], depth - 1)
+					AdditionalProperties = Convert(x.GetGenericArguments()[1], depth - 1),
+					Extensions = new Dictionary<string, IOpenApiExtension>
+					{
+						[MICROSERVICE_EXTENSION_BEAMABLE_TYPE_NAMESPACE] = new OpenApiString(runtimeType.Namespace),
+						[MICROSERVICE_EXTENSION_BEAMABLE_TYPE_NAME] = new OpenApiString(runtimeType.Name),
+						[MICROSERVICE_EXTENSION_BEAMABLE_TYPE_ASSEMBLY_QUALIFIED_NAME] = new OpenApiString(runtimeType.GetGenericQualifiedTypeName()),
+						[MICROSERVICE_EXTENSION_BEAMABLE_TYPE_OWNER_ASSEMBLY] = new OpenApiString(runtimeType.Assembly.GetName().Name),
+						[MICROSERVICE_EXTENSION_BEAMABLE_TYPE_OWNER_ASSEMBLY_VERSION] = new OpenApiString(runtimeType.Assembly.GetName().Version.ToString()),
+						[MICROSERVICE_EXTENSION_BEAMABLE_FORCE_TYPE_NAME] = new OpenApiString(runtimeType.GetGenericSanitizedFullName())
+					}
 				};
 
 			
@@ -190,7 +200,15 @@ public class SchemaGenerator
 				var enumNames = Enum.GetNames(runtimeType);
 				return new OpenApiSchema
 				{
-					Enum = enumNames.Select(name => new OpenApiString(name)).Cast<IOpenApiAny>().ToList()
+					Enum = enumNames.Select(name => new OpenApiString(name)).Cast<IOpenApiAny>().ToList(),
+					Extensions = new Dictionary<string, IOpenApiExtension>
+				{
+					[MICROSERVICE_EXTENSION_BEAMABLE_TYPE_NAMESPACE] = new OpenApiString(runtimeType.Namespace),
+					[MICROSERVICE_EXTENSION_BEAMABLE_TYPE_NAME] = new OpenApiString(runtimeType.Name),
+					[MICROSERVICE_EXTENSION_BEAMABLE_TYPE_ASSEMBLY_QUALIFIED_NAME] = new OpenApiString(GetQualifiedReferenceName(runtimeType)),
+					[MICROSERVICE_EXTENSION_BEAMABLE_TYPE_OWNER_ASSEMBLY] = new OpenApiString(runtimeType.Assembly.GetName().Name),
+					[MICROSERVICE_EXTENSION_BEAMABLE_TYPE_OWNER_ASSEMBLY_VERSION] = new OpenApiString(runtimeType.Assembly.GetName().Version.ToString())
+				}
 				};
 			
 			default:


### PR DESCRIPTION
Fixes:

- Adjusted Dictionary Support for C# openApi gen.
- Adjusted Enum support for C# openApi gen.
- Skip Optional types on schema generator because Unreal generates all schemas found in openApi, and we don't need to add them.
- Fixes an Issue when the schema doesn't have a format or type, resulting in a nullref.
- Fixes byte type generator on Unreal Code Generator
- Fixes the Enum generation on Unreal Code Generator.