### PR TITLE
Adds visible Content Manager progress during realm sync/revert operations and improves content download resilience for large syncs

### DIFF
--- a/cli/cli/Commands/Content/ContentSyncCommand.cs
+++ b/cli/cli/Commands/Content/ContentSyncCommand.cs
@@ -22,6 +22,11 @@ public class ContentSyncCommand : AtomicCommand<ContentSyncCommandArgs, ContentS
 	private static ConfigurableOption TARGET_MANIFEST_UID_OPTION =
 		new("target", "If you pass in a Manifest's UID, we'll sync with that as the target. If filters are provided, will only do this for content that matches the filter");
 
+	private static Option<int> DOWNLOAD_MAX_PARALLEL_COUNT_OPTION = new(
+		"--download-max-parallel-count",
+		() => 64,
+		"Maximum number of content files to download in parallel while syncing. Use 0 for unbounded parallelism.");
+
 	private ContentService _contentService;
 
 	public ContentSyncCommand() : base("sync", "Synchronizes the local content matching the filters to the latest content stored in the realm")
@@ -38,6 +43,7 @@ public class ContentSyncCommand : AtomicCommand<ContentSyncCommandArgs, ContentS
 		AddOption(SYNC_CONFLICTS_OPTION, (args, b) => args.SyncConflicts = b);
 		AddOption(SYNC_DELETED_OPTION, (args, b) => args.SyncDeleted = b);
 		AddOption(TARGET_MANIFEST_UID_OPTION, (args, b) => args.TargetManifestUid = b);
+		AddOption(DOWNLOAD_MAX_PARALLEL_COUNT_OPTION, (args, i) => args.DownloadMaxParallelCount = i);
 	}
 
 	public override async Task<ContentSyncResult> GetResult(ContentSyncCommandArgs args)
@@ -49,7 +55,8 @@ public class ContentSyncCommand : AtomicCommand<ContentSyncCommandArgs, ContentS
 		foreach (var manifestId in args.ManifestIdsToReset)
 		{
 			var task = _contentService.SyncLocalContent(args.Lifecycle, manifestId, args.FilterType, args.Filter, args.SyncCreated,
-				args.SyncModified, args.SyncConflicts, args.SyncDeleted, args.TargetManifestUid, this.SendResults<ProgressStreamResultChannel, ContentProgressUpdateData>);
+				args.SyncModified, args.SyncConflicts, args.SyncDeleted, args.TargetManifestUid, this.SendResults<ProgressStreamResultChannel, ContentProgressUpdateData>,
+				args.DownloadMaxParallelCount);
 				
 			resetPromises.Add(task);
 		}
@@ -71,6 +78,7 @@ public class ContentSyncCommandArgs : ContentCommandArgs
 	public bool SyncConflicts;
 	public bool SyncDeleted;
 	public string TargetManifestUid;
+	public int DownloadMaxParallelCount;
 }
 
 [CliContractType]

--- a/cli/cli/Services/Content/ContentService.cs
+++ b/cli/cli/Services/Content/ContentService.cs
@@ -1253,8 +1253,14 @@ public partial class ContentService
 	}
 
 	/// <summary>
-	/// Determines whether a content download failure is likely transient and should be retried.
+	/// Determines whether a content download failure is likely caused by temporary transport or service pressure
+	/// and should be retried instead of failing the entire sync operation.
 	/// </summary>
+	/// <remarks>
+	/// Content sync can download hundreds or thousands of small files in parallel. In that scenario, occasional
+	/// TLS/socket resets, timeouts, rate limits, or temporary server errors can happen even when the content is valid.
+	/// Retrying only those transient failures prevents one short-lived network issue from aborting the full sync.
+	/// </remarks>
 	private static bool IsTransientContentDownloadException(Exception exception)
 	{
 		if (exception is RequesterException requesterException)

--- a/cli/cli/Services/Content/ContentService.cs
+++ b/cli/cli/Services/Content/ContentService.cs
@@ -78,6 +78,13 @@ public partial class ContentService
 	/// </summary>
 	private const string FAKE_EMPTY_MANIFEST_UID = "EmptyManifest";
 
+	private const int CONTENT_DOWNLOAD_MAX_ATTEMPTS = 4;
+	private const int DEFAULT_CONTENT_DOWNLOAD_MAX_CONCURRENCY = 64;
+	private const int CONTENT_DOWNLOAD_RETRY_BASE_DELAY_MS = 250;
+	private const int CONTENT_DOWNLOAD_RETRY_JITTER_MS = 250;
+
+	private static readonly HttpClient _contentDownloadClient = new(CreateContentDownloadHandler());
+
 	private readonly CliRequester _requester;
 	private readonly ConfigService _config;
 	private readonly IContentApi _contentApi;
@@ -942,10 +949,11 @@ public partial class ContentService
 	public async Task<ContentSyncReport> SyncLocalContent(AppLifecycle lifecycle, string manifestId,
 		ContentFilterType filterType = ContentFilterType.ExactIds, string[] filters = null,
 		bool deleteCreated = true, bool syncModified = true, bool forceSyncConflicts = true, bool syncDeleted = true,
-		string referenceManifestUid = "", Action<ContentProgressUpdateData> onContentSyncProgressUpdate = null)
+		string referenceManifestUid = "", Action<ContentProgressUpdateData> onContentSyncProgressUpdate = null,
+		int downloadMaxParallelCount = DEFAULT_CONTENT_DOWNLOAD_MAX_CONCURRENCY)
 	{
 		var targetManifest = await GetManifest(manifestId, referenceManifestUid, replaceLatest: string.IsNullOrEmpty(referenceManifestUid));
-		return await SyncLocalContent(targetManifest, manifestId, filterType, filters, deleteCreated, syncModified, forceSyncConflicts, syncDeleted, onContentSyncProgressUpdate, lifecycle.CancellationToken);
+		return await SyncLocalContent(targetManifest, manifestId, filterType, filters, deleteCreated, syncModified, forceSyncConflicts, syncDeleted, onContentSyncProgressUpdate, lifecycle.CancellationToken, downloadMaxParallelCount);
 	}
 
 	/// <summary>
