### PR TITLE
Microservice build- Specify the output path for the app binaries

### DIFF
--- a/cli/cli/Commands/Project/BuildSolutionCommand.cs
+++ b/cli/cli/Commands/Project/BuildSolutionCommand.cs
@@ -28,10 +28,10 @@ public class BuildSolutionCommandResults
 }
 public class BuildSolutionCommand : StreamCommand<BuildSolutionCommandArgs, BuildSolutionCommandResults>
 {
-    
+
     // I haven't thought too hard about this yet; this command
     //  was developed as a way to test solution-level building
-    //  for usage in the plan/release flows. 
+    //  for usage in the plan/release flows.
     public override bool IsForInternalUse => true;
 
     public BuildSolutionCommand() : base("build-sln", "Builds all local projects with a temp solution file")
@@ -59,15 +59,15 @@ public class BuildSolutionCommand : StreamCommand<BuildSolutionCommandArgs, Buil
         }
     }
 
-    public static async Task<Dictionary<string, BuildImageSourceOutput>> Build<TArgs>(TArgs args, 
+    public static async Task<Dictionary<string, BuildImageSourceOutput>> Build<TArgs>(TArgs args,
         bool forDeployment=true,
         bool forceCpu=true)
         where TArgs : CommandArgs, IHasSolutionFileArg
     {
         var beamo = args.BeamoLocalSystem;
         var resultMap = new Dictionary<string, BuildImageSourceOutput>();
-        
-        
+
+
         var buildDirRoot = Path.Combine("bin", "beamApp");
         var buildDirSupport = Path.Combine(buildDirRoot, "support");
         var buildDirApp = Path.Combine(buildDirRoot, "app");
@@ -119,12 +119,12 @@ public class BuildSolutionCommand : StreamCommand<BuildSolutionCommandArgs, Buil
                         //  /app folder.
                         $"-p:PublishDir={buildDirSupport.EnquotePath()} " +
                         /// trick- specify the output path for the app binaries
-                        $"-p:OutputPath={buildDirApp.EnquotePath()} "
+                        $"-p:OutputPath={buildDirApp.EnquotePath()} " +
                         // trick; do a "publish" command, but make nothing publishable.
                         //  this prevents any projects from actually being published
                         //  EXCEPT the ones that pay attention to the 'BeamPublish' flag.
                         //  Microservice projects override `IsPublishable` when `BeamPublish`
-                        //  is enabled. 
+                        //  is enabled.
                         $"-p:BeamPublish=\"true\"";
         
         Log.Verbose($"Running dotnet publish {buildArgs}");
@@ -133,12 +133,12 @@ public class BuildSolutionCommand : StreamCommand<BuildSolutionCommandArgs, Buil
         var command = CliExtensions.GetDotnetCommand(dotnetPath, buildArgs)
             .WithEnvironmentVariables(new Dictionary<string, string>
             {
-                ["DOTNET_WATCH_SUPPRESS_EMOJIS"] = "1", 
+                ["DOTNET_WATCH_SUPPRESS_EMOJIS"] = "1",
                 ["DOTNET_WATCH_RESTART_ON_RUDE_EDIT"] = "1",
-                
+
                 // control where the custom log file goes
                 [MsBuildSolutionLogger.LOG_PATH_ENV_VAR] = buildLogFile,
-                
+
                 // this makes it so that no projects publish, unless those projects
                 //  explicitly set the `IsPublishable` property to true. Our
                 //  microservices do this in the .props file when BeamPublish it set.
@@ -209,15 +209,15 @@ public class BuildSolutionCommand : StreamCommand<BuildSolutionCommandArgs, Buil
                     // this build has failed, and there is no point in file-copying...
                     continue;
                 }
-                
+
                 if (!Directory.Exists(result.outputDirSupport))
                 {
-                    // the build failed and there is nothing to move. 
+                    // the build failed and there is nothing to move.
                     continue;
                 }
-                
+
                 Directory.CreateDirectory(result.outputDirApp);
-                
+
                 var filesToMove = Directory.GetFiles(result.outputDirSupport, beamoId + ".*", SearchOption.TopDirectoryOnly);
                 foreach (var fileToMove in filesToMove)
                 {


### PR DESCRIPTION
# Issue

When I did create a new beam project from the CLI it all is working fine, I can create new service and `dotnet beam deploy plan` works fine. But when after creating new storage for that service docker builds stops working. I did a digging and find out that in my example the command that was run for build was:
```
dotnet publish BeamableServices.sln --verbosity minimal --no-self-contained --runtime unix-x64 -p:BeamPlatform=lin -p:BeamRunningArchitecture=x64 -p:BeamCollectorPlatformArchArg="--platform lin --arch x64"  --configuration Release -p:Deterministic="True" -p:BeamGenProps="disable" -p:GenerateClientCode="false" -p:CopyToLinkedProjects="false" -logger:"cli.Utils.MsBuildSolutionLogger,/Users/test/.nuget/packages/beamable.tools/6.2.1/tools/net9.0/any/Beamable.Tools.dll" -p:PublishDir="bin/beamApp/support" -p:BeamPublish="true"
```

Result of that command was that `services/ForgeService/bin/beamApp/support` got populated, but `services/ForgeService/bin/beamApp/app` was empty.  Adding `-p:OutputPath="bin/beamApp/app"` to that command fixed the problem. 

I assume this is the issue some of our customers are facing from time to time when they get `chmod: /beamApp/{ServiceName}.dll: No such file or directory` errors. At least this was my case.