### PR TITLE
allows build commands to ignore bad docker output

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Added a new command `project generate web-client `, which generates typescript/javascript web client code for calling c# microservices.
  - New Static Analyzer for Generic Types on `Microservice` classes; 
 
+### Fixed
+- `beam deploy` commands handle non JSON `docker build` logs, which fixes error where builds couldn't find the docker image id of successfully built services. 
 
 ## [5.1.0] - 2025-07-23
 ### Added

--- a/cli/cli/Commands/Services/ServicesBuildCommand.cs
+++ b/cli/cli/Commands/Services/ServicesBuildCommand.cs
@@ -309,6 +309,57 @@ public class ServicesBuildCommand : AppCommand<ServicesBuildCommandArgs>
 		};
 	}
 
+	public static bool TryExtractAllMessages(StringBuilder buffer, out List<BuildkitMessage> messages)
+	{
+		messages = new List<BuildkitMessage>();
+		while (TryExtractFirstMessage(buffer, out var msg))
+		{
+			messages.Add(msg);
+		}
+
+		return messages.Count > 0;
+	}
+	public static bool TryExtractFirstMessage(StringBuilder buffer, out BuildkitMessage msg)
+	{
+		var line = buffer.ToString();
+		msg = null;
+		var openingBracketIndex = line.IndexOf('{');
+		if (openingBracketIndex == -1)
+		{
+			return false;
+		}
+		var index = openingBracketIndex;
+		var parsed = false;
+		while (!parsed)
+		{
+			var closingBracketIndex = line.IndexOf('}', index);
+			if (closingBracketIndex == -1)
+			{
+				break;
+			}
+
+			var json = line.Substring(openingBracketIndex, (closingBracketIndex - openingBracketIndex) + 1);
+			try
+			{
+				msg = System.Text.Json.JsonSerializer.Deserialize<BuildkitMessage>(json,
+					new JsonSerializerOptions
+					{
+						IncludeFields = true,
+					});
+
+				buffer.Remove(0, closingBracketIndex + 1);
+				parsed = true;
+				return true;
+			}
+			catch
+			{
+				index = closingBracketIndex + 1;
+			}
+		}
+
+		return false;
+	}
+
 	/// <summary>
 	/// Use docker buildkit to build a beamo service id.
 	/// </summary>
@@ -439,22 +490,6 @@ public class ServicesBuildCommand : AppCommand<ServicesBuildCommandArgs>
 		var digestToVertex = new Dictionary<string, BuildkitVertex>();
 		var idToStatus = new Dictionary<string, BuildkitStatus>();
 		string imageId = string.Empty; 
-		bool TryParse(out BuildkitMessage msg)
-		{
-			string json = buffer.ToString();
-			try
-			{
-				msg = System.Text.Json.JsonSerializer.Deserialize<BuildkitMessage>(json,
-					new JsonSerializerOptions { IncludeFields = true });
-				buffer.Clear();
-				return true;
-			}
-			catch
-			{
-				msg = null;
-				return false;
-			}
-		}
 
 		void PostMessage(BuildkitMessage msg)
 		{
@@ -556,9 +591,12 @@ public class ServicesBuildCommand : AppCommand<ServicesBuildCommandArgs>
 				lock (buffer)
 				{
 					buffer.Append(line);
-					if (TryParse(out var msg))
+					if (TryExtractAllMessages(buffer, out var messages))
 					{
-						PostMessage(msg);
+						foreach (var message in messages)
+						{
+							PostMessage(message);
+						}
 					}
 				}
 			}));
@@ -598,7 +636,7 @@ public class ServicesBuildCommand : AppCommand<ServicesBuildCommandArgs>
 	/// https://github.com/moby/buildkit/blob/master/api/services/control/control.proto#L115
 	/// of the StatusResponse
 	/// </summary>