@@ -954,7 +962,8 @@ public partial class ContentService
 	public async Task<ContentSyncReport> SyncLocalContent(ClientManifestJsonResponse targetManifest, string manifestId,
 		ContentFilterType filterType = ContentFilterType.ExactIds, string[] filters = null,
 		bool syncCreated = true, bool syncModified = true, bool forceSyncConflicts = true, bool syncDeleted = true,
-		Action<ContentProgressUpdateData> onContentSyncProgressUpdate = null, CancellationToken cancellationToken = default)
+		Action<ContentProgressUpdateData> onContentSyncProgressUpdate = null, CancellationToken cancellationToken = default,
+		int downloadMaxParallelCount = DEFAULT_CONTENT_DOWNLOAD_MAX_CONCURRENCY)
 	{
 		// Reset processed count when calling SyncLocalContent method
 		_syncProcessedCount = 0;
@@ -995,10 +1004,14 @@ public partial class ContentService
 		
 		// Download and overwrite the local content for things that have changed based on the hash or don't exist.
 		int totalItems = contentToDownload.Length + contentToDelete.Length;
+		using var contentDownloadSemaphore = downloadMaxParallelCount > 0 ? new SemaphoreSlim(downloadMaxParallelCount) : null;
 		var downloadPromises = contentToDownload.Select(async c => 
 		{
-			Log.Verbose("Downloading content with id. ID={Id}", c.Id);
-			
+			if (contentDownloadSemaphore != null)
+			{
+				await contentDownloadSemaphore.WaitAsync(cancellationToken);
+			}
+
 			ContentProgressUpdateData contentProgress = new ContentProgressUpdateData
 			{
 				totalItems = totalItems, 
@@ -1008,8 +1021,7 @@ public partial class ContentService
 			JsonElement customRequest;
 			try
 			{
-				customRequest = await _requester.CustomRequest(Method.GET, c.ReferenceContent.uri,
-					parser: s => JsonSerializer.Deserialize<JsonElement>(s));
+				customRequest = await DownloadContentFile(c, cancellationToken);
 			}
 			catch (HttpRequesterException exception)
 			{
@@ -1017,6 +1029,17 @@ public partial class ContentService
 				contentProgress.errorMessage = exception.Message;
 				onContentSyncProgressUpdate?.Invoke(contentProgress);
 				throw;
+			}
+			catch (Exception exception) when (!cancellationToken.IsCancellationRequested)
+			{
+				contentProgress.EventType = ContentProgressUpdateData.EVT_TYPE_SyncError;
+				contentProgress.errorMessage = exception.Message;
+				onContentSyncProgressUpdate?.Invoke(contentProgress);
+				throw;
+			}
+			finally
+			{
+				contentDownloadSemaphore?.Release();
 			}
 
 			contentProgress.EventType = ContentProgressUpdateData.EVT_TYPE_SyncComplete;
@@ -1161,6 +1184,71 @@ public partial class ContentService
 		{
 			_fileSystemOperationSemaphore.Release();
 		}
+	}
+
+	private async Task<JsonElement> DownloadContentFile(ContentFile contentFile, CancellationToken cancellationToken)
+	{
+		for (var attempt = 1; attempt <= CONTENT_DOWNLOAD_MAX_ATTEMPTS; attempt++)
+		{
+			try
+			{
+				using var response = await _contentDownloadClient.GetAsync(contentFile.ReferenceContent.uri, cancellationToken);
+				await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+				using var reader = new StreamReader(stream, Encoding.UTF8);
+				var rawResponse = await reader.ReadToEndAsync();
+
+				if (!response.IsSuccessStatusCode)
+				{
+					throw new RequesterException("Cli", Method.GET.ToReadableString(), contentFile.ReferenceContent.uri, (int)response.StatusCode, rawResponse);
+				}
+
+				return JsonSerializer.Deserialize<JsonElement>(rawResponse);
+			}
+			catch (Exception exception) when (!cancellationToken.IsCancellationRequested && IsTransientContentDownloadException(exception) && attempt < CONTENT_DOWNLOAD_MAX_ATTEMPTS)
+			{
+				var delay = GetContentDownloadRetryDelay(attempt);
+				Log.Warning($"Transient content download failure. Retrying content-id=[{contentFile.Id}] attempt=[{attempt + 1}/{CONTENT_DOWNLOAD_MAX_ATTEMPTS}] delay-ms=[{delay.TotalMilliseconds}] error=[{exception.GetType().Name}] message=[{exception.Message}]");
+				await Task.Delay(delay, cancellationToken);
+			}
+		}
+
+		throw new InvalidOperationException($"Content download retry loop exited unexpectedly. content-id=[{contentFile.Id}]");
+	}
+
+	private static HttpClientHandler CreateContentDownloadHandler()
+	{
+		return new HttpClientHandler
+		{
+			MaxConnectionsPerServer = int.MaxValue,
+			UseCookies = false
+		};
+	}
+
+	private static TimeSpan GetContentDownloadRetryDelay(int failedAttempt)
+	{
+		var exponentialDelayMs = CONTENT_DOWNLOAD_RETRY_BASE_DELAY_MS * (1 << (failedAttempt - 1));
+		var jitterMs = Random.Shared.Next(0, CONTENT_DOWNLOAD_RETRY_JITTER_MS);
+		return TimeSpan.FromMilliseconds(exponentialDelayMs + jitterMs);
+	}
+
+	private static bool IsTransientContentDownloadException(Exception exception)
+	{
+		if (exception is RequesterException requesterException)
+		{
+			return requesterException.Status is 408 or 429 || requesterException.Status >= 500 && requesterException.Status < 600;
+		}
+
+		if (exception is HttpRequestException || exception is TimeoutException)
+		{
+			return true;
+		}
+
+		if (exception is TaskCanceledException)
+		{
+			return true;
+		}
+
+		return exception.InnerException != null && IsTransientContentDownloadException(exception.InnerException);
 	}
 
 

--- a/cli/cli/Services/Content/ContentService.cs
+++ b/cli/cli/Services/Content/ContentService.cs
@@ -83,6 +83,12 @@ public partial class ContentService
 	private const int CONTENT_DOWNLOAD_RETRY_BASE_DELAY_MS = 250;
 	private const int CONTENT_DOWNLOAD_RETRY_JITTER_MS = 250;
 
+	/// <summary>
+	/// Shared client for CDN content-file downloads during sync.
+	/// </summary>
+	/// <remarks>
+	/// This intentionally bypasses the generic CLI requester to avoid per-file verbose request/response logging while preserving connection reuse.
+	/// </remarks>
 	private static readonly HttpClient _contentDownloadClient = new(CreateContentDownloadHandler());
 
 	private readonly CliRequester _requester;
@@ -1186,6 +1192,12 @@ public partial class ContentService
 		}
 	}
 
+	/// <summary>
+	/// Downloads a single content file from its remote content URI with transient retry handling.
+	/// </summary>
+	/// <remarks>
+	/// Content sync may download hundreds or thousands of small files. This path keeps those downloads off the generic requester so Unity does not receive a verbose log event for every response body.
+	/// </remarks>
 	private async Task<JsonElement> DownloadContentFile(ContentFile contentFile, CancellationToken cancellationToken)
 	{
 		for (var attempt = 1; attempt <= CONTENT_DOWNLOAD_MAX_ATTEMPTS; attempt++)
@@ -1215,6 +1227,12 @@ public partial class ContentService
 		throw new InvalidOperationException($"Content download retry loop exited unexpectedly. content-id=[{contentFile.Id}]");
 	}
 
+	/// <summary>
+	/// Creates the HTTP handler used by the shared content download client.
+	/// </summary>
+	/// <remarks>
+	/// The sync command owns concurrency limits separately, so the handler allows a high per-server connection ceiling.
+	/// </remarks>
 	private static HttpClientHandler CreateContentDownloadHandler()
 	{
 		return new HttpClientHandler
@@ -1224,6 +1242,9 @@ public partial class ContentService
 		};
 	}
 
