### PR TITLE
[CLI] Portal Extensions microservice client support

### DIFF
--- a/cli/beamable.common/Runtime/Constants/Implementations/PortalExtensionConstants.cs
+++ b/cli/beamable.common/Runtime/Constants/Implementations/PortalExtensionConstants.cs
@@ -7,6 +7,7 @@ namespace Beamable.Common
 			public static partial class PortalExtension
 			{
 				public const string EXTENSION_DEPENDENCIES_PROPERTY_NAME = "microserviceDependencies";
+				public const string EXTENSION_BEAMABLE_PROPERTY_NAME = "beamable";
 				public const string EXTENSION_NAME_PROPERTY_NAME = "name";
 			}
 		}

--- a/cli/beamable.templates/templates/PortalExtensionReactApp/tsconfig.json
+++ b/cli/beamable.templates/templates/PortalExtensionReactApp/tsconfig.json
@@ -14,5 +14,5 @@
     "noEmit": true,
     "types": ["vite/client"]
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts", "beamable/**/*.ts"]
 }

--- a/cli/cli/Commands/Portal/PortalExtensionAddDependencyCommand.cs
+++ b/cli/cli/Commands/Portal/PortalExtensionAddDependencyCommand.cs
@@ -1,7 +1,9 @@
+using Beamable.Server;
 using cli.Services;
 using cli.Services.Web;
 using Newtonsoft.Json.Linq;
 using System.CommandLine;
+using static Beamable.Common.Constants.Features.PortalExtension;
 
 namespace cli.Portal;
 
@@ -62,7 +64,13 @@ public class PortalExtensionAddDependencyCommand : AppCommand<PortalExtensionAdd
 
 			extension.MicroserviceDependencies.Add(microservice.BeamoId);
 
-			root[Beamable.Common.Constants.Features.PortalExtension.EXTENSION_DEPENDENCIES_PROPERTY_NAME] =
+			if (root[EXTENSION_BEAMABLE_PROPERTY_NAME] == null)
+			{
+				throw new CliException(
+					$"Field {EXTENSION_BEAMABLE_PROPERTY_NAME} expected in extension pakage.json file");
+			}
+
+			root[EXTENSION_BEAMABLE_PROPERTY_NAME][EXTENSION_DEPENDENCIES_PROPERTY_NAME] =
 				JToken.FromObject(extension.MicroserviceDependencies);
 
 			File.WriteAllText(packagePath, root.ToString(Newtonsoft.Json.Formatting.Indented));
@@ -86,8 +94,14 @@ public class PortalExtensionAddDependencyCommand : AppCommand<PortalExtensionAdd
 
 		foreach ((string beamId, HttpMicroserviceLocalProtocol localProtocol) in manifest.HttpMicroserviceLocalProtocols)
 		{
-			if (!dependencies.Contains(beamId) || localProtocol.OpenApiDoc == null)
+			if (!dependencies.Contains(beamId))
 			{
+				continue;
+			}
+
+			if (localProtocol.OpenApiDoc == null)
+			{
+				Log.Warning($"Client generation for {beamId} is being skipped because there is no API doc. Try running {beamId} once to make it available and try again.");
 				continue;
 			}
 

--- a/cli/cli/Commands/Portal/PortalExtensionAddDependencyCommand.cs
+++ b/cli/cli/Commands/Portal/PortalExtensionAddDependencyCommand.cs
@@ -67,7 +67,7 @@ public class PortalExtensionAddDependencyCommand : AppCommand<PortalExtensionAdd
 			if (root[EXTENSION_BEAMABLE_PROPERTY_NAME] == null)
 			{
 				throw new CliException(
-					$"Field {EXTENSION_BEAMABLE_PROPERTY_NAME} expected in extension pakage.json file");
+					$"Field {EXTENSION_BEAMABLE_PROPERTY_NAME} expected in extension package.json file");
 			}
 
 			root[EXTENSION_BEAMABLE_PROPERTY_NAME][EXTENSION_DEPENDENCIES_PROPERTY_NAME] =
@@ -118,7 +118,7 @@ public class PortalExtensionAddDependencyCommand : AppCommand<PortalExtensionAdd
 
 		JObject root = JObject.Parse(jsonContent);
 
