### PR TITLE
[CLI] OTel config should enable/disable telemetry collector ps watcher

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue that considered types used in ServerCallable methods on Microservices to be generated to client code.
 - Creating microservices when CultureInfo is expecting `,` instead of `.` as the decimal separator.
 - Fix an issue where some summary tag were missing the closing tag, which produced a truncated summary tag.
+- Setting environment variable ``BEAM_NO_TELEMETRY`` or the ``BeamCliAllowTelemetry`` config now prevents collector ps process from starting
 
 ## [7.0.1] - 2026-04-02
 ### Fixed

--- a/cli/cli/Commands/OtelCommands/CollectorStatusCommand.cs
+++ b/cli/cli/Commands/OtelCommands/CollectorStatusCommand.cs
@@ -36,6 +36,15 @@ public class CollectorStatusCommand : StreamCommand<CollectorStatusCommandArgs, 
 
 	public override async Task Handle(CollectorStatusCommandArgs args)
 	{
+		var otelConfig = args.ConfigService.LoadOtelConfigFromFile();
+
+		if (!Otel.CliTracesEnabled() || !otelConfig.BeamCliAllowTelemetry) // if otel is disabled, then we don't start anything
+		{
+			Log.Trace("Trying to start collector ps, but telemetry is disabled.");
+			return;
+		}
+
+
 		CollectorManager.AddDefaultCollectorHostAndPortFallback();
 		
 		var port = Environment.GetEnvironmentVariable(Otel.ENV_COLLECTOR_PORT);


### PR DESCRIPTION
# Ticket

resolves #4590 

# Brief Description

This just checks if Otel is disabled and abort execution of the ps command if so.