+	/// <summary>
+	/// Calculates exponential retry delay with jitter for a failed content download attempt.
+	/// </summary>
 	private static TimeSpan GetContentDownloadRetryDelay(int failedAttempt)
 	{
 		var exponentialDelayMs = CONTENT_DOWNLOAD_RETRY_BASE_DELAY_MS * (1 << (failedAttempt - 1));
@@ -1231,6 +1252,9 @@ public partial class ContentService
 		return TimeSpan.FromMilliseconds(exponentialDelayMs + jitterMs);
 	}
 
+	/// <summary>
+	/// Determines whether a content download failure is likely transient and should be retried.
+	/// </summary>
 	private static bool IsTransientContentDownloadException(Exception exception)
 	{
 		if (exception is RequesterException requesterException)

--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added in-window Content Manager progress for sync and revert operations.
+- Added editor content sync download concurrency configuration.
+
 ### Fixed
+- Improved content sync resilience for transient SSL/socket reset download failures.
 - Deserialization issue with `properties` field in Score Items of Events
 - Fixed an issue where the Unity Editor would not detect changes to Icon subObject (for Sprites in Multiple Mode) and thus not saving it correctly
 <<<<<<< fix/contentNullFields

--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -14,11 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved content sync resilience for transient SSL/socket reset download failures.
 - Deserialization issue with `properties` field in Score Items of Events
 - Fixed an issue where the Unity Editor would not detect changes to Icon subObject (for Sprites in Multiple Mode) and thus not saving it correctly
-<<<<<<< fix/contentNullFields
 - Fixed an issue when creating a new Content Object some Optional and string values were null instead of default values.
-=======
 - Fix issue where Critical log errors where not being parsed to Unity LogLevels.
->>>>>>> main
 
 ### Changed
 - Added support to configure Max Parallel Service Build count on MicroserviceConfiguration.

--- a/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentSync.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/Commands/BeamContentSync.cs
@@ -26,6 +26,8 @@ namespace Beamable.Editor.BeamCli.Commands
         public bool syncDeleted;
         /// <summary>If you pass in a Manifest's UID, we'll sync with that as the target. If filters are provided, will only do this for content that matches the filter</summary>
         public string target;
+        /// <summary>Maximum number of content files to download in parallel while syncing. Use 0 for unbounded parallelism.</summary>
+        public int downloadMaxParallelCount;
         /// <summary>Serializes the arguments for command line usage.</summary>
         public virtual string Serialize()
         {
@@ -74,6 +76,11 @@ namespace Beamable.Editor.BeamCli.Commands
             if ((this.target != default(string)))
             {
                 genBeamCommandArgs.Add(("--target=" + this.target));
+            }
+            // If the downloadMaxParallelCount value was not default, then add it to the list of args.
+            if ((this.downloadMaxParallelCount != default(int)))
+            {
+                genBeamCommandArgs.Add(("--download-max-parallel-count=" + this.downloadMaxParallelCount));
             }
             string genBeamCommandStr = "";
             // Join all the args with spaces

--- a/client/Packages/com.beamable/Editor/ContentService/CliContentService.cs
+++ b/client/Packages/com.beamable/Editor/ContentService/CliContentService.cs
@@ -20,6 +20,18 @@ using Object = UnityEngine.Object;
 
 namespace Beamable.Editor.ContentService
 {
+	public class ContentOperationProgress
+	{
+		public bool IsActive;
+		public bool HasError;
+		public string Title = string.Empty;
+		public string Description = string.Empty;
+		public string CurrentContentName = string.Empty;
+		public int ProcessedItems;
+		public int TotalItems;
+		public float Progress;
+	}
+
 	public class CliContentService : IStorageHandler<CliContentService>, ILoadWithContext
 	{
 		private const string SYNC_OPERATION_TITLE = "Sync Contents";
@@ -46,6 +58,7 @@ namespace Beamable.Editor.ContentService
 		private int syncedContents;
 		private int publishedContents;
 		private readonly Dictionary<string, string> _lastSavedPropertiesCache = new();
+		private bool _showUnityModalProgress;
 		
 		[NonSerialized]
 		public bool isReloading;
@@ -55,6 +68,8 @@ namespace Beamable.Editor.ContentService
 
 		private readonly Dictionary<string, ContentObject> _contentScriptableCache;
 		public BeamContentPsProgressMessage LatestProgressUpdate;
+		public ContentOperationProgress CurrentProgress { get; } = new();
+		public int ProgressUpdateVersion { get; private set; }
 		private readonly ContentConfiguration _contentConfiguration;
 
 		private ValidationContext ValidationContext => _provider.GetService<ValidationContext>();
@@ -205,11 +220,12 @@ namespace Beamable.Editor.ContentService
 		                                           bool syncConflicted,
 		                                           bool syncDeleted,
 		                                           string filter = null,
-		                                           ContentFilterType filterType = default)
+		                                           ContentFilterType filterType = default,
+		                                           bool showUnityModalProgress = false)
 		{
 
 			syncedContents = 0;
-			EditorUtility.DisplayProgressBar(SYNC_OPERATION_TITLE, "Synchronizing contents...", 0);
+			BeginActionProgress(SYNC_OPERATION_TITLE, "Synchronizing contents...", showUnityModalProgress);
 			try
 			{
 				if (_contentWatcher != null)
@@ -226,6 +242,7 @@ namespace Beamable.Editor.ContentService
 					syncDeleted = syncDeleted,
 					filter = filter,
 					filterType = filterType,
+					downloadMaxParallelCount = GetEditorSyncDownloadMaxParallelCountCliOption(),
 					
 				});
 
@@ -259,6 +276,7 @@ namespace Beamable.Editor.ContentService
 				syncDeleted = syncDeleted,
 				filter = filter,
 				filterType = filterType,
+				downloadMaxParallelCount = GetEditorSyncDownloadMaxParallelCountCliOption(),
 			});
 			
 			await contentSyncCommand.Run();