-		JToken deps = root[Beamable.Common.Constants.Features.PortalExtension.EXTENSION_DEPENDENCIES_PROPERTY_NAME];
+		JToken deps = root[EXTENSION_BEAMABLE_PROPERTY_NAME][EXTENSION_DEPENDENCIES_PROPERTY_NAME];
 
 		if (deps is { Type: JTokenType.Array })
 		{

--- a/cli/cli/Commands/Portal/PortalExtensionAddDependencyCommand.cs
+++ b/cli/cli/Commands/Portal/PortalExtensionAddDependencyCommand.cs
@@ -105,7 +105,7 @@ public class PortalExtensionAddDependencyCommand : AppCommand<PortalExtensionAdd
 				continue;
 			}
 
-			var generator = new WebClientCodeGenerator(localProtocol.OpenApiDoc, "js");
+			var generator = new WebClientCodeGenerator(localProtocol.OpenApiDoc, "ts");
 			var clientsOutputDirectory = Path.Combine(extensionPath, "beamable/clients");
 			generator.GenerateClientCode(clientsOutputDirectory);
 		}
@@ -122,7 +122,6 @@ public class PortalExtensionAddDependencyCommand : AppCommand<PortalExtensionAdd
 
 		if (deps is { Type: JTokenType.Array })
 		{
-			// Convert the JArray directly to a List<string>
 			return deps.ToObject<List<string>>();
 		}
 

