### PR TITLE
[issue/4365] Add way to disable otel entirely from Unity

### DIFF
--- a/client/Packages/com.beamable/Editor/BeamCli/UI/BeamCliWindow_Otel.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/UI/BeamCliWindow_Otel.cs
@@ -44,7 +44,13 @@ namespace Beamable.Editor.BeamCli.UI
 			string lastPublished = _unityOtelManager.OtelFileStatus.LastPublishTimestamp == 0
 				? "Never"
 				: DateTimeOffset.FromUnixTimeMilliseconds(_unityOtelManager.OtelFileStatus.LastPublishTimestamp).ToLocalTime().ToString("g");
+
+			bool otelEnabled = CoreConfiguration.Instance.EnableOtel.HasValue
+				? CoreConfiguration.Instance.EnableOtel.Value
+				: _unityOtelManager.TelemetryEnabled;
+
 			CoreConfiguration.Instance.EnableOtelAutoPublish = EditorGUILayout.Toggle("Auto-Publish", CoreConfiguration.Instance.EnableOtelAutoPublish, EditorStyles.boldLabel);
+			EditorGUILayout.LabelField("Otel Enabled: ", otelEnabled.ToString(), EditorStyles.boldLabel);
 			EditorGUILayout.LabelField("Last Published", lastPublished, EditorStyles.boldLabel);
 			EditorGUILayout.LabelField("Size:", $"{(float)_unityOtelManager.OtelFileStatus.FolderSize/(1024 * 1024):F} MB", EditorStyles.boldLabel);
 			EditorGUILayout.LabelField("Log Files Count: ", _unityOtelManager.OtelFileStatus.FileCount.ToString(), EditorStyles.boldLabel);

--- a/client/Packages/com.beamable/Editor/Utility/UnityOtelManager.cs
+++ b/client/Packages/com.beamable/Editor/Utility/UnityOtelManager.cs
@@ -52,6 +52,8 @@ namespace Beamable.Editor.Utility
 			"Unhandled exception"
 		};
 
+		public bool TelemetryEnabled => _telemetryEnabled;
+
 		private bool _telemetryEnabled;
 		private long _telemetryMaxSize;
 		private OtelLogLevel _telemetryLogLevel;
@@ -74,9 +76,6 @@ namespace Beamable.Editor.Utility
 			Application.wantsToQuit += OnUnityQuitting;
 			AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
 			CoreConfig.OnValidateCallback += OnCoreConfigChanged;
-
-			_telemetryLogLevel = CoreConfig.TelemetryMinLogLevel;
-			_telemetryMaxSize = CoreConfig.TelemetryMaxSize;
 			
 			_ = FetchOtelConfig();
 			_ = GetUnparsedCrashLogs();
@@ -261,18 +260,18 @@ namespace Beamable.Editor.Utility
 		
 		private void OnCoreConfigChanged()
 		{
-			if (CoreConfig.TelemetryMaxSize.Value == _telemetryMaxSize && CoreConfig.TelemetryMinLogLevel.Value == _telemetryLogLevel && CoreConfig.EnableOtel == _telemetryEnabled)
+			if (CoreConfig.TelemetryMaxSize.Value == _telemetryMaxSize && CoreConfig.TelemetryMinLogLevel.Value == _telemetryLogLevel && CoreConfig.EnableOtel.Value == _telemetryEnabled)
 			{
 				return;
 			}
 			_telemetryMaxSize = CoreConfig.TelemetryMaxSize.HasValue ? CoreConfig.TelemetryMaxSize.Value : _telemetryMaxSize;
 			_telemetryLogLevel = CoreConfig.TelemetryMinLogLevel.HasValue ? CoreConfig.TelemetryMinLogLevel.Value : _telemetryLogLevel;
-			_telemetryEnabled = CoreConfig.EnableOtel;
+			_telemetryEnabled = CoreConfig.EnableOtel.HasValue ? CoreConfig.EnableOtel.Value : _telemetryEnabled;
 			var commandWrapper = _cli.TelemetrySetConfig(new TelemetrySetConfigArgs()
 			{
 				cliLogLevel = _telemetryLogLevel.ToString(),
 				cliTelemetryMaxSize = _telemetryMaxSize.ToString(),
-				cliAllowTelemetry = CoreConfig.EnableOtel
+				cliAllowTelemetry = _telemetryEnabled
 			});
 			commandWrapper.Run();
 		}

--- a/client/Packages/com.beamable/Runtime/Modules/CoreConfiguration.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/CoreConfiguration.cs
@@ -129,7 +129,7 @@ The default is 60 seconds.
 		[Header("OTEL Configuration")]
 
 		[Tooltip("When true, Beamable SDK will collect Otel data")]
-		public bool EnableOtel = true;
+		public OptionalBool EnableOtel = new() {HasValue = false, Value = true};
 
 		[Tooltip("When true, Unity will auto publish OTEL logs to backend each X seconds. X is defined in the field below")]
 		public bool EnableOtelAutoPublish = true;


### PR DESCRIPTION
# Ticket

resolves #4365 

# Brief Description

This PR adds a way to disable otel completely through a configuration in the project settings (`Beamable/Editor/Core`)
