### PR TITLE
Issue/4218 invalid credential when calling login with email triggers call to refresh token

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # beamable-sdk
 
+## 0.4.1
+
+### Patch Changes
+
+- Fix invalid credential when `loginWithEmail` triggers a refresh token and retries.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- Introduced initialization via `Beam.init()` and `BeamServer.init()`. 
+- Introduced initialization via `Beam.init()` and `BeamServer.init()`.
 - Introduced new environment-variable support via `BeamBase.env` or `Beam.env` or `BeamServer.env`.
 - Introduced `use()` as a service locator, and an SDK mixin to register client and server services.
 - Added support for authentication via email/password, third-party providers, and external identity.

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beamable-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Beamable Web SDK",
   "main": "dist/node/index.js",
   "module": "dist/node/index.mjs",

--- a/web/src/network/http/BeamRequester.ts
+++ b/web/src/network/http/BeamRequester.ts
@@ -99,9 +99,18 @@ export class BeamRequester implements HttpRequester {
     const newReq: HttpRequest = { ...req, body };
     let response = await this.inner.request<TRes, any>(newReq);
 
-    if (response.status === 401 && !this.useSignedRequest) {
+    const isInvalidCredentialsError =
+      typeof response.body === 'string'
+        ? (response.body as string).includes('InvalidCredentialsError')
+        : false;
+
+    if (
+      response.status === 401 &&
+      !this.useSignedRequest &&
+      !isInvalidCredentialsError
+    ) {
       await this.handleRefresh();
-      response = await this.inner.request<TRes, TReq>(req);
+      response = await this.inner.request<TRes, TReq>(newReq);
     }
 
     // throw a beam error if the response is not successful


### PR DESCRIPTION
# Ticket

Closes #4218

# Brief Description

> Fix invalid credential when loginWithEmail triggers a refresh token and retries.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?