--- a/cli/cli/Services/PortalExtension/PortalExtensionDiscoveryService.cs
+++ b/cli/cli/Services/PortalExtension/PortalExtensionDiscoveryService.cs
@@ -21,7 +21,8 @@ public class ExtensionBuildMetaData
 public class PortalExtensionDiscoveryService : Microservice
 {
 
-	[ClientCallable]
+	// Note: this creates source code leaking, even tho the service has an ever changing Guid
+	[Callable]
 	public ExtensionBuildData RequestPortalExtensionData(string currentHash = "")
 	{
 		var observer = Provider.GetService<PortalExtensionObserver>();

--- a/cli/cli/Services/Web/WebClientCodeGenerator.cs
+++ b/cli/cli/Services/Web/WebClientCodeGenerator.cs
@@ -1,4 +1,4 @@
-﻿using Beamable.Server;
+using Beamable.Server;
 using cli.Services.Web.CodeGen;
 using cli.Services.Web.Helpers;
 using Microsoft.OpenApi.Any;
@@ -74,7 +74,7 @@ public class WebClientCodeGenerator
 		if (_schemas.Count > 0)
 		{
 			var tsBeamSchemaImport =
-				new TsImport("beamable-sdk/schema", defaultImport: "* as Schemas", typeImportOnly: true);
+				new TsImport("@beamable/sdk/schema", defaultImport: "* as Schemas", typeImportOnly: true);
 			_clientFile.AddImport(tsBeamSchemaImport);
 		}
 
@@ -283,7 +283,7 @@ public class WebClientCodeGenerator
 		var className = tsClass.Name;
 		var camelCaseClassName = StringHelper.ToCamelCaseIdentifier(className);
 		var serviceName = tsClass.Name.Replace("Client", string.Empty);
-		var tsModule = new TsModule("beamable-sdk");
+		var tsModule = new TsModule("@beamable/sdk");
 		var tsInterface = new TsInterface("BeamBase");
 		var tsProperty = new TsProperty(camelCaseClassName, TsType.Of(className));
 		var tsComment = new TsComment(

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCliUtil.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCliUtil.cs
@@ -284,13 +284,13 @@ namespace Beamable.Editor.BeamCli
 					{
 						var packageId = "beamable.tools";
 						var version = BeamableEnvironment.NugetPackageVersion.ToString().ToLowerInvariant();
-						var globalPackages = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+						var globalPackages = System.Environment.GetEnvironmentVariable("NUGET_PACKAGES");
 						if (string.IsNullOrEmpty(globalPackages))
 						{
-							var home = Environment.GetEnvironmentVariable("HOME");
+							var home = System.Environment.GetEnvironmentVariable("HOME");
 							if (string.IsNullOrEmpty(home))
 							{
-								home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+								home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
 							}
 							globalPackages = Path.Combine(home, ".nuget", "packages");
 						}

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCliUtil.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCliUtil.cs
@@ -145,13 +145,15 @@ namespace Beamable.Editor.BeamCli
 					installCommand += " --add-source BeamableNugetSource ";
 				}
 
-				if (!BeamableEnvironment.NugetPackageVersion.ToString().Equals("0.0.123"))
+				// Lowercase the version: dotnet tool install builds the global-packages path from the raw --version string, so an uppercase pre-release label (7.2.0-PREVIEW.RC1) mismatches NuGet's lowercased cache folder on case-sensitive (Linux) filesystems.
+				var versionArg = BeamableEnvironment.NugetPackageVersion.ToString().ToLowerInvariant();
+				if (!versionArg.Equals("0.0.123"))
 				{
-					installCommand += $" --version {BeamableEnvironment.NugetPackageVersion}";
+					installCommand += $" --version {versionArg}";
 				}
 				else
 				{
-					installCommand += $" --version {BeamableEnvironment.NugetPackageVersion}.*";
+					installCommand += $" --version {versionArg}.*";
 				}
 
 				var proc = NewInstallProcess();

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCliUtil.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCliUtil.cs
@@ -166,6 +166,8 @@ namespace Beamable.Editor.BeamCli
 					RedirectStandardError = true
 				};
 				proc.StartInfo.Environment.Add("DOTNET_CLI_UI_LANGUAGE", "en");
+				// Remove a corrupt global-packages entry (extracted, missing its .nupkg) so the install re-downloads cleanly instead of short-circuiting on it.
+				HealCorruptGlobalPackagesEntry();
 				Debug.Log($"[BeamCLI] Installing Beam CLI version [{BeamableEnvironment.NugetPackageVersion}]. " +
 				          $"Command: [dotnet {installCommand}]. A first-time install with a cold NuGet cache can be slow while packages download.");
 				TryRunWithTimeout(1);
@@ -274,6 +276,45 @@ namespace Beamable.Editor.BeamCli
 					Debug.Log($"[BeamCLI] Retrying install with a longer timeout (attempt {currentTry + 1}).");
 					return TryRunWithTimeout(++currentTry);
 
+				}
+
+				void HealCorruptGlobalPackagesEntry()
+				{
+					try
+					{
+						var packageId = "beamable.tools";
+						var version = BeamableEnvironment.NugetPackageVersion.ToString().ToLowerInvariant();
+						var globalPackages = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+						if (string.IsNullOrEmpty(globalPackages))
+						{
+							var home = Environment.GetEnvironmentVariable("HOME");
+							if (string.IsNullOrEmpty(home))
+							{
+								home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+							}
+							globalPackages = Path.Combine(home, ".nuget", "packages");
+						}
+
+						var packageDir = Path.Combine(globalPackages, packageId, version);
+						if (!Directory.Exists(packageDir))
+						{
+							Debug.Log($"[BeamCLI] No pre-existing global-packages entry at [{packageDir}].");
+							return;
+						}
+
+						var nupkgCount = Directory.GetFiles(packageDir, "*.nupkg").Length;
+						var totalFiles = Directory.GetFiles(packageDir, "*", SearchOption.AllDirectories).Length;
+						Debug.Log($"[BeamCLI] Found global-packages entry [{packageDir}]: {nupkgCount} .nupkg, {totalFiles} total files.");
+						if (nupkgCount == 0)
+						{
+							Debug.LogWarning($"[BeamCLI] Entry [{packageDir}] is missing its .nupkg (corrupt). Deleting it so the install can re-download a complete copy.");
+							Directory.Delete(packageDir, true);
+						}
+					}
+					catch (Exception healEx)
+					{
+						Debug.LogWarning($"[BeamCLI] Auto-heal of the global-packages cache failed: {healEx.Message}");
+					}
 				}
 			}
 		}

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCliUtil.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCliUtil.cs
@@ -138,7 +138,10 @@ namespace Beamable.Editor.BeamCli
 				var proc = new Process();
 				var installCommand = $"tool install Beamable.Tools --create-manifest-if-needed --allow-downgrade";
 
-				if (Application.isBatchMode)
+				// Only add the local folder feed for the local dev version (0.0.123.*). For a published
+				// version, installing from a local folder feed extracts into the global packages folder
+				// without copying the .nupkg, which then crashes finalization; let it resolve from nuget.org.
+				if (Application.isBatchMode && BeamableEnvironment.NugetPackageVersion.ToString().StartsWith("0.0.123"))
 				{
 					installCommand += " --add-source BeamableNugetSource ";
 				}

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCliUtil.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCliUtil.cs
@@ -163,6 +163,8 @@ namespace Beamable.Editor.BeamCli
 					RedirectStandardError = true
 				};
 				proc.StartInfo.Environment.Add("DOTNET_CLI_UI_LANGUAGE", "en");
