### PR TITLE
Fix - Null values for ContentObject fields after creation

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Deserialization issue with `properties` field in Score Items of Events
 - Fixed an issue where the Unity Editor would not detect changes to Icon subObject (for Sprites in Multiple Mode) and thus not saving it correctly
+- Fixed an issue when creating a new Content Object some Optional and string values were null instead of default values.
 
 ### Changed
 - Added support to configure Max Parallel Service Build count on MicroserviceConfiguration.

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_ItemsPanel.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_ItemsPanel.cs
@@ -387,6 +387,9 @@ namespace Beamable.Editor.UI.ContentWindow
 			}
 			
 			var contentObject = CreateInstance(type) as ContentObject;
+			// Force Unity's serializer to instantiate all nested [Serializable] reference fields
+			// (e.g. Optional abd strings types) with proper default instances instead of leaving them null.
+			JsonUtility.FromJsonOverwrite(JsonUtility.ToJson(contentObject), contentObject);
 			string baseName = $"New_{itemType.Replace(".","_")}_";
 			int nextNumber = _contentService.GetContentsFromType(type)
 			                                .Select(item => item.Name)


### PR DESCRIPTION
Fixed an issue when creating a new Content Object some Optional and string values were null instead of default values.