### PR TITLE
Bump CLI_CURRENT_DOCS_VERSION from 6.1 to 7.0

### DIFF
--- a/cli/beamable.common/Runtime/Constants/Constants.cs
+++ b/cli/beamable.common/Runtime/Constants/Constants.cs
@@ -20,7 +20,7 @@ namespace Beamable.Common
 		public const string BEAM_STAGE_PORTAL_URI = "https://staging-portal.beamable.com";
 		public const string BEAM_DEV_PORTAL_URI = "https://dev-portal.beamable.com";
 		
-		public const string CLI_CURRENT_DOCS_VERSION = "6.1";
+		public const string CLI_CURRENT_DOCS_VERSION = "7.0";
 		
 		public const string OPEN_API_FILE_NAME = "beam_openApi.json";
 		public const string OPEN_API_DIR_PROPERTY_KEY = "OutDir";


### PR DESCRIPTION
## Summary

- Fixes #4586
- `CLI_CURRENT_DOCS_VERSION` was not bumped when the 7.x release was
  cut; all `Beamable.Microservice.SourceGen` diagnostic help links
  pointed at the 6.1 docs section even when running CLI 7.0.1.
- One-line change: `"6.1"` -> `"7.0"`.

## Test plan

- [ ] Build a microservice project that triggers any BEAM_SRV diagnostic
      (e.g. BEAM_SRV_0012 by using a non-serializable type in a
      `[ClientCallable]` method).
- [ ] Confirm the help link in the error output reads
      `https://help.beamable.com/CLI-7.0/...` rather than `CLI-6.1/...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)