+				Debug.Log($"[BeamCLI] Installing Beam CLI version [{BeamableEnvironment.NugetPackageVersion}]. " +
+				          $"Command: [dotnet {installCommand}]. A first-time install with a cold NuGet cache can be slow while packages download.");
 				TryRunWithTimeout(1);
 
 				const string errorGuide =
@@ -221,14 +223,34 @@ namespace Beamable.Editor.BeamCli
 
 				bool TryRunWithTimeout(int currentTry)
 				{
+					var timeoutMs = 30 * 1000 * currentTry;
+					Debug.Log($"[BeamCLI] Install attempt {currentTry} starting (timeout {timeoutMs / 1000}s)...");
+					var stopwatch = Stopwatch.StartNew();
 					proc.Start();
-					if (proc.WaitForExit(10 * 1000 * currentTry))
+					if (proc.WaitForExit(timeoutMs))
 					{
+						Debug.Log($"[BeamCLI] Install attempt {currentTry} exited with code {proc.ExitCode} after {stopwatch.Elapsed.TotalSeconds:0.#}s.");
 						return true;
 					}
 
+					// Kill the still-running process before retrying; a concurrent retry corrupts the NuGet cache (a version folder left without its .nupkg), which then fails every later restore.
 					Debug.LogError(
-						"dotnet tool install command did not finish fast enough; timed out. Trying again with longer timeout");
+						$"[BeamCLI] Install attempt {currentTry} did not finish within {timeoutMs / 1000}s. " +
+						"Killing the dotnet process before retrying to avoid corrupting the NuGet cache.");
+					try
+					{
+						if (!proc.HasExited)
+						{
+							proc.Kill();
+						}
+						proc.WaitForExit();
+						Debug.Log($"[BeamCLI] Killed the timed-out dotnet process from attempt {currentTry}.");
+					}
+					catch (Exception killEx)
+					{
+						Debug.LogWarning($"[BeamCLI] Failed to kill the timed-out dotnet install process: {killEx.Message}");
+					}
+
 					const int maxRetries = 5;
 					if (currentTry > maxRetries)
 					{
@@ -246,6 +268,7 @@ namespace Beamable.Editor.BeamCli
 						return false;
 					}
 
+					Debug.Log($"[BeamCLI] Retrying install with a longer timeout (attempt {currentTry + 1}).");
 					return TryRunWithTimeout(++currentTry);
 
 				}

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCliUtil.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCliUtil.cs
@@ -135,7 +135,6 @@ namespace Beamable.Editor.BeamCli
 					return true;
 				}
 
-				var proc = new Process();
 				var installCommand = $"tool install Beamable.Tools --create-manifest-if-needed --allow-downgrade";
 
 				// Only add the local folder feed for the local dev version (0.0.123.*). For a published
@@ -155,19 +154,7 @@ namespace Beamable.Editor.BeamCli
 					installCommand += $" --version {BeamableEnvironment.NugetPackageVersion}.*";
 				}
 
-				proc.StartInfo = new ProcessStartInfo
-				{
-					FileName = "dotnet",
-					WorkingDirectory = Path.GetFullPath("."),
-					Arguments = installCommand,
-					UseShellExecute = false,
-					CreateNoWindow = true,
-					RedirectStandardOutput = true,
-					RedirectStandardError = true
-				};
-				proc.StartInfo.Environment.Add("DOTNET_CLI_UI_LANGUAGE", "en");
-				// Remove a corrupt global-packages entry (extracted, missing its .nupkg) so the install re-downloads cleanly instead of short-circuiting on it.
-				HealCorruptGlobalPackagesEntry();
+				var proc = NewInstallProcess();
 				Debug.Log($"[BeamCLI] Installing Beam CLI version [{BeamableEnvironment.NugetPackageVersion}]. " +
 				          $"Command: [dotnet {installCommand}]. A first-time install with a cold NuGet cache can be slow while packages download.");
 				TryRunWithTimeout(1);
@@ -177,6 +164,22 @@ namespace Beamable.Editor.BeamCli
 
 				var output = proc.StandardOutput.ReadToEnd();
 				var error = proc.StandardError.ReadToEnd();
