### PR TITLE
fixes #4156 - fix non async task callables

### DIFF
--- a/microservice/beamable.tooling.common/Microservice/ServiceMethodHelper.cs
+++ b/microservice/beamable.tooling.common/Microservice/ServiceMethodHelper.cs
@@ -247,9 +247,8 @@ namespace Beamable.Server
 	      }
 	      else
 	      {
-		      var isAsync = null != method.GetCustomAttribute<AsyncStateMachineAttribute>();
-
-		      if (isAsync)
+		      var isTaskBased = resultType.IsAssignableTo(typeof(Task));
+		      if (isTaskBased)
 		      {
 			      executor = (target, args) =>
 			      {

--- a/microservice/microservice/CHANGELOG.md
+++ b/microservice/microservice/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Non `async` Callables can return `Task` types [4156](https://github.com/beamable/BeamableProduct/issues/4156)
+
 ## [5.0.3] - 2025-06-24
 no changes
 

--- a/microservice/microserviceTests/microservice/SimpleMicroservice.cs
+++ b/microservice/microserviceTests/microservice/SimpleMicroservice.cs
@@ -363,5 +363,39 @@ namespace microserviceTests.microservice
             throw;
          }
       }
+      
+      // WORKS
+      [Callable]
+      public RandomResponse Random1()
+      {
+	      return new RandomResponse {number = 123};
+      }
+		
+      // WORKS
+      [Callable]
+      public async Task<RandomResponse> Random2()
+      {
+	      return await Task.FromResult(new RandomResponse {number = 123});
+      }
+		
+      // DOES NOT WORK
+      [Callable]
+      public Task<RandomResponse> Random3()
+      {
+	      return Task.FromResult(new RandomResponse {number = 123});
+      }
+
+      // WORKS
+      [Callable]
+      public async Task<RandomResponse> Random4()
+      {
+	      return new RandomResponse {number = 123};
+      }
    }
+}
+
+[Serializable]
+public class RandomResponse
+{
+	public int number;
 }


### PR DESCRIPTION
Not sure why we made it so complicated before; but rather than checking for the compiler generated `async` attribute, we can just check for the `Task`-like return type. 
