### PR TITLE
Bake live content by default on build

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Able to use the new Client Code Generator from CLI that uses OpenAPI instead of the old one that uses Reflection
 - `Core.Platform.Api` namespace moved into `Beamable.Api` namespace
 - `Core.Platform` namespace moved into `Beamable` namespace
+- Content baking on build will use content from server. It can be changed with `BEAMABLE_CONTENT_BAKE_ONLY_FROM_LOCAL` define symbol.
 
 ## [2.4.0] - 2025-06-11 
 

--- a/client/Packages/com.beamable/Editor/BuildPreProcessor.cs
+++ b/client/Packages/com.beamable/Editor/BuildPreProcessor.cs
@@ -98,7 +98,11 @@ namespace Beamable.Editor
 
 			if (ContentConfiguration.Instance.BakeContentOnBuild)
 			{
+#if !BEAMABLE_CONTENT_BAKE_ONLY_FROM_LOCAL
 				await ContentIO.BakeContent(skipCheck: true);
+#else
+				await ContentIO.BakeLiveContent();
+#endif
 			}
 			if (CoreConfiguration.Instance.PreventCodeStripping)
 			{


### PR DESCRIPTION
We've introduced new way of baking content, let's use it by default on build