+
+				// On some SDKs the local tool installer caches the package without its .nupkg and then crashes finalizing it. Only when we see that exact failure, pre-download the package via a normal restore (which keeps the .nupkg) and retry once, so unaffected SDKs never pay the cost.
+				var installLog = (output ?? string.Empty) + (error ?? string.Empty);
+				if (proc.ExitCode != 0 && installLog.Contains(".nupkg") &&
+				    (installLog.Contains("Could not find file") || installLog.Contains("FileNotFoundException")))
+				{
+					Debug.LogWarning("[BeamCLI] Install failed with a missing .nupkg in the global packages cache (known local tool-install issue). Healing the cache and pre-downloading the package, then retrying once.");
+					HealCorruptGlobalPackagesEntry();
+					WarmGlobalPackagesCache();
+
+					proc = NewInstallProcess();
+					TryRunWithTimeout(1);
+					output = proc.StandardOutput.ReadToEnd();
+					error = proc.StandardError.ReadToEnd();
+				}
+
 				if (!string.IsNullOrWhiteSpace(error) || proc.ExitCode != 0)
 				{
 					StringBuilder message = new StringBuilder("Unable to install BeamCLI");
@@ -225,6 +228,25 @@ namespace Beamable.Editor.BeamCli
 				}
 
 				return proc.ExitCode == 0;
+
+				Process NewInstallProcess()
+				{
+					var p = new Process
+					{
+						StartInfo = new ProcessStartInfo
+						{
+							FileName = "dotnet",
+							WorkingDirectory = Path.GetFullPath("."),
+							Arguments = installCommand,
+							UseShellExecute = false,
+							CreateNoWindow = true,
+							RedirectStandardOutput = true,
+							RedirectStandardError = true
+						}
+					};
+					p.StartInfo.Environment.Add("DOTNET_CLI_UI_LANGUAGE", "en");
+					return p;
+				}
 
 				bool TryRunWithTimeout(int currentTry)
 				{
@@ -276,6 +298,61 @@ namespace Beamable.Editor.BeamCli
 					Debug.Log($"[BeamCLI] Retrying install with a longer timeout (attempt {currentTry + 1}).");
 					return TryRunWithTimeout(++currentTry);
 
+				}
+
+				void WarmGlobalPackagesCache()
+				{
+					var version = BeamableEnvironment.NugetPackageVersion.ToString();
+					// The local dev flow installs 0.0.123.* from the local folder feed, which already
+					// lands the .nupkg in the cache, so there is nothing to warm (and it is not on nuget.org).
+					if (version.StartsWith("0.0.123"))
+					{
+						return;
+					}
+
+					try
+					{
+						var warmDir = Path.Combine(Path.GetFullPath("Library/BeamableEditor"), "cli-cache-warm");
+						Directory.CreateDirectory(warmDir);
+						var csprojPath = Path.Combine(warmDir, "warm.csproj");
+						File.WriteAllText(csprojPath,
+							"<Project Sdk=\"Microsoft.NET.Sdk\">\n" +
+							"  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>\n" +
+							$"  <ItemGroup><PackageDownload Include=\"Beamable.Tools\" Version=\"[{version}]\" /></ItemGroup>\n" +
+							"</Project>\n");
+
+						var warm = new Process
+						{
+							StartInfo = new ProcessStartInfo
+							{
+								FileName = "dotnet",
+								WorkingDirectory = warmDir,
+								Arguments = $"restore \"{csprojPath}\"",
+								UseShellExecute = false,
+								CreateNoWindow = true,
+								RedirectStandardOutput = true,
+								RedirectStandardError = true
+							}
+						};
+						warm.StartInfo.Environment.Add("DOTNET_CLI_UI_LANGUAGE", "en");
+						Debug.Log($"[BeamCLI] Warming the NuGet cache with Beamable.Tools [{version}] via PackageDownload restore...");
+						warm.Start();
+						if (!warm.WaitForExit(120 * 1000))
+						{
+							try { if (!warm.HasExited) warm.Kill(); }
+							catch { /* ignore */ }
+							Debug.LogWarning("[BeamCLI] Cache-warm restore timed out; continuing to the install anyway.");
+							return;
+						}
+
+						var output = warm.StandardOutput.ReadToEnd();
+						var error = warm.StandardError.ReadToEnd();
+						Debug.Log($"[BeamCLI] Cache-warm restore exited with code {warm.ExitCode}. {output} {error}");
+					}
+					catch (Exception warmEx)
+					{
+						Debug.LogWarning($"[BeamCLI] Cache-warm failed (continuing to the install anyway): {warmEx.Message}");
+					}
 				}
 
 				void HealCorruptGlobalPackagesEntry()

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCliUtil.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCliUtil.cs
@@ -180,6 +180,7 @@ namespace Beamable.Editor.BeamCli
 
 					message.AppendLine($"Error: {error}");
 					message.Append(errorGuide);
