### PR TITLE
Fix validation case issue for rewards in `game_types` content

### DIFF
--- a/cli/beamable.common/Runtime/Content/Validation/MustReferenceContent.cs
+++ b/cli/beamable.common/Runtime/Content/Validation/MustReferenceContent.cs
@@ -142,7 +142,13 @@ namespace Beamable.Common.Content.Validation
 					var typeField = fieldType.GetField("type");
 					if (typeField != null)
 					{
-						string typeValue = typeField.GetValue(field.Target).ToString();
+						var typeValueBase = typeField.GetValue(field.Target);
+
+						string typeValue = typeValueBase.ToString();
+						if (typeValueBase.GetType().IsEnum)
+						{
+							typeValue = typeValue.ToLowerInvariant();
+						}
 						if (!string.IsNullOrWhiteSpace(typeValue))
 						{
 							string fullId = $"{typeValue}.{contentName}";

--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - `content ps -w` no longer hangs forever when invoked from CLI server 
+- validation case issue for rewards in `game_types` content 
 
 ## [6.2.2]
 ### Changed


### PR DESCRIPTION
I had this issue with Validation changing my reward id from `currency.Coins` to `Currency.Coins` because the `type` field where it was reading the value from was not string with value `currency` like in many other cases but the `Beamable.Common.Content.RewardType` enum with one variant `Currency`.

This change is a fix for it.
<img width="3552" height="1527" alt="image" src="https://github.com/user-attachments/assets/32acc9fa-9b2c-4462-a41c-925a50b3d696" />
