### PR TITLE
Change - Added the detach flag to start collector command

### DIFF
--- a/microservice/beamable.tooling.common/Microservice/CollectorManager.cs
+++ b/microservice/beamable.tooling.common/Microservice/CollectorManager.cs
@@ -515,11 +515,13 @@ public class CollectorManager
 		int alarmCounter = 0;
 
 		CollectorStatus = await IsCollectorRunning(socket, cts.Token, logger);
+		
 		if (!CollectorStatus.isRunning)
 		{
 			logger.ZLogInformation($"Starting local process for collector");
 			StartCollectorProcess(collectorExecutablePath, detach, logger, cts, otlpEndpoint);
 		}
+		
 		
 		while (!cts.IsCancellationRequested) // Should we stop this after a number of attempts to find the collector?
 		{
@@ -640,8 +642,6 @@ public class CollectorManager
 		{
 			throw new Exception("Invalid value for port");
 		}
-
-		logger.ZLogInformation($"Starting listening to otel collector in port [{portNumber}]...");
 
 		Socket socket = GetSocket(portNumber, logger);
 


### PR DESCRIPTION
# Ticket

There's no ticket for this task.

# Brief Description

> We added a detach boolean on the `dotnet beam collector start` command that allowed the process to keep running if you pass the flag as false.

OBS: The collector keep running on the windows machines even if pass or not the detach boolean.