+					Debug.Log("Failed Install Command: " + installCommand);
 					Debug.LogError(message.ToString());
 					var tryAgainButtonInfo = new OptionDialogWindow.ButtonInfo()
 					{

--- a/dev-web.sh
+++ b/dev-web.sh
@@ -77,8 +77,8 @@ echo "  [cmd] pnpm version $VERSION --no-git-tag-version"
 pnpm version "$VERSION" --no-git-tag-version
 echo "  [cmd] pnpm build"
 pnpm build
-echo "  [cmd] pnpm publish --registry $REGISTRY --no-git-checks"
-pnpm publish --registry "$REGISTRY" --no-git-checks
+echo "  [cmd] pnpm publish --registry $REGISTRY --no-git-checks --tag local"
+pnpm publish --registry "$REGISTRY" --no-git-checks --tag local
 
 cp package.json.devbak package.json && rm package.json.devbak
 SDK_BACKUP=false
@@ -119,8 +119,8 @@ pnpm version "$VERSION" --no-git-tag-version
 
 echo "  [cmd] pnpm build"
 pnpm build
-echo "  [cmd] pnpm publish --registry $REGISTRY --no-git-checks"
-pnpm publish --registry "$REGISTRY" --no-git-checks
+echo "  [cmd] pnpm publish --registry $REGISTRY --no-git-checks --tag local"
+pnpm publish --registry "$REGISTRY" --no-git-checks --tag local
 
 cp package.json.devbak package.json && rm package.json.devbak
 TOOLKIT_BACKUP=false

--- a/template_updater/update-template.cs
+++ b/template_updater/update-template.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 
 // ── Args ───────────────────────────────────────────────────────────────────────
-var validTemplates = new[] { "BeamService", "BeamStorage", "PortalExtensionApp" };
+var validTemplates = new[] { "BeamService", "BeamStorage", "PortalExtensionApp", "PortalExtensionReactApp" };
 
 if (args.Length < 1) { Usage(); return; }
 
@@ -85,6 +85,7 @@ switch (templateName)
         break;
     }
     case "PortalExtensionApp":