@@ -421,7 +439,7 @@ namespace Beamable.Editor.ContentService
 		
 		public async Promise PublishContentsWithProgress()
 		{
-			EditorUtility.DisplayProgressBar(PUBLISH_OPERATION_TITLE, "Publishing contents...", 0);
+			BeginActionProgress(PUBLISH_OPERATION_TITLE, "Publishing contents...", true);
 			publishedContents = 0;
 			
 			try
@@ -451,8 +469,44 @@ namespace Beamable.Editor.ContentService
 
 		private void FinishActionProgress()
 		{
-			EditorUtility.ClearProgressBar();
+			if (_showUnityModalProgress)
+			{
+				EditorUtility.ClearProgressBar();
+			}
+
+			CurrentProgress.IsActive = false;
+			ProgressUpdateVersion++;
 			_ = Reload();
+		}
+
+		private void BeginActionProgress(string title, string description, bool showUnityModalProgress)
+		{
+			_showUnityModalProgress = showUnityModalProgress;
+			CurrentProgress.IsActive = true;
+			CurrentProgress.Title = title;
+			CurrentProgress.Description = description;
+			CurrentProgress.CurrentContentName = string.Empty;
+			CurrentProgress.ProcessedItems = 0;
+			CurrentProgress.TotalItems = 0;
+			CurrentProgress.Progress = 0;
+			CurrentProgress.HasError = false;
+			ProgressUpdateVersion++;
+
+			if (_showUnityModalProgress)
+			{
+				EditorUtility.DisplayProgressBar(title, description, 0);
+			}
+		}
+
+		private int GetEditorSyncDownloadMaxParallelCountCliOption()
+		{
+			if (_contentConfiguration.EditorSyncDownloadMaxParallelCount?.HasValue != true)
+			{
+				return default;
+			}
+
+			var value = _contentConfiguration.EditorSyncDownloadMaxParallelCount.Value;
+			return value == 0 ? -1 : value;
 		}
 
 		public async Task PublishContents()
@@ -908,13 +962,23 @@ namespace Beamable.Editor.ContentService
 		                                string onSuccessBaseMessage,
 		                                string onErrorBaseMessage, ref int countItem)
 		{
-			string description = string.Empty;
-			float progress = (float)countItem / data.totalItems;
+			int totalItems = Math.Max(data.totalItems, 0);
+			string description = CurrentProgress.Description;
+			float progress = totalItems == 0 ? 0 : Mathf.Clamp01((float)countItem / totalItems);
+			int processedItemsForDisplay = countItem;
 
 			switch (data.EventType)
 			{
 				case 0: // Error on Content Progress Update
-					EditorUtility.ClearProgressBar();
+					CurrentProgress.HasError = true;
+					CurrentProgress.CurrentContentName = data.contentName;
+					CurrentProgress.TotalItems = totalItems;
+					CurrentProgress.Description = string.Format(onErrorBaseMessage, data.contentName, data.errorMessage);
+					ProgressUpdateVersion++;
+					if (_showUnityModalProgress)
+					{
+						EditorUtility.ClearProgressBar();
+					}
 					EditorUtility.DisplayDialog(
 						operationTitle,
 						string.Format(onErrorBaseMessage, data.contentName, data.errorMessage),
@@ -923,14 +987,33 @@ namespace Beamable.Editor.ContentService
 					return;
 				case 1: // Sync Complete
 				case 2: // Publish Complete
-					description = string.Format(onSuccessBaseMessage, data.contentName, countItem, data.totalItems);
+					CurrentProgress.CurrentContentName = data.contentName;
+					int visibleCount = totalItems == 0 ? 0 : Mathf.Min(totalItems, countItem + 1);
+					processedItemsForDisplay = visibleCount;
+					description = string.Format(onSuccessBaseMessage, data.contentName, visibleCount, totalItems);
+					progress = totalItems == 0 ? 1 : Mathf.Clamp01((float)visibleCount / totalItems);
 					break;
 				case 3: // Update Processed item count
 					countItem = data.processedItems;
+					processedItemsForDisplay = totalItems == 0 ? countItem : Mathf.Min(countItem, totalItems);
+					progress = totalItems == 0 ? 1 : Mathf.Clamp01((float)processedItemsForDisplay / totalItems);
+					description = totalItems == 0
+						? $"{operationTitle} complete."
+						: $"{processedItemsForDisplay}/{totalItems} items processed.";
 					break;
 			}
 
-			EditorUtility.DisplayProgressBar(operationTitle, description, progress);
+			CurrentProgress.Title = operationTitle;
+			CurrentProgress.Description = description;
+			CurrentProgress.ProcessedItems = processedItemsForDisplay;
+			CurrentProgress.TotalItems = totalItems;
+			CurrentProgress.Progress = progress;
+			ProgressUpdateVersion++;
+
+			if (_showUnityModalProgress)
+			{
+				EditorUtility.DisplayProgressBar(operationTitle, description, progress);
+			}
 		}
 
 		public void SetManifestId(string id)

--- a/client/Packages/com.beamable/Editor/ContentService/CliContentService.cs
+++ b/client/Packages/com.beamable/Editor/ContentService/CliContentService.cs
@@ -20,6 +20,9 @@ using Object = UnityEngine.Object;
 
 namespace Beamable.Editor.ContentService
 {
+	/// <summary>
+	/// Tracks the currently running content operation so the Content Manager can render progress inside the window.
+	/// </summary>
 	public class ContentOperationProgress
 	{
 		public bool IsActive;
@@ -68,7 +71,13 @@ namespace Beamable.Editor.ContentService
 
 		private readonly Dictionary<string, ContentObject> _contentScriptableCache;
 		public BeamContentPsProgressMessage LatestProgressUpdate;
+		/// <summary>
+		/// Current publish or sync progress state consumed by the Content Manager IMGUI view.
+		/// </summary>
 		public ContentOperationProgress CurrentProgress { get; } = new();
+		/// <summary>
+		/// Monotonic value incremented when <see cref="CurrentProgress"/> changes so the Content Manager can repaint on demand.
+		/// </summary>
 		public int ProgressUpdateVersion { get; private set; }
 		private readonly ContentConfiguration _contentConfiguration;
 
@@ -467,6 +476,9 @@ namespace Beamable.Editor.ContentService
 			}
 		}
 
+		/// <summary>
+		/// Finishes the active content operation, clears any modal progress UI, and reloads local content state.
+		/// </summary>
 		private void FinishActionProgress()
 		{
 			if (_showUnityModalProgress)
@@ -479,6 +491,9 @@ namespace Beamable.Editor.ContentService
 			_ = Reload();
 		}
 
+		/// <summary>
+		/// Initializes progress state for a content operation. Sync can use in-window progress only, while publish can still opt into Unity's modal progress UI.
+		/// </summary>
 		private void BeginActionProgress(string title, string description, bool showUnityModalProgress)
 		{
 			_showUnityModalProgress = showUnityModalProgress;
@@ -498,6 +513,12 @@ namespace Beamable.Editor.ContentService
 			}
 		}
 
