### PR TITLE
Fix - Adds support to JSON arguments on CLi Commands on Unity

### DIFF
--- a/cli/cli/Services/UnityCliGenerator.cs
+++ b/cli/cli/Services/UnityCliGenerator.cs
@@ -374,25 +374,13 @@ MonoImporter:
 				var conditional = new CodeConditionStatement(valueIsNotNullExpr);
 				CodeMethodInvokeExpression addStatement;
 
-				if (parameter.Type.BaseType == "System.String")
-				{
-					var optionalValWithoutEscape =
-						new CodeBinaryOperatorExpression(new CodePrimitiveExpression("--" + option.Name + "=\""),
-							CodeBinaryOperatorType.Add, parameterReference);
-					var optionalVal =
-						new CodeBinaryOperatorExpression(optionalValWithoutEscape,
-							CodeBinaryOperatorType.Add, new CodePrimitiveExpression("\""));
-					addStatement =
-						new CodeMethodInvokeExpression(argReference, nameof(List<int>.Add), optionalVal);
-				}
-				else
-				{
-					var optionalVal =
-						new CodeBinaryOperatorExpression(new CodePrimitiveExpression("--" + option.Name + "="),
-							CodeBinaryOperatorType.Add, parameterReference);
-					addStatement =
-						new CodeMethodInvokeExpression(argReference, nameof(List<int>.Add), optionalVal);
-				}
+				
+				var optionalVal =
+					new CodeBinaryOperatorExpression(new CodePrimitiveExpression("--" + option.Name + "="),
+						CodeBinaryOperatorType.Add, parameterReference);
+				addStatement =
+					new CodeMethodInvokeExpression(argReference, nameof(List<int>.Add), optionalVal);
+				
 
 				if (option.AllowMultipleArgumentsPerToken)
 				{

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamWebCommand.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamWebCommand.cs
@@ -254,7 +254,8 @@ namespace Beamable.Editor.BeamCli
 				port = port,
 				owner = "\"" + Owner + "\"",
 				autoIncPort = true,
-				selfDestructSeconds = _options.selfDestructOverride.GetOrElse(15) // TODO: validate that a low ttl will restart the server
+				selfDestructSeconds = _options.selfDestructOverride.GetOrElse(15), // TODO: validate that a low ttl will restart the server
+				customSplitter = true,
 			};
 			var p = args.port;
 			_serverCommand = processCommands.ServerServe(args);

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/Beam.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/Beam.cs
@@ -68,14 +68,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the cid value was not default, then add it to the list of args.
             if ((this.cid != default(string)))
             {
-                genBeamCommandArgs.Add((("--cid=\"" + this.cid) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--cid=" + this.cid));
             }
             // If the pid value was not default, then add it to the list of args.
             if ((this.pid != default(string)))
             {
-                genBeamCommandArgs.Add((("--pid=\"" + this.pid) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--pid=" + this.pid));
             }
             // If the quiet value was not default, then add it to the list of args.
             if ((this.quiet != default(bool)))
@@ -85,26 +83,22 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the host value was not default, then add it to the list of args.
             if ((this.host != default(string)))
             {
-                genBeamCommandArgs.Add((("--host=\"" + this.host) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--host=" + this.host));
             }
             // If the accessToken value was not default, then add it to the list of args.
             if ((this.accessToken != default(string)))
             {
-                genBeamCommandArgs.Add((("--access-token=\"" + this.accessToken) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--access-token=" + this.accessToken));
             }
             // If the refreshToken value was not default, then add it to the list of args.
             if ((this.refreshToken != default(string)))
             {
-                genBeamCommandArgs.Add((("--refresh-token=\"" + this.refreshToken) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--refresh-token=" + this.refreshToken));
             }
             // If the log value was not default, then add it to the list of args.
             if ((this.log != default(string)))
             {
-                genBeamCommandArgs.Add((("--log=\"" + this.log) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--log=" + this.log));
             }
             // If the noRedirect value was not default, then add it to the list of args.
             if ((this.noRedirect != default(bool)))
@@ -143,8 +137,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the dockerCliPath value was not default, then add it to the list of args.
             if ((this.dockerCliPath != default(string)))
             {
-                genBeamCommandArgs.Add((("--docker-cli-path=\"" + this.dockerCliPath) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--docker-cli-path=" + this.dockerCliPath));
             }
             // If the emitLogStreams value was not default, then add it to the list of args.
             if ((this.emitLogStreams != default(bool)))
@@ -163,8 +156,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the dir value was not default, then add it to the list of args.
             if ((this.dir != default(string)))
             {
-                genBeamCommandArgs.Add((("--dir=\"" + this.dir) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--dir=" + this.dir));
             }
             // If the raw value was not default, then add it to the list of args.
             if ((this.raw != default(bool)))
@@ -184,8 +176,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the dotnetPath value was not default, then add it to the list of args.
             if ((this.dotnetPath != default(string)))
             {
-                genBeamCommandArgs.Add((("--dotnet-path=\"" + this.dotnetPath) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--dotnet-path=" + this.dotnetPath));
             }
             // If the version value was not default, then add it to the list of args.
             if ((this.version != default(bool)))

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCollectorGet.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamCollectorGet.cs
@@ -20,20 +20,17 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the platform value was not default, then add it to the list of args.
             if ((this.platform != default(string)))
             {
-                genBeamCommandArgs.Add((("--platform=\"" + this.platform) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--platform=" + this.platform));
             }
             // If the arch value was not default, then add it to the list of args.
             if ((this.arch != default(string)))
             {
-                genBeamCommandArgs.Add((("--arch=\"" + this.arch) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--arch=" + this.arch));
             }
             // If the overrideVersion value was not default, then add it to the list of args.
             if ((this.overrideVersion != default(string)))
             {
-                genBeamCommandArgs.Add((("--override-version=\"" + this.overrideVersion) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--override-version=" + this.overrideVersion));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentPs.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentPs.cs
@@ -25,8 +25,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the manifestIds value was not default, then add it to the list of args.
             if ((this.manifestIds != default(string[])))
             {
-                genBeamCommandArgs.Add((("--manifest-ids=\"" + this.manifestIds) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--manifest-ids=" + this.manifestIds));
             }
             // If the requireProcessId value was not default, then add it to the list of args.
             if ((this.requireProcessId != default(int)))

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentPublish.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentPublish.cs
@@ -16,8 +16,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the manifestIds value was not default, then add it to the list of args.
             if ((this.manifestIds != default(string[])))
             {
-                genBeamCommandArgs.Add((("--manifest-ids=\"" + this.manifestIds) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--manifest-ids=" + this.manifestIds));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentResolve.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentResolve.cs
@@ -28,8 +28,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the manifestIds value was not default, then add it to the list of args.
             if ((this.manifestIds != default(string[])))
             {
-                genBeamCommandArgs.Add((("--manifest-ids=\"" + this.manifestIds) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--manifest-ids=" + this.manifestIds));
             }
             // If the filterType value was not default, then add it to the list of args.
             if ((this.filterType != default(Beamable.Common.Content.ContentFilterType)))
@@ -39,14 +38,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the filter value was not default, then add it to the list of args.
             if ((this.filter != default(string)))
             {
-                genBeamCommandArgs.Add((("--filter=\"" + this.filter) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--filter=" + this.filter));
             }
             // If the use value was not default, then add it to the list of args.
             if ((this.use != default(string)))
             {
-                genBeamCommandArgs.Add((("--use=\"" + this.use) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--use=" + this.use));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentSave.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentSave.cs
@@ -22,20 +22,17 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the manifestIds value was not default, then add it to the list of args.
             if ((this.manifestIds != default(string[])))
             {
-                genBeamCommandArgs.Add((("--manifest-ids=\"" + this.manifestIds) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--manifest-ids=" + this.manifestIds));
             }
             // If the contentIds value was not default, then add it to the list of args.
             if ((this.contentIds != default(string[])))
             {
-                genBeamCommandArgs.Add((("--content-ids=\"" + this.contentIds) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--content-ids=" + this.contentIds));
             }
             // If the contentProperties value was not default, then add it to the list of args.
             if ((this.contentProperties != default(string[])))
             {
-                genBeamCommandArgs.Add((("--content-properties=\"" + this.contentProperties) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--content-properties=" + this.contentProperties));
             }
             // If the force value was not default, then add it to the list of args.
             if ((this.force != default(bool)))

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentSync.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentSync.cs
@@ -32,8 +32,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the manifestIds value was not default, then add it to the list of args.
             if ((this.manifestIds != default(string[])))
             {
-                genBeamCommandArgs.Add((("--manifest-ids=\"" + this.manifestIds) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--manifest-ids=" + this.manifestIds));
             }
             // If the filterType value was not default, then add it to the list of args.
             if ((this.filterType != default(Beamable.Common.Content.ContentFilterType)))
@@ -43,8 +42,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the filter value was not default, then add it to the list of args.
             if ((this.filter != default(string)))
             {
-                genBeamCommandArgs.Add((("--filter=\"" + this.filter) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--filter=" + this.filter));
             }
             // If the syncCreated value was not default, then add it to the list of args.
             if ((this.syncCreated != default(bool)))
@@ -64,8 +62,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the target value was not default, then add it to the list of args.
             if ((this.target != default(string)))
             {
-                genBeamCommandArgs.Add((("--target=\"" + this.target) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--target=" + this.target));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamDeploymentGet.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamDeploymentGet.cs
@@ -25,14 +25,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the toFile value was not default, then add it to the list of args.
             if ((this.toFile != default(string)))
             {
-                genBeamCommandArgs.Add((("--to-file=\"" + this.toFile) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--to-file=" + this.toFile));
             }
             // If the id value was not default, then add it to the list of args.
             if ((this.id != default(string)))
             {
-                genBeamCommandArgs.Add((("--id=\"" + this.id) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--id=" + this.id));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamDeploymentPlan.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamDeploymentPlan.cs
@@ -37,8 +37,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the comment value was not default, then add it to the list of args.
             if ((this.comment != default(string)))
             {
-                genBeamCommandArgs.Add((("--comment=\"" + this.comment) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--comment=" + this.comment));
             }
             // If the serviceComments value was not default, then add it to the list of args.
             if ((this.serviceComments != default(string[])))
@@ -52,14 +51,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the fromManifest value was not default, then add it to the list of args.
             if ((this.fromManifest != default(string)))
             {
-                genBeamCommandArgs.Add((("--from-manifest=\"" + this.fromManifest) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--from-manifest=" + this.fromManifest));
             }
             // If the fromManifestId value was not default, then add it to the list of args.
             if ((this.fromManifestId != default(string)))
             {
-                genBeamCommandArgs.Add((("--from-manifest-id=\"" + this.fromManifestId) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--from-manifest-id=" + this.fromManifestId));
             }
             // If the runHealthChecks value was not default, then add it to the list of args.
             if ((this.runHealthChecks != default(bool)))
@@ -89,14 +86,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the sln value was not default, then add it to the list of args.
             if ((this.sln != default(string)))
             {
-                genBeamCommandArgs.Add((("--sln=\"" + this.sln) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--sln=" + this.sln));
             }
             // If the toFile value was not default, then add it to the list of args.
             if ((this.toFile != default(string)))
             {
-                genBeamCommandArgs.Add((("--to-file=\"" + this.toFile) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--to-file=" + this.toFile));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamDeploymentRegistry.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamDeploymentRegistry.cs
@@ -6,7 +6,7 @@ namespace Beamable.Editor.BeamCli.Commands
     
     public partial class DeploymentRegistryArgs : Beamable.Common.BeamCli.IBeamCommandArgs
     {
-        /// <summary>The beamo id for the service to get logs for</summary>
+        /// <summary>The beamo id for the service to get images for</summary>
         public string serviceId;
         /// <summary>Serializes the arguments for command line usage.</summary>
         public virtual string Serialize()

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamDeploymentRelease.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamDeploymentRelease.cs
@@ -39,8 +39,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the comment value was not default, then add it to the list of args.
             if ((this.comment != default(string)))
             {
-                genBeamCommandArgs.Add((("--comment=\"" + this.comment) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--comment=" + this.comment));
             }
             // If the serviceComments value was not default, then add it to the list of args.
             if ((this.serviceComments != default(string[])))
@@ -54,14 +53,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the fromManifest value was not default, then add it to the list of args.
             if ((this.fromManifest != default(string)))
             {
-                genBeamCommandArgs.Add((("--from-manifest=\"" + this.fromManifest) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--from-manifest=" + this.fromManifest));
             }
             // If the fromManifestId value was not default, then add it to the list of args.
             if ((this.fromManifestId != default(string)))
             {
-                genBeamCommandArgs.Add((("--from-manifest-id=\"" + this.fromManifestId) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--from-manifest-id=" + this.fromManifestId));
             }
             // If the runHealthChecks value was not default, then add it to the list of args.
             if ((this.runHealthChecks != default(bool)))
@@ -91,14 +88,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the fromPlan value was not default, then add it to the list of args.
             if ((this.fromPlan != default(string)))
             {
-                genBeamCommandArgs.Add((("--from-plan=\"" + this.fromPlan) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--from-plan=" + this.fromPlan));
             }
             // If the sln value was not default, then add it to the list of args.
             if ((this.sln != default(string)))
             {
-                genBeamCommandArgs.Add((("--sln=\"" + this.sln) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--sln=" + this.sln));
             }
             // If the fromLatestPlan value was not default, then add it to the list of args.
             if ((this.fromLatestPlan != default(bool)))

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamFederationList.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamFederationList.cs
@@ -20,20 +20,17 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the type value was not default, then add it to the list of args.
             if ((this.type != default(string)))
             {
-                genBeamCommandArgs.Add((("--type=\"" + this.type) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--type=" + this.type));
             }
             // If the id value was not default, then add it to the list of args.
             if ((this.id != default(string)))
             {
-                genBeamCommandArgs.Add((("--id=\"" + this.id) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--id=" + this.id));
             }
             // If the fedIds value was not default, then add it to the list of args.
             if ((this.fedIds != default(string)))
             {
-                genBeamCommandArgs.Add((("--fed-ids=\"" + this.fedIds) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--fed-ids=" + this.fedIds));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamFederationLocalSettingsGetIFederatedGameServer.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamFederationLocalSettingsGetIFederatedGameServer.cs
@@ -18,14 +18,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the beamoId value was not default, then add it to the list of args.
             if ((this.beamoId != default(string)))
             {
-                genBeamCommandArgs.Add((("--beamo-id=\"" + this.beamoId) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--beamo-id=" + this.beamoId));
             }
             // If the fedId value was not default, then add it to the list of args.
             if ((this.fedId != default(string)))
             {
-                genBeamCommandArgs.Add((("--fed-id=\"" + this.fedId) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--fed-id=" + this.fedId));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamFederationLocalSettingsSetIFederatedGameServer.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamFederationLocalSettingsSetIFederatedGameServer.cs
@@ -20,14 +20,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the beamoId value was not default, then add it to the list of args.
             if ((this.beamoId != default(string)))
             {
-                genBeamCommandArgs.Add((("--beamo-id=\"" + this.beamoId) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--beamo-id=" + this.beamoId));
             }
             // If the fedId value was not default, then add it to the list of args.
             if ((this.fedId != default(string)))
             {
-                genBeamCommandArgs.Add((("--fed-id=\"" + this.fedId) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--fed-id=" + this.fedId));
             }
             // If the contentIds value was not default, then add it to the list of args.
             if ((this.contentIds != default(string[])))

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamInit.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamInit.cs
@@ -43,26 +43,22 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the email value was not default, then add it to the list of args.
             if ((this.email != default(string)))
             {
-                genBeamCommandArgs.Add((("--email=\"" + this.email) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--email=" + this.email));
             }
             // If the password value was not default, then add it to the list of args.
             if ((this.password != default(string)))
             {
-                genBeamCommandArgs.Add((("--password=\"" + this.password) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--password=" + this.password));
             }
             // If the host value was not default, then add it to the list of args.
             if ((this.host != default(string)))
             {
-                genBeamCommandArgs.Add((("--host=\"" + this.host) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--host=" + this.host));
             }
             // If the refreshToken value was not default, then add it to the list of args.
             if ((this.refreshToken != default(string)))
             {
-                genBeamCommandArgs.Add((("--refresh-token=\"" + this.refreshToken) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--refresh-token=" + this.refreshToken));
             }
             // If the saveExtraPaths value was not default, then add it to the list of args.
             if ((this.saveExtraPaths != default(string[])))

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListenPlayer.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamListenPlayer.cs
@@ -16,8 +16,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the context value was not default, then add it to the list of args.
             if ((this.context != default(string)))
             {
-                genBeamCommandArgs.Add((("--context=\"" + this.context) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--context=" + this.context));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamOapiDownload.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamOapiDownload.cs
@@ -20,14 +20,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the output value was not default, then add it to the list of args.
             if ((this.output != default(string)))
             {
-                genBeamCommandArgs.Add((("--output=\"" + this.output) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--output=" + this.output));
             }
             // If the filter value was not default, then add it to the list of args.
             if ((this.filter != default(string)))
             {
-                genBeamCommandArgs.Add((("--filter=\"" + this.filter) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--filter=" + this.filter));
             }
             // If the combineIntoOneDocument value was not default, then add it to the list of args.
             if ((this.combineIntoOneDocument != default(bool)))

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectBuildSln.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectBuildSln.cs
@@ -16,8 +16,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the sln value was not default, then add it to the list of args.
             if ((this.sln != default(string)))
             {
-                genBeamCommandArgs.Add((("--sln=\"" + this.sln) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--sln=" + this.sln));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDepsList.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectDepsList.cs
@@ -20,8 +20,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the service value was not default, then add it to the list of args.
             if ((this.service != default(string)))
             {
-                genBeamCommandArgs.Add((("--service=\"" + this.service) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--service=" + this.service));
             }
             // If the all value was not default, then add it to the list of args.
             if ((this.all != default(bool)))

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateClient.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateClient.cs
@@ -63,8 +63,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the outputDir value was not default, then add it to the list of args.
             if ((this.outputDir != default(string)))
             {
-                genBeamCommandArgs.Add((("--output-dir=\"" + this.outputDir) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--output-dir=" + this.outputDir));
             }
             // If the outputLinks value was not default, then add it to the list of args.
             if ((this.outputLinks != default(bool)))

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateClientOapi.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateClientOapi.cs
@@ -16,8 +16,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the outputDir value was not default, then add it to the list of args.
             if ((this.outputDir != default(string)))
             {
-                genBeamCommandArgs.Add((("--output-dir=\"" + this.outputDir) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--output-dir=" + this.outputDir));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateProperties.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectGenerateProperties.cs
@@ -30,8 +30,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the buildDir value was not default, then add it to the list of args.
             if ((this.buildDir != default(string)))
             {
-                genBeamCommandArgs.Add((("--build-dir=\"" + this.buildDir) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--build-dir=" + this.buildDir));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectLogs.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectLogs.cs
@@ -8,6 +8,8 @@ namespace Beamable.Editor.BeamCli.Commands
     {
         /// <summary>The name of the service to view logs for</summary>
         public Beamable.Common.Semantics.ServiceName service;
+        /// <summary>Listens to the given process id. Terminates this long-running command when the it no longer is running</summary>
+        public int requireProcessId;
         /// <summary>If the service stops, and reconnect is enabled, then the logs command will wait for the service to restart and then reattach to logs</summary>
         public bool reconnect;
         /// <summary>Serializes the arguments for command line usage.</summary>
@@ -17,6 +19,11 @@ namespace Beamable.Editor.BeamCli.Commands
             System.Collections.Generic.List<string> genBeamCommandArgs = new System.Collections.Generic.List<string>();
             // Add the service value to the list of args.
             genBeamCommandArgs.Add(this.service.ToString());
+            // If the requireProcessId value was not default, then add it to the list of args.
+            if ((this.requireProcessId != default(int)))
+            {
+                genBeamCommandArgs.Add(("--require-process-id=" + this.requireProcessId));
+            }
             // If the reconnect value was not default, then add it to the list of args.
             if ((this.reconnect != default(bool)))
             {

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewCommonLib.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewCommonLib.cs
@@ -22,14 +22,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the sln value was not default, then add it to the list of args.
             if ((this.sln != default(string)))
             {
-                genBeamCommandArgs.Add((("--sln=\"" + this.sln) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--sln=" + this.sln));
             }
             // If the outputPath value was not default, then add it to the list of args.
             if ((this.outputPath != default(string)))
             {
-                genBeamCommandArgs.Add((("--output-path=\"" + this.outputPath) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--output-path=" + this.outputPath));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewService.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewService.cs
@@ -30,14 +30,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the sln value was not default, then add it to the list of args.
             if ((this.sln != default(string)))
             {
-                genBeamCommandArgs.Add((("--sln=\"" + this.sln) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--sln=" + this.sln));
             }
             // If the serviceDirectory value was not default, then add it to the list of args.
             if ((this.serviceDirectory != default(string)))
             {
-                genBeamCommandArgs.Add((("--service-directory=\"" + this.serviceDirectory) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--service-directory=" + this.serviceDirectory));
             }
             // If the linkTo value was not default, then add it to the list of args.
             if ((this.linkTo != default(string[])))

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewStorage.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectNewStorage.cs
@@ -26,14 +26,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the sln value was not default, then add it to the list of args.
             if ((this.sln != default(string)))
             {
-                genBeamCommandArgs.Add((("--sln=\"" + this.sln) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--sln=" + this.sln));
             }
             // If the serviceDirectory value was not default, then add it to the list of args.
             if ((this.serviceDirectory != default(string)))
             {
-                genBeamCommandArgs.Add((("--service-directory=\"" + this.serviceDirectory) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--service-directory=" + this.serviceDirectory));
             }
             // If the linkTo value was not default, then add it to the list of args.
             if ((this.linkTo != default(string[])))

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectOpen.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectOpen.cs
@@ -20,8 +20,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the sln value was not default, then add it to the list of args.
             if ((this.sln != default(string)))
             {
-                genBeamCommandArgs.Add((("--sln=\"" + this.sln) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--sln=" + this.sln));
             }
             // If the onlyGenerate value was not default, then add it to the list of args.
             if ((this.onlyGenerate != default(bool)))

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectOpenSwagger.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectOpenSwagger.cs
@@ -27,8 +27,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the routingKey value was not default, then add it to the list of args.
             if ((this.routingKey != default(string)))
             {
-                genBeamCommandArgs.Add((("--routing-key=\"" + this.routingKey) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--routing-key=" + this.routingKey));
             }
             // If the remote value was not default, then add it to the list of args.
             if ((this.remote != default(bool)))
@@ -38,8 +37,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the srcTool value was not default, then add it to the list of args.
             if ((this.srcTool != default(string)))
             {
-                genBeamCommandArgs.Add((("--src-tool=\"" + this.srcTool) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--src-tool=" + this.srcTool));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectRegenerate.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectRegenerate.cs
@@ -34,8 +34,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the sln value was not default, then add it to the list of args.
             if ((this.sln != default(string)))
             {
-                genBeamCommandArgs.Add((("--sln=\"" + this.sln) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--sln=" + this.sln));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectRemoteLogs.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectRemoteLogs.cs
@@ -26,26 +26,22 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the filter value was not default, then add it to the list of args.
             if ((this.filter != default(string)))
             {
-                genBeamCommandArgs.Add((("--filter=\"" + this.filter) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--filter=" + this.filter));
             }
             // If the serverLogLevel value was not default, then add it to the list of args.
             if ((this.serverLogLevel != default(string)))
             {
-                genBeamCommandArgs.Add((("--server-log-level=\"" + this.serverLogLevel) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--server-log-level=" + this.serverLogLevel));
             }
             // If the from value was not default, then add it to the list of args.
             if ((this.from != default(string)))
             {
-                genBeamCommandArgs.Add((("--from=\"" + this.from) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--from=" + this.from));
             }
             // If the to value was not default, then add it to the list of args.
             if ((this.to != default(string)))
             {
-                genBeamCommandArgs.Add((("--to=\"" + this.to) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--to=" + this.to));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectRemove.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectRemove.cs
@@ -24,14 +24,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the sln value was not default, then add it to the list of args.
             if ((this.sln != default(string)))
             {
-                genBeamCommandArgs.Add((("--sln=\"" + this.sln) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--sln=" + this.sln));
             }
             // If the serviceDirectory value was not default, then add it to the list of args.
             if ((this.serviceDirectory != default(string)))
             {
-                genBeamCommandArgs.Add((("--service-directory=\"" + this.serviceDirectory) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--service-directory=" + this.serviceDirectory));
             }
             // If the ids value was not default, then add it to the list of args.
             if ((this.ids != default(string[])))

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectStorageRestore.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectStorageRestore.cs
@@ -27,8 +27,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the input value was not default, then add it to the list of args.
             if ((this.input != default(string)))
             {
-                genBeamCommandArgs.Add((("--input=\"" + this.input) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--input=" + this.input));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectStorageSnapshot.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamProjectStorageSnapshot.cs
@@ -20,8 +20,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the output value was not default, then add it to the list of args.
             if ((this.output != default(string)))
             {
-                genBeamCommandArgs.Add((("--output=\"" + this.output) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--output=" + this.output));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServerClear.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServerClear.cs
@@ -22,14 +22,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the version value was not default, then add it to the list of args.
             if ((this.version != default(string)))
             {
-                genBeamCommandArgs.Add((("--version=\"" + this.version) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--version=" + this.version));
             }
             // If the owner value was not default, then add it to the list of args.
             if ((this.owner != default(string)))
             {
-                genBeamCommandArgs.Add((("--owner=\"" + this.owner) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--owner=" + this.owner));
             }
             // If the port value was not default, then add it to the list of args.
             if ((this.port != default(int)))

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServerPs.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServerPs.cs
@@ -22,14 +22,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the version value was not default, then add it to the list of args.
             if ((this.version != default(string)))
             {
-                genBeamCommandArgs.Add((("--version=\"" + this.version) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--version=" + this.version));
             }
             // If the owner value was not default, then add it to the list of args.
             if ((this.owner != default(string)))
             {
-                genBeamCommandArgs.Add((("--owner=\"" + this.owner) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--owner=" + this.owner));
             }
             // If the port value was not default, then add it to the list of args.
             if ((this.port != default(int)))

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServerReq.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServerReq.cs
@@ -23,8 +23,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the cli value was not default, then add it to the list of args.
             if ((this.cli != default(string)))
             {
-                genBeamCommandArgs.Add((("--cli=\"" + this.cli) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--cli=" + this.cli));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesDeploy.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesDeploy.cs
@@ -25,14 +25,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the fromFile value was not default, then add it to the list of args.
             if ((this.fromFile != default(string)))
             {
-                genBeamCommandArgs.Add((("--from-file=\"" + this.fromFile) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--from-file=" + this.fromFile));
             }
             // If the comment value was not default, then add it to the list of args.
             if ((this.comment != default(string)))
             {
-                genBeamCommandArgs.Add((("--comment=\"" + this.comment) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--comment=" + this.comment));
             }
             // If the serviceComments value was not default, then add it to the list of args.
             if ((this.serviceComments != default(string[])))
@@ -46,8 +44,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the dockerRegistryUrl value was not default, then add it to the list of args.
             if ((this.dockerRegistryUrl != default(string)))
             {
-                genBeamCommandArgs.Add((("--docker-registry-url=\"" + this.dockerRegistryUrl) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--docker-registry-url=" + this.dockerRegistryUrl));
             }
             // If the keepContainers value was not default, then add it to the list of args.
             if ((this.keepContainers != default(bool)))

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesPromote.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesPromote.cs
@@ -17,8 +17,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the sourcePid value was not default, then add it to the list of args.
             if ((this.sourcePid != default(string)))
             {
-                genBeamCommandArgs.Add((("--source-pid=\"" + this.sourcePid) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--source-pid=" + this.sourcePid));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesServiceLogs.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesServiceLogs.cs
@@ -16,8 +16,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the id value was not default, then add it to the list of args.
             if ((this.id != default(string)))
             {
-                genBeamCommandArgs.Add((("--id=\"" + this.id) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--id=" + this.id));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesServiceMetrics.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamServicesServiceMetrics.cs
@@ -18,14 +18,12 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the id value was not default, then add it to the list of args.
             if ((this.id != default(string)))
             {
-                genBeamCommandArgs.Add((("--id=\"" + this.id) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--id=" + this.id));
             }
             // If the metric value was not default, then add it to the list of args.
             if ((this.metric != default(string)))
             {
-                genBeamCommandArgs.Add((("--metric=\"" + this.metric) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--metric=" + this.metric));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamTempClearLogs.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamTempClearLogs.cs
@@ -22,8 +22,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the olderThan value was not default, then add it to the list of args.
             if ((this.olderThan != default(string)))
             {
-                genBeamCommandArgs.Add((("--older-than=\"" + this.olderThan) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--older-than=" + this.olderThan));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamTokenFromRefresh.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamTokenFromRefresh.cs
@@ -16,8 +16,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the token value was not default, then add it to the list of args.
             if ((this.token != default(string)))
             {
-                genBeamCommandArgs.Add((("--token=\"" + this.token) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--token=" + this.token));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamTokenInspect.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamTokenInspect.cs
@@ -23,8 +23,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the token value was not default, then add it to the list of args.
             if ((this.token != default(string)))
             {
-                genBeamCommandArgs.Add((("--token=\"" + this.token) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--token=" + this.token));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamTokenList.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamTokenList.cs
@@ -44,8 +44,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the pid value was not default, then add it to the list of args.
             if ((this.pid != default(string)))
             {
-                genBeamCommandArgs.Add((("--pid=\"" + this.pid) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--pid=" + this.pid));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamUnityRestore.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamUnityRestore.cs
@@ -16,8 +16,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the csproj value was not default, then add it to the list of args.
             if ((this.csproj != default(string)))
             {
-                genBeamCommandArgs.Add((("--csproj=\"" + this.csproj) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--csproj=" + this.csproj));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamUnityUpdateReferences.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamUnityUpdateReferences.cs
@@ -24,8 +24,7 @@ namespace Beamable.Editor.BeamCli.Commands
             // If the sln value was not default, then add it to the list of args.
             if ((this.sln != default(string)))
             {
-                genBeamCommandArgs.Add((("--sln=\"" + this.sln) 
-                                + "\""));
+                genBeamCommandArgs.Add(("--sln=" + this.sln));
             }
             // If the paths value was not default, then add it to the list of args.
             if ((this.paths != default(string[])))


### PR DESCRIPTION
Enables Custom Splitter and removed the additional quotes being added in the UnityCliGenerator.