+    case "PortalExtensionReactApp":
     {
         foreach (string f in EnumerateFiles(searchPath, "package.json", ignorePaths, [templatesDir]))
         {

--- a/web/src/services/ContentService.ts
+++ b/web/src/services/ContentService.ts
@@ -398,47 +398,64 @@ export class ContentService
     const contentStorage = await this.contentStoragePromise;
     const checksumKey = this.getManifestChecksumKey(manifestId);
 
-    // Fetch the locally stored checksum and the latest checksum from the API in parallel.
-    const [cachedChecksum, { body: latestChecksum }] = await Promise.all([
-      contentStorage.get<ContentManifestChecksum>(checksumKey),
-      contentGetManifestChecksumBasic(
-        this.requester,
-        manifestId,
-        undefined,
-        this.accountId,
-      ),
-    ]);
+    let latestChecksum;
+    try {
+      // Fetch the locally stored checksum and the latest checksum from the API in parallel.
+      const [cachedChecksum, checksumResponse] = await Promise.all([
+        contentStorage.get<ContentManifestChecksum>(checksumKey),
+        contentGetManifestChecksumBasic(
+          this.requester,
+          manifestId,
+          undefined,
+          this.accountId,
+        ),
+      ]);
+      latestChecksum = checksumResponse.body;
 
-    // Compare the checksums to see if an update is needed.
-    if (cachedChecksum?.checksum === latestChecksum.checksum) {
-      // Checksums match. The local version is up-to-date.
-      const entriesKey = this.getManifestEntriesKey(manifestId);
-      const manifestEntries =
-        await contentStorage.get<ClientContentInfoJson[]>(entriesKey);
+      // Compare the checksums to see if an update is needed.
+      if (cachedChecksum?.checksum === latestChecksum.checksum) {
+        // Checksums match. The local version is up-to-date.
+        const entriesKey = this.getManifestEntriesKey(manifestId);
+        const manifestEntries =
+          await contentStorage.get<ClientContentInfoJson[]>(entriesKey);
 
-      if (!manifestEntries) {
-        // Manifest entries not found in storage. Fetch them from the API.
+        if (!manifestEntries) {
+          // Manifest entries not found in storage. Fetch them from the API.
+          await this.fetchAndCacheManifestEntries(manifestId, {
+            id: latestChecksum.id,
+            checksum: latestChecksum.checksum,
+            created: latestChecksum.createdAt,
+            uid: latestChecksum.uid,
+          });
+          return;
+        }
+
+        // Manifest entries found in storage. Load them into the in-memory cache.
+        ContentService._manifestChecksumsCache[manifestId] = cachedChecksum;
+        ContentService._manifestEntriesCache[manifestId] = manifestEntries;
+      } else {
+        // Checksums differ. Fetch the manifest entries from the API and cache it.
         await this.fetchAndCacheManifestEntries(manifestId, {
           id: latestChecksum.id,
           checksum: latestChecksum.checksum,
           created: latestChecksum.createdAt,
           uid: latestChecksum.uid,
         });
+      }
+    } catch (err) {
+      if (ContentService.isManifestNotFound(err)) {
+        // Realm has no published content — treat as empty manifest.
+        ContentService._manifestEntriesCache[manifestId] = [];
         return;
       }
-
-      // Manifest entries found in storage. Load them into the in-memory cache.
-      ContentService._manifestChecksumsCache[manifestId] = cachedChecksum;
-      ContentService._manifestEntriesCache[manifestId] = manifestEntries;
-    } else {
-      // Checksums differ. Fetch the manifest entries from the API and cache it.
-      await this.fetchAndCacheManifestEntries(manifestId, {
-        id: latestChecksum.id,
-        checksum: latestChecksum.checksum,
-        created: latestChecksum.createdAt,
-        uid: latestChecksum.uid,
-      });
+      throw err;
     }
+  }
+
+  private static isManifestNotFound(err: unknown): boolean {
+    if (!BeamError.is(err)) return false;
+    const status = (err.context?.response as { status?: number })?.status;
+    return status === 404;
   }
 
   /** Fetches a content manifest entries from the API and caches it locally. */


### PR DESCRIPTION
## Summary
  
  - Fix portal extension dependency management to read/write microserviceDependencies under the beamable key in package.json instead of at the root level
  - Generate TypeScript clients (.ts) instead of JavaScript (.js) and fix SDK import paths to use @beamable/sdk instead of beamable-sdk
  - Handle content manifest 404 as an empty manifest in the Web SDK, fixing errors on realms with no published content
  - Change RequestPortalExtensionData from [ClientCallable] to [Callable] to remove the requirement for an initialized player
  - Fix dev-web.sh to publish with --tag local to avoid polluting the latest npm tag

## Changes

  Portal Extension dependency & client generation (cli/)
  
  - PortalExtensionAddDependencyCommand.cs: Dependencies are now read/written under package.json > beamable > microserviceDependencies instead of the root. Added validation that the beamable field exists. Split the skip condition for missing dependencies vs missing OpenAPI doc, with a warning log when the doc
  isn't available. Client code is now generated as .ts files.
  - PortalExtensionConstants.cs: Added EXTENSION_BEAMABLE_PROPERTY_NAME constant for the new beamable key.
  - WebClientCodeGenerator.cs: Fixed import paths from beamable-sdk and beamable-sdk/schema to @beamable/sdk and @beamable/sdk/schema.
  - React template tsconfig.json: Added beamable/**/*.ts to include so generated client types are picked up.

  Portal Extension discovery (PortalExtensionDiscoveryService.cs)

  - Changed [ClientCallable] to [Callable] so portal extensions can be served without requiring a fully initialized player session.

  Web SDK content service (ContentService.ts)
  
  - Wrapped manifest checksum fetch in try/catch to handle 404 responses gracefully — treats them as an empty manifest instead of crashing. Added isManifestNotFound helper.

  Dev tooling (dev-web.sh)
  
  - Added --tag local to pnpm publish commands to prevent local dev builds from overwriting the latest tag in the local registry.

## Test plan
  
  - Run beam pe add-dep on a portal extension with a microservice dependency — verify package.json is updated under beamable.microserviceDependencies and a .ts client is generated with correct @beamable/sdk imports
  - Load a portal extension in the portal without being logged in as a player — verify it loads (no ClientCallable auth requirement)
  - Open a realm with no published content — verify no crash and content page shows empty state
  - Run dev-web.sh — verify packages are published with --tag local in the local registry