+		/// <summary>
+		/// Converts the optional editor sync concurrency setting to the CLI argument value.
+		/// </summary>
+		/// <remarks>
+		/// Returning the default int omits the CLI argument, allowing the CLI default to apply. A configured value of 0 maps to -1 so the generated command includes an explicit unbounded setting.
+		/// </remarks>
 		private int GetEditorSyncDownloadMaxParallelCountCliOption()
 		{
 			if (_contentConfiguration.EditorSyncDownloadMaxParallelCount?.HasValue != true)

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow.cs
@@ -31,6 +31,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		private ContentConfiguration _contentConfiguration;
 		private Vector2 _horizontalScrollPosition;
 		private int _lastManifestChangedCount;
+		private int _lastProgressUpdateVersion;
 		private EditorGUISplitView _mainSplitter;
 
 		static ContentWindow()
@@ -109,6 +110,12 @@ namespace Beamable.Editor.UI.ContentWindow
 				ReloadData();
 				Repaint(); 
 			}
+
+			if (_contentService != null && _contentService.ProgressUpdateVersion != _lastProgressUpdateVersion)
+			{
+				_lastProgressUpdateVersion = _contentService.ProgressUpdateVersion;
+				Repaint();
+			}
 		}
 
 		private void ReloadData()
@@ -119,7 +126,7 @@ namespace Beamable.Editor.UI.ContentWindow
 			
 			if(!_contentService.HasChangedContents && _windowStatus != ContentWindowStatus.SnapshotManager)
 			{
-				ChangeWindowStatus(ContentWindowStatus.Normal);
+				ChangeWindowStatusDelayed(ContentWindowStatus.Normal);
 			}
 		}
 

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_ContentActions.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_ContentActions.cs
@@ -267,6 +267,10 @@ namespace Beamable.Editor.UI.ContentWindow
 			EditorGUILayout.EndVertical();
 		}
 
