### PR TITLE
[448] Add microServiceId field to MicroserviceServiceProviderRequest for service grouping

### DIFF
--- a/microservice/microservice/dbmicroservice/BeamableMicroService.cs
+++ b/microservice/microservice/dbmicroservice/BeamableMicroService.cs
@@ -60,6 +60,7 @@ namespace Beamable.Server
 	   public string beamoName; // the name of the service, as written by the user. Ex: "Tuna"
 	   public string? routingKey; // Option[String] = None, // Arbitrary unique key. This should only be used for locally running services
 	   public long? startedById; //: Option[Long] = None, // accountId of the user who started this service. This should only be used for locally running services
+	   public string microServiceId; // the unique id for the microservice in question
 
 	   public string ToJson()
 	   {
@@ -97,6 +98,7 @@ namespace Beamable.Server
    public class BeamableMicroService
    {
       public string MicroserviceName => _serviceAttribute.MicroserviceName;
+      public string MicroserviceID => _microServiceId;
       
       /// <summary>
       /// The term, "micro_" is a legacy string from 1.x days.
@@ -117,6 +119,7 @@ namespace Beamable.Server
       private Promise<IConnection> _webSocketPromise;
       private MicroserviceRequester _requester;
       private IActivityProvider _activityProvider;
+      private readonly string _microServiceId = Guid.NewGuid().ToString();
       public SocketRequesterContext SocketContext => _socketRequesterContext;
       private SocketRequesterContext _socketRequesterContext;
       public ServiceMethodCollection ServiceMethods { get; private set; }
@@ -884,6 +887,7 @@ namespace Beamable.Server
 		      type = "basic", 
 		      name = QualifiedName,
 		      beamoName = MicroserviceName,
+		      microServiceId = _microServiceId,
 	      };
 	      if (_args.TryGetRoutingKey(out var routingKey))
 	      {
@@ -978,7 +982,5 @@ namespace Beamable.Server
          }).ToUnit();
          return Promise.Sequence(serviceProvider).ToUnit();
       }
-
-
    }
 }


### PR DESCRIPTION
# Ticket

[#448](https://github.com/beamable/BeamableBackend/issues/448)

# Brief Description

Adds a `microServiceId` field to the `MicroserviceServiceProviderRequest` class to enable proper grouping of service provider registrations from the same C# microservice instance. Each C# microservice generates a unique GUID that is shared across all 10 service provider registrations, allowing the backend to correctly identify and count microservice instances instead of counting individual service providers.

This change helps to address the issue where C# microservices were being counted as 10 separate instances (due to 10 websocket connections) instead of 1 instance for billing and monitoring purposes.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

# Notes

This is the first part of a two-part fix for microservice counting issues. The backend aggregation pipeline will need to be updated separately to utilize this new field for proper grouping and counting.

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit.

Does this introduce tech-debt? No.
