### PR TITLE
Fix - Issues when deserializing Content Type with Optional field with Attribte IgnoreContentField and fix performance issues in Unity

### DIFF
--- a/client/Packages/com.beamable/Common/Runtime/Content/ContentSerializer.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Content/ContentSerializer.cs
@@ -379,7 +379,7 @@ namespace Beamable.Common.Content
 
 				case ArrayDict dict:
 
-					var fields = GetFieldInfos(type);
+					var fields = GetFieldInfos(type, true);
 					var instance = Activator.CreateInstance(type);
 					foreach (var field in fields)
 					{
@@ -423,7 +423,7 @@ namespace Beamable.Common.Content
 			}
 		}
 
-		private List<FieldInfoWrapper> GetFieldInfos(Type type)
+		private List<FieldInfoWrapper> GetFieldInfos(Type type, bool useIgnoreField = false)
 		{
 			FieldInfoWrapper CreateFieldWrapper(FieldInfo field)
 			{
@@ -486,10 +486,10 @@ namespace Beamable.Common.Content
 				return field.GetCustomAttributes<SerializeField>() != null || field.GetCustomAttribute<ContentFieldAttribute>() != null;
 			});
 
-			var serializableFields = listOfPublicFields.Union(listOfPrivateFields);
+			var serializableFields = listOfPublicFields.Union(listOfPrivateFields).ToList();
 			var notIgnoredFields = serializableFields.Where(field => field.GetCustomAttribute<IgnoreContentFieldAttribute>() == null);
 
-			var ll = notIgnoredFields.Select(CreateFieldWrapper);
+			var ll = useIgnoreField ? serializableFields.Select(CreateFieldWrapper) : notIgnoredFields.Select(CreateFieldWrapper);
 
 
 			ll = ll.OrderBy(n => n.SerializedName);
@@ -668,7 +668,7 @@ namespace Beamable.Common.Content
 
 		private IContentObject BaseConvertType(ArrayDict root, bool disableExceptions, IContentObject instance, string itemId = null)
 		{
-			var fields = GetFieldInfos(instance.GetType());
+			var fields = GetFieldInfos(instance.GetType(), true);
 
 			var id = itemId ?? root["id"].ToString();
 

--- a/client/Packages/com.beamable/Editor/Server/Usam/UsamService_GenerateClient.cs
+++ b/client/Packages/com.beamable/Editor/Server/Usam/UsamService_GenerateClient.cs
@@ -234,7 +234,7 @@ namespace Beamable.Server.Editor.Usam
 							var writeTime = File.GetLastWriteTime(path).ToFileTime();
 							beamoIdToWriteTime[service.beamoId] = writeTime;
 						}
-						Reload();
+						UpdateUnityManifest(taskId);
 					}
 				}
 			}

--- a/client/Packages/com.beamable/Editor/Server/Usam/UsamService_Reload.cs
+++ b/client/Packages/com.beamable/Editor/Server/Usam/UsamService_Reload.cs
@@ -31,6 +31,15 @@ namespace Beamable.Server.Editor.Usam
 			//  been flushed yet. 
 			// await _ctx.BeamCli.OnReady;
 
+			Promise updatePromise = UpdateUnityManifest(taskId);
+			ListenForStatus();
+			ListenForDocker();
+			ListenForBuildChanges();
+			await updatePromise;
+		}
+
+		private Promise UpdateUnityManifest(int taskId)
+		{
 			var command = _cli.UnityManifest();
 
 			if (!_config.DisableAutoChecks)
@@ -80,10 +89,7 @@ namespace Beamable.Server.Editor.Usam
 			});
 			
 			var p = command.Run();
-			ListenForStatus();
-			ListenForDocker();
-			ListenForBuildChanges();
-			await p;
+			return p;
 		}
 
 		private void OnBeamEditorRealmChanged(RealmView realm)


### PR DESCRIPTION
fix: When deserializing a content type we still deserialize and set default value for ignored fields as they could be null (if optional types)

fix: Unity performance issues from UsamService_Reload reloading itself every single time.