+		/// <summary>
+		/// Draws the active content operation progress bar in the Content Manager action panel.
+		/// </summary>
+		/// <returns>True when progress UI was drawn and the caller should reserve spacing for it.</returns>
 		private bool DrawContentOperationProgress()
 		{
 			var progress = _contentService.CurrentProgress;

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_ContentActions.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_ContentActions.cs
@@ -31,7 +31,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		{
 			if (_contentService.HasConflictedContent || _contentService.HasInvalidContent || !_contentService.HasChangedContents)
 			{
-				ChangeWindowStatus(ContentWindowStatus.Normal);
+				ChangeWindowStatusDelayed(ContentWindowStatus.Normal);
 				return;
 			}
 			
@@ -43,7 +43,7 @@ namespace Beamable.Editor.UI.ContentWindow
 				{
 					_contentService.PublishContentsWithProgress().Then(_ =>
 					{
-						ChangeWindowStatus(ContentWindowStatus.Normal);
+						ChangeWindowStatusDelayed(ContentWindowStatus.Normal);
 					});
 				}
 			}
@@ -55,9 +55,9 @@ namespace Beamable.Editor.UI.ContentWindow
 		
 		private void DrawRevertPanel()
 		{
-			if (!_contentService.HasChangedContents)
+			if (!_contentService.HasChangedContents && !_contentService.CurrentProgress.IsActive)
 			{
-				ChangeWindowStatus(ContentWindowStatus.Normal);
+				ChangeWindowStatusDelayed(ContentWindowStatus.Normal);
 				return;
 			}
 			
@@ -69,7 +69,7 @@ namespace Beamable.Editor.UI.ContentWindow
 				{ 
 					_revertAction?.Invoke().Then(_ =>
 					{
-						ChangeWindowStatus(ContentWindowStatus.Normal);
+						ChangeWindowStatusDelayed(ContentWindowStatus.Normal);
 					});
 				}
 			}
@@ -195,7 +195,7 @@ namespace Beamable.Editor.UI.ContentWindow
 			GUILayout.FlexibleSpace();
 			if (BeamGUI.CancelButton("Back", GUILayout.Width(60)))
 			{
-				ChangeWindowStatus(ContentWindowStatus.Normal);
+				ChangeWindowStatusDelayed(ContentWindowStatus.Normal);
 			}
 		}
 		
