### PR TITLE
Fix Editor namespace usage to address Android build failures.

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed incorrect `MailMessage` `expires` field parsing.
 - Fixed issue with `WebSocketConnection` not sending updates after reconnection.
 - Improve IAP error detection.
+- Fixed Editor namespace usage to be `Beamable.Editor.Config` to address Android build errors.
 
 ### Change
 - Able to use the new Client Code Generator from CLI that uses OpenAPI instead of the old one that uses Reflection

--- a/client/Packages/com.beamable/Editor/UI/Config/UpdateGPGSRealmConfigHelper.cs
+++ b/client/Packages/com.beamable/Editor/UI/Config/UpdateGPGSRealmConfigHelper.cs
@@ -12,7 +12,7 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
-namespace Editor.UI.Config
+namespace Beamable.Editor.Config
 {
 	public class UpdateGPGSRealmConfigHelper : EditorWindow
 	{


### PR DESCRIPTION
# Ticket

Fixes #4096 

# Brief Description

The CS0118 errors when building for Android were caused by improper namespacing in `UpdateGPGSRealmConfigHelper.cs`; changing the namespace to `Beamable.Editor.Config` in that file should prevent those errors.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
