### PR TITLE
Faster content field finding

### DIFF
--- a/cli/beamable.common/Runtime/Content/ContentTypeReflectionCache.cs
+++ b/cli/beamable.common/Runtime/Content/ContentTypeReflectionCache.cs
@@ -335,7 +335,7 @@ namespace Beamable.Common.Content
 				field = string.Empty;
 				foreach (var key in keys)
 				{
-					if (key.SequenceEqual(FieldName))
+					if(string.Equals(key, FieldName, StringComparison.Ordinal))
 					{
 						field = key;
 						return true;
@@ -343,7 +343,7 @@ namespace Beamable.Common.Content
 
 					for (int i = 0; i < FormerlySerializedAs.Count; i++)
 					{
-						if (key.SequenceEqual(FormerlySerializedAs[i]))
+						if(string.Equals(key, FormerlySerializedAs[i], StringComparison.Ordinal))
 						{
 							field = key;
 						}


### PR DESCRIPTION
# Twice the speed, 95 percent less allocations

Looking at the `TryGetPropertyForField` in profiler.
4.0 version(6,8 kb allocated, 0.27s spend):
<img width="909" height="139" alt="image" src="https://github.com/user-attachments/assets/57981822-a294-4a92-96d9-7196e854a492" />
Proposed version: 
<img width="987" height="178" alt="image" src="https://github.com/user-attachments/assets/e43927d2-f9b7-452a-bd7e-e3d8e90c5187" />