@@ -240,24 +240,61 @@ namespace Beamable.Editor.UI.ContentWindow
 			EditorGUILayout.EndScrollView();
 			
 			EditorGUILayout.Space(12);
+
+			if (DrawContentOperationProgress())
+			{
+				EditorGUILayout.Space(12);
+			}
 			
 			var buttonsRect = EditorGUILayout.GetControlRect(GUILayout.ExpandWidth(true), GUILayout.Height(30f));
 			var buttonsRectController = new EditorGUIRectController(buttonsRect);
 			var primaryBtnContent = new GUIContent(buttonText);
 			var primaryBtnSize = GUI.skin.button.CalcSize(primaryBtnContent);
 			
-			if (BeamGUI.PrimaryButton(buttonsRectController.ReserveWidthFromRight(primaryBtnSize.x + BASE_PADDING * 2), primaryBtnContent))
+			if (BeamGUI.ShowDisabled(!_contentService.CurrentProgress.IsActive,
+			                         () => BeamGUI.PrimaryButton(buttonsRectController.ReserveWidthFromRight(primaryBtnSize.x + BASE_PADDING * 2), primaryBtnContent)))
 			{
 				onButtonClicked?.Invoke();
 			}
 			var cancelBtnContent = new GUIContent("Cancel");
 			var cancelBtnSize = GUI.skin.button.CalcSize(cancelBtnContent);
-			if (BeamGUI.CustomButton(buttonsRectController.ReserveWidthFromRight(cancelBtnSize.x + BASE_PADDING * 2), cancelBtnContent, BeamGUI.ColorizeButton(Color.gray)))
+			if (BeamGUI.ShowDisabled(!_contentService.CurrentProgress.IsActive,
+			                         () => BeamGUI.CustomButton(buttonsRectController.ReserveWidthFromRight(cancelBtnSize.x + BASE_PADDING * 2), cancelBtnContent, BeamGUI.ColorizeButton(Color.gray))))
 			{
-				ChangeWindowStatus(ContentWindowStatus.Normal);
+				ChangeWindowStatusDelayed(ContentWindowStatus.Normal);
 			}
 
 			EditorGUILayout.EndVertical();
+		}
+
+		private bool DrawContentOperationProgress()
+		{
+			var progress = _contentService.CurrentProgress;
+			if (!progress.IsActive)
+			{
+				return false;
+			}
+
+			var progressAction = progress.Title == "Publish Contents" ? "published" : "synced";
+			var progressText = progress.TotalItems > 0
+				? $"{progress.ProcessedItems}/{progress.TotalItems} items {progressAction}"
+				: $"Preparing {progress.Title.ToLowerInvariant()}...";
+
+			if (!string.IsNullOrEmpty(progress.CurrentContentName))
+			{
+				progressText = $"{progressText} - {progress.CurrentContentName}";
+			}
+
+			EditorGUILayout.LabelField(progress.Title, EditorStyles.boldLabel);
+			var progressRect = EditorGUILayout.GetControlRect(GUILayout.ExpandWidth(true), GUILayout.Height(20));
+			EditorGUI.ProgressBar(progressRect, progress.Progress, progressText);
+
+			if (!string.IsNullOrEmpty(progress.Description))
+			{
+				EditorGUILayout.LabelField(progress.Description, _contentHeaderDescriptionStyle);
+			}
+
+			return true;
 		}
 
 		private void DrawChangedContents(float width,

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_Header.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_Header.cs
@@ -260,6 +260,12 @@ namespace Beamable.Editor.UI.ContentWindow
 				Repaint();
 		}
 