-	class BuildkitMessage
+	public class BuildkitMessage
 	{
 		public List<BuildkitVertex> vertexes = new List<BuildkitVertex>();
 		public List<BuildkitStatus> statuses = new List<BuildkitStatus>();
@@ -610,7 +648,7 @@ public class ServicesBuildCommand : AppCommand<ServicesBuildCommandArgs>
 	/// a vertex represents a build step in the docker-file.
 	/// buildkit will publish all the vertexes and then publish status and log updates for each vertex.
 	/// </summary>
-	class BuildkitVertex
+	public class BuildkitVertex
 	{
 		public string digest;
 		public string name;
@@ -630,7 +668,7 @@ public class ServicesBuildCommand : AppCommand<ServicesBuildCommandArgs>
 		public List<string> inputs = new List<string>(); 
 	}
 
-	class BuildkitLogs
+	public class BuildkitLogs
 	{
 		public string vertex;
 		public DateTimeOffset timestamp;
@@ -645,7 +683,7 @@ public class ServicesBuildCommand : AppCommand<ServicesBuildCommandArgs>
 		public string DecodedMessage => Encoding.UTF8.GetString(Convert.FromBase64String(data));
 	}
 
-	class BuildkitStatus
+	public class BuildkitStatus
 	{
 		public string id;
 		public string vertex;
@@ -657,7 +695,7 @@ public class ServicesBuildCommand : AppCommand<ServicesBuildCommandArgs>
 		public bool IsStarted => started.HasValue;
 	}
 
-	class VertexWarning
+	public class VertexWarning
 	{
 		public string vertex;
 		public long level;

--- a/cli/tests/DeployGetImageTests.cs
+++ b/cli/tests/DeployGetImageTests.cs
@@ -1,0 +1,53 @@
+using System.Text;
+using cli;
+using NUnit.Framework;
+
+namespace tests;
+
+public class DeployGetImageTests
+{
+    [Test]
+    public void Test()
+    {
+        var success = BuildkitStatusUtil.TryGetImageId(
+            "writing image sha256:09990e99bdada1c9cebef658b560b56cc59d0b9485d6e763528d24d5a9c49e26", out var image);
+        
+        Assert.That(success, Is.True);
+        Assert.That(image, Is.EqualTo("sha256:09990e99bdada1c9cebef658b560b56cc59d0b9485d6e763528d24d5a9c49e26"));
+    }
+
+    [Test]
+    public void Extract_FromActualCustomerLogs()
+    {
+        var str =
+            "\r\n2025/07/28 09:33:53 http2: server: error reading preface from client //./pipe/dockerDesktopLinuxEngine: file has already been closed{\"vertexes\":[{\"digest\":\"sha256:fbce4a65adf1e25319ad129936c2d21f3d382d2d1cbdd096c5568e478d0b310a\",\"name\":\"[internal] load build definition from Dockerfile\"}]}{\"vertexes\":[{\"digest\":\"sha256:fbce4a65adf1e25319ad129936c2d21f3d382d2d1cbdd096c5568e478d0b310a\",\"name\":\"[internal] load build definition from Dockerfile\",\"started\":\"2025-07-28T16:33:53.5921041Z\",\"completed\":\"2025-07-28T16:33:53.5921553Z\"}]}";
+        var builder = new StringBuilder();
+        builder.Append(str);
+        var extracted = ServicesBuildCommand.TryExtractAllMessages(builder, out var messages);
+        
+        Assert.IsTrue(extracted);
+        
+        Assert.AreEqual(2, messages.Count);
+    }
+    
+    [Test]
+    public void Extract_Hypothetical_After()
+    {
+        var str =
+            "\r\n2025/07/28 09:33:53 http2: server: error reading preface from client //./pipe/dockerDesktopLinuxEngine: file has already been closed{\"vertexes\":[{\"digest\":\"sha256:fbce4a65adf1e25319ad129936c2d21f3d382d2d1cbdd096c5568e478d0b310a\",\"name\":\"[internal] load build definition from Dockerfile\"}]}{\"vertexes\":[{\"digest\":\"sha256:fbce4a65adf1e25319ad129936c2d21f3d382d2d1cbdd096c5568e478d0b310a\",\"name\":\"[internal] load build definition from Dockerfile\",\"started\":\"2025-07-28T16:33:53.5921041Z\",\"completed\":\"2025-07-28T16:33:53.5921553Z\"}]}abc{";
+        var builder = new StringBuilder();
+        builder.Append(str);
+        var extracted = ServicesBuildCommand.TryExtractAllMessages(builder, out var messages);
+        
+        Assert.IsTrue(extracted);
+        
+        Assert.AreEqual(2, messages.Count);
+
+        builder.Append("}a");
+        
+        extracted = ServicesBuildCommand.TryExtractAllMessages(builder, out messages);
+        Assert.IsTrue(extracted);
+        Assert.AreEqual(1, messages.Count);
+
+    }
+}


### PR DESCRIPTION
https://github.com/docker/for-win/issues/13611

Sometimes `docker buildx` outputs non JSON messages even when you ask it to output JSON :( 

So this change allows the log parser to be way more robust in its parsing of the output. It essentially looks for `{` and then tries to successfully parse `}` substrings.