### PR TITLE
Feature - Unity - add a way to force regeneration of shared csproj files

### DIFF
--- a/client/Packages/com.beamable/Editor/Server/UI/UsamWindow/UsamWindow.cs
+++ b/client/Packages/com.beamable/Editor/Server/UI/UsamWindow/UsamWindow.cs
@@ -42,7 +42,7 @@ namespace Beamable.Editor.Microservice.UI2
 
 		[MenuItem(
 			Constants.MenuItems.Windows.Paths.MENU_ITEM_PATH_WINDOW_BEAMABLE + "/" +
-			"Force Generate Shared Project",
+			"Generate Assembly Definition Projects",
 			priority = Constants.MenuItems.Windows.Orders.MENU_ITEM_PATH_WINDOW_PRIORITY_1)]
 		public static void ForceGenerateSharedProject()
 		{

--- a/client/Packages/com.beamable/Editor/Server/UI/UsamWindow/UsamWindow_Service.cs
+++ b/client/Packages/com.beamable/Editor/Server/UI/UsamWindow/UsamWindow_Service.cs
@@ -254,7 +254,7 @@ namespace Beamable.Editor.Microservice.UI2
 				             {
 					             usam.ToggleServiceAutoGenerateClient(service.beamoId);
 				             });
-				menu.AddItem(new GUIContent("Force Generate shared libs"), false, () =>
+				menu.AddItem(new GUIContent("Generate Assembly Definition Projects"), false, () =>
 				{
 					CsProjUtil.OnPreGeneratingCSProjectFiles(usam);
 				});


### PR DESCRIPTION
# Ticket

https://github.com/beamable/BeamableProduct/issues/4229

# Brief Description

Two new ways to force generate C# Shared Libs
1. Top Bar Menu Item
<img width="550" height="176" alt="image" src="https://github.com/user-attachments/assets/2ea8c4a4-3132-4d84-a059-82e3f702f082" />
2. Menu Option on Beam Services
<img width="462" height="341" alt="image" src="https://github.com/user-attachments/assets/d5575fbd-bccf-4003-b6a5-c3d57adb09f1" />