+		/// <summary>
+		/// Defers Content Manager state changes until the current IMGUI event has finished.
+		/// </summary>
+		/// <remarks>
+		/// Some state transitions remove or add controls. Deferring them avoids mismatched layout groups during repaint.
+		/// </remarks>
 		private void ChangeWindowStatusDelayed(ContentWindowStatus windowStatus)
 		{
 			EditorApplication.delayCall += () => ChangeWindowStatus(windowStatus);

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_Header.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_Header.cs
@@ -119,7 +119,7 @@ namespace Beamable.Editor.UI.ContentWindow
 			{
 				if (BeamGUI.HeaderButton("Content Editor", BeamGUI.iconContentEditorIcon, width: 90, iconPadding: 2))
 				{
-					ChangeWindowStatus(ContentWindowStatus.Normal);
+					ChangeWindowStatusDelayed(ContentWindowStatus.Normal);
 				}
 			}
 			if (_windowStatus is ContentWindowStatus.Normal || _windowStatus is ContentWindowStatus.Validate)
@@ -258,6 +258,11 @@ namespace Beamable.Editor.UI.ContentWindow
 
 			if(shouldRepaint)
 				Repaint();
+		}
+
+		private void ChangeWindowStatusDelayed(ContentWindowStatus windowStatus)
+		{
+			EditorApplication.delayCall += () => ChangeWindowStatus(windowStatus);
 		}
 
 		private void DrawLowBarHeader(Rect rect)
@@ -420,27 +425,27 @@ namespace Beamable.Editor.UI.ContentWindow
 
 		private async Promise RevertAllContents()
 		{
-			await _contentService.SyncContentsWithProgress(true, true, true, true);
+			await _contentService.SyncContentsWithProgress(true, true, true, true, showUnityModalProgress: false);
 		}
 
 		private async Promise RevertModifiedContents()
 		{
-			await _contentService.SyncContentsWithProgress(true, false, false, false);
+			await _contentService.SyncContentsWithProgress(true, false, false, false, showUnityModalProgress: false);
 		}
 
 		private async Promise RevertConflictedContents()
 		{
-			await _contentService.SyncContentsWithProgress(false, false, true, false);
+			await _contentService.SyncContentsWithProgress(false, false, true, false, showUnityModalProgress: false);
 		}
 
 		private async Promise RevertDeletedContents()
 		{
-			await _contentService.SyncContentsWithProgress(false, false, false, true);
+			await _contentService.SyncContentsWithProgress(false, false, false, true, showUnityModalProgress: false);
 		}
 
 		private async Promise RevertAllNewContents()
 		{
-			await _contentService.SyncContentsWithProgress(false, true, false, false);
+			await _contentService.SyncContentsWithProgress(false, true, false, false, showUnityModalProgress: false);
 		}
 
 		

--- a/client/Packages/com.beamable/Runtime/Modules/Content/ContentConfiguration.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/Content/ContentConfiguration.cs
@@ -33,6 +33,9 @@ namespace Beamable.Content
         [Tooltip("In editor, when downloading content, this controls the batch size of the download. By default, it is 100.")]
         public OptionalInt EditorDownloadBatchSize;
 
+        /// <summary>
+        /// Controls the maximum parallel content-file downloads used by editor content sync. Leave unset to use the CLI default; use 0 for unbounded parallelism.
+        /// </summary>
         [Tooltip("In editor, when syncing content from the realm, this controls how many content files can be downloaded in parallel. Leave unset to use the CLI default. Use 0 for unbounded parallelism.")]
         public OptionalInt EditorSyncDownloadMaxParallelCount;
 #endif

--- a/client/Packages/com.beamable/Runtime/Modules/Content/ContentConfiguration.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/Content/ContentConfiguration.cs
@@ -32,6 +32,9 @@ namespace Beamable.Content
 
         [Tooltip("In editor, when downloading content, this controls the batch size of the download. By default, it is 100.")]
         public OptionalInt EditorDownloadBatchSize;
+
+        [Tooltip("In editor, when syncing content from the realm, this controls how many content files can be downloaded in parallel. Leave unset to use the CLI default. Use 0 for unbounded parallelism.")]
+        public OptionalInt EditorSyncDownloadMaxParallelCount;
 #endif
 
 		[Tooltip("When enabled, content checksum will be calculated based on default object property order.")]


### PR DESCRIPTION
# Ticket

Fixes #4605

# Brief Description

Details

Added an in-window Content Manager progress display for sync/revert flows.

Shows operation title, processed item count, total item count, progress bar fill, and current content item name.
Keeps sync progress inside the Content Manager instead of relying on Unity’s modal progress UI.
Disables revert/action buttons while a sync operation is active to avoid overlapping operations.
Uses delayed window-state transitions to avoid IMGUI layout mismatches during repaint.
Improved CLI content download behavior during content sync.

Added a dedicated content-file download path in ContentService.
Uses a shared HttpClient for content file downloads instead of routing every CDN file through the generic verbose CLI requester.
Adds transient retry handling with jittered backoff for socket resets, timeouts, and retryable HTTP responses.
Removes per-file verbose “Downloading content with id...” sync log noise from the Unity CLI Debugger.
Keeps large syncs faster and cleaner while avoiding the SSL/socket reset failures seen during high-content-count tests.
Added sync download concurrency control.

New CLI flag: --download-max-parallel-count
New Unity content configuration field: EditorSyncDownloadMaxParallelCount
The editor passes this value into content sync when configured.
CLI default is 64.
Unity unset means the CLI default is used.
0 means unbounded parallelism.

Tests:
- stress testing with 2k+ content amount
- confirmed consistently that no SSL/socket reset failures are happening during content sync

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


