### PR TITLE
Generate portal extension microservice clients on build

### DIFF
--- a/cli/cli/App.cs
+++ b/cli/cli/App.cs
@@ -616,6 +616,7 @@ public class App
 		Commands.AddSubCommand<RemoveReplacementTypeCommand, RemoveReplacementTypeCommandArgs, ProjectCommand>();
 		
 		Commands.AddSubCommand<GenerateWebClientCommand, GenerateWebClientCommandArgs, ProjectGenerateCommand>();
+		Commands.AddSubCommand<GeneratePortalExtensionClientsCommand, GeneratePortalExtensionClientsCommandArgs, ProjectGenerateCommand>();
 
 		Commands.AddRootCommand<AccountMeCommand, AccountMeCommandArgs>();
 		Commands.AddRootCommand<GenerateDocsCommand, GenerateDocsCommandArgs>();

--- a/cli/cli/Commands/Project/GeneratePortalExtensionClientsCommand.cs
+++ b/cli/cli/Commands/Project/GeneratePortalExtensionClientsCommand.cs
@@ -1,4 +1,5 @@
 using Beamable.Server;
+using cli.Dotnet;
 using cli.Services;
 using cli.Services.Web;
 using Microsoft.OpenApi.Models;
@@ -9,7 +10,9 @@ namespace cli.Commands.Project;
 
 public class GeneratePortalExtensionClientsCommandArgs : CommandArgs
 {
-	public string ServiceName;
+	public List<string> services = new List<string>();
+	public List<string> withServiceTags = new List<string>();
+	public List<string> withoutServiceTags = new List<string>();
 }
 
 
@@ -25,39 +28,26 @@ public class GeneratePortalExtensionClientsCommand : AppCommand<GeneratePortalEx
 
 	public override void Configure()
 	{
-		AddOption(new Option<string>("--service-name", () => null,
-				"When null or empty, it will generate clients for all microservices. Generates a client for this service for all dependent portal extensions"),
-			(args, val) => args.ServiceName = val);
+		ProjectCommand.AddIdsOption(this, (args, i) => args.services = i);
+		ProjectCommand.AddServiceTagsOption(this,
+			bindWithTags: (args, i) => args.withServiceTags = i,
+			bindWithoutTags: (args, i) => args.withoutServiceTags = i);
 	}
 
 	public override async Task Handle(GeneratePortalExtensionClientsCommandArgs args)
 	{
+		ProjectCommand.FinalizeServicesArg(args,
+			withTags: args.withServiceTags,
+			withoutTags: args.withoutServiceTags,
+			includeStorage: false,
+			ref args.services);
+
 		var allServices = args.BeamoLocalSystem.BeamoManifest.ServiceDefinitions;
 		var allExtensions = allServices.Where((s) => s.Protocol == BeamoProtocolType.PortalExtension).ToList();
 
-		var micros = new List<BeamoServiceDefinition>();
-
-		if (!string.IsNullOrEmpty(args.ServiceName))
-		{
-			var def = allServices.FirstOrDefault((s) => s.BeamoId == args.ServiceName);
-
-			if (def == null)
-			{
-				throw new CliException($"Could not find microservice with name: {args.ServiceName}");
-			}
-
-			micros.Add(def);
-		}
-		else
-		{
-			foreach (var service in allServices)
-			{
-				if (service.Protocol == BeamoProtocolType.HttpMicroservice)
-				{
-					micros.Add(service);
-				}
-			}
-		}
+		var micros = allServices
+			.Where(s => s.Protocol == BeamoProtocolType.HttpMicroservice && args.services.Contains(s.BeamoId))
+			.ToList();
 
 		var parallelOptions = new ParallelOptions { MaxDegreeOfParallelism = 8 };
 

--- a/cli/cli/Commands/Project/GeneratePortalExtensionClientsCommand.cs
+++ b/cli/cli/Commands/Project/GeneratePortalExtensionClientsCommand.cs
@@ -1,0 +1,97 @@
+using Beamable.Server;
+using cli.Services;
+using cli.Services.Web;
+using Microsoft.OpenApi.Models;
+using System.Collections.Concurrent;
+using System.CommandLine;
+
+namespace cli.Commands.Project;
+
+public class GeneratePortalExtensionClientsCommandArgs : CommandArgs
+{
+	public string ServiceName;
+}
+
+
+public class GeneratePortalExtensionClientsCommand : AppCommand<GeneratePortalExtensionClientsCommandArgs>
+{
+	private static readonly ConcurrentDictionary<string, object> _pathLocks = new();
+	public override bool IsForInternalUse => true;
+
+	public GeneratePortalExtensionClientsCommand() : base("portal-extension-clients", "Generates portal extension clients for a specified microservice (or for all if none is passed)")
+	{
+		AddAlias("pe-client");
+	}
+
+	public override void Configure()
+	{
+		AddOption(new Option<string>("--service-name", () => null,
+				"When null or empty, it will generate clients for all microservices. Generates a client for this service for all dependent portal extensions"),
+			(args, val) => args.ServiceName = val);
+	}
+
+	public override async Task Handle(GeneratePortalExtensionClientsCommandArgs args)
+	{
+		var allServices = args.BeamoLocalSystem.BeamoManifest.ServiceDefinitions;
+		var allExtensions = allServices.Where((s) => s.Protocol == BeamoProtocolType.PortalExtension).ToList();
+
+		var micros = new List<BeamoServiceDefinition>();
+
+		if (!string.IsNullOrEmpty(args.ServiceName))
+		{
+			var def = allServices.FirstOrDefault((s) => s.BeamoId == args.ServiceName);
+
+			if (def == null)
+			{
+				throw new CliException($"Could not find microservice with name: {args.ServiceName}");
+			}
+
+			micros.Add(def);
+		}
+		else
+		{
+			foreach (var service in allServices)
+			{
+				if (service.Protocol == BeamoProtocolType.HttpMicroservice)
+				{
+					micros.Add(service);
+				}
+			}
+		}
+
+		var parallelOptions = new ParallelOptions { MaxDegreeOfParallelism = 8 };
+
+		await Parallel.ForEachAsync(micros, parallelOptions, async (ms, cancellationToken) =>
+		{
+			var extensionsToUpdate = allExtensions
+				.Where(e => e.PortalExtensionDefinition.MicroserviceDependencies.Contains(ms.BeamoId))
+				.ToList();
+
+			if (extensionsToUpdate.Count == 0) return;
+
+			(bool hasOpenApiDocument, OpenApiDocument document) = await BeamoServiceDefinition.TryGetOpenApiDocument(ms.OpenApiPath);
+
+			if (!hasOpenApiDocument)
+			{
+				Log.Warning("Could not find any open API document: {path} for service {beamoId}", new object[] { ms.OpenApiPath, ms.BeamoId });
+				return;
+			}
+
+			var generator = new WebClientCodeGenerator(document, "ts");
+
+			foreach (var extension in extensionsToUpdate)
+			{
+				var extensionPath = extension.PortalExtensionDefinition.AbsolutePath;
+				var clientsOutputDirectory = Path.Combine(extensionPath, "beamable/clients");
+
+				object pathLock = _pathLocks.GetOrAdd(clientsOutputDirectory, _ => new object());
+
+				// Multiple microservices might try to generate client to the same extension, so we lock this by path
+				lock (pathLock)
+				{
+					generator.GenerateClientCode(clientsOutputDirectory);
+				}
+			}
+		});
+	}
+}

--- a/cli/cli/Services/BeamoLocalSystem.cs
+++ b/cli/cli/Services/BeamoLocalSystem.cs
@@ -586,29 +586,40 @@ public class BeamoServiceDefinition
 		// create a default instance so that downstream callers don't need to check for isLocal over and over again. 
 		= new MicroserviceFederationsConfig();
 
+	public static async Task<(bool, OpenApiDocument)> TryGetOpenApiDocument(string openApiPath)
+	{
+		if (!File.Exists(openApiPath))
+		{
+			return (false, null);
+		}
+
+		var openApiStringReader = new OpenApiStringReader();
+		var fileContent = await File.ReadAllTextAsync(openApiPath);
+		var document = openApiStringReader.Read(fileContent, out var diagnostic);
+		foreach (var warning in diagnostic.Warnings)
+		{
+			Log.Warning("found warning for {path}. {message} . from {pointer}", openApiPath, warning.Message,
+				warning.Pointer);
+			throw new OpenApiException($"invalid document {openApiPath} - {warning.Message} - {warning.Pointer}");
+		}
+
+		foreach (var error in diagnostic.Errors)
+		{
+			Log.Error("found ERROR for {path}. {message} . from {pointer}", openApiPath, error.Message,
+				error.Pointer);
+			throw new OpenApiException($"invalid document {openApiPath} - {error.Message} - {error.Pointer}");
+		}
+
+		return (true, document);
+	}
+
 	public static async Task<MicroserviceFederationsConfig> ReloadFederationsData(string openApiPath)
 	{
 		// string openApiPath = definition.OpenApiPath;
-		if (File.Exists(openApiPath))
+		(bool hasOpenApiDocument, OpenApiDocument document) = await TryGetOpenApiDocument(openApiPath);
+		if (hasOpenApiDocument)
 		{
-			var openApiStringReader = new OpenApiStringReader();
-			var fileContent = await File.ReadAllTextAsync(openApiPath);
-			var openApiDocument = openApiStringReader.Read(fileContent, out var diagnostic);
-			foreach (var warning in diagnostic.Warnings)
-			{
-				Log.Warning("found warning for {path}. {message} . from {pointer}", openApiPath, warning.Message,
-					warning.Pointer);
-				throw new OpenApiException($"invalid document {openApiPath} - {warning.Message} - {warning.Pointer}");
-			}
-
-			foreach (var error in diagnostic.Errors)
-			{
-				Log.Error("found ERROR for {path}. {message} . from {pointer}", openApiPath, error.Message,
-					error.Pointer);
-				throw new OpenApiException($"invalid document {openApiPath} - {error.Message} - {error.Pointer}");
-			}
-
-			if (!openApiDocument.Extensions.TryGetValue(ServiceConstants.MICROSERVICE_FEDERATED_COMPONENTS_V2_KEY,
+			if (!document.Extensions.TryGetValue(ServiceConstants.MICROSERVICE_FEDERATED_COMPONENTS_V2_KEY,
 				    out var ext) ||
 			    ext is not OpenApiArray { Count: > 0 } federationIds)
 			{

--- a/cli/cli/Services/PortalExtension/PortalExtensionDiscoveryService.cs
+++ b/cli/cli/Services/PortalExtension/PortalExtensionDiscoveryService.cs
@@ -373,9 +373,6 @@ public class PortalExtensionObserver
 			return; // this case we ignore because these are the build files
 		}
 
-		// generate microservice client files, in case a manually change happened to the package.json adding a new dep
-		PortalExtensionAddDependencyCommand.GenerateDependenciesClients(AppFilesPath, _manifest);
-
 		// build the app since there are new changes in the src files
 		BuildExtension();
 

--- a/microservice/microservice/Targets/Beamable.Microservice.Runtime.targets
+++ b/microservice/microservice/Targets/Beamable.Microservice.Runtime.targets
@@ -117,6 +117,17 @@
     </Target>
 
     <!--
+        Generate client .ts files for portal extensions that are dependant of this service
+    -->
+    <Target Name="GeneratePortalExtensionClients"
+            DependsOnTargets="generate-oapi"
+            AfterTargets="AfterBuild">
+        <Exec EchoOff="true"
+              EnvironmentVariables="MSBUILDTERMINALLOGGER=off"
+              Command="dotnet beam project generate pe-client --service-name $(BeamId)" />
+    </Target>
+
+    <!--
         Generate client .cs files from upstream OAPI specs into this project's own
         $(BeamClientGenOutputDir).  MSBuild incremental: re-runs only for OAPI files
         that are newer than their corresponding stamp file.

--- a/microservice/microservice/Targets/Beamable.Microservice.Runtime.targets
+++ b/microservice/microservice/Targets/Beamable.Microservice.Runtime.targets
@@ -124,7 +124,7 @@
             AfterTargets="AfterBuild">
         <Exec EchoOff="true"
               EnvironmentVariables="MSBUILDTERMINALLOGGER=off"
-              Command="dotnet beam project generate pe-client --service-name $(BeamId)" />
+              Command="dotnet beam project generate pe-client --ids $(BeamId)" />
     </Target>
 
     <!--


### PR DESCRIPTION

  ## Summary
  - Add a new CLI command `beam project generate portal-extension-clients` (alias `pe-client`) that generates TypeScript API clients for portal extensions from their dependent microservices' OpenAPI specs
  - Extract OpenAPI document parsing into a reusable `TryGetOpenApiDocument` static method on `BeamoServiceDefinition`, shared by both the new command and existing federation data loading
  - Wire client generation into the microservice build pipeline via an MSBuild target (`GeneratePortalExtensionClients`) that runs after each microservice build
  - Remove the old on-file-change client generation call from `PortalExtensionObserver` in favor of the build-time approach

  ## Changes

  ### New CLI Command (`GeneratePortalExtensionClientsCommand`)
  - Registered under `project generate portal-extension-clients` with alias `pe-client`
  - Accepts an optional `--service-name` flag; when omitted, generates clients for all HTTP microservices
  - For each microservice, finds portal extensions that depend on it, reads the microservice's OpenAPI document, and generates TypeScript client code into `<extension>/beamable/clients/`
  - Uses `Parallel.ForEachAsync` with a concurrency limit of 8 and path-level locking to safely handle multiple microservices writing to the same extension directory

  ### Refactored OpenAPI Parsing (`BeamoLocalSystem.cs`)
  - Extracted `TryGetOpenApiDocument(string openApiPath)` as a public static method returning `(bool, OpenApiDocument)`
  - `ReloadFederationsData` now delegates to this method instead of inlining the parsing logic

  ### Build-Time Integration (`Beamable.Microservice.Runtime.targets`)
  - New MSBuild target `GeneratePortalExtensionClients` runs after `AfterBuild`, depends on `generate-oapi`
  - Invokes `dotnet beam project generate pe-client --service-name $(BeamId)` so clients are regenerated whenever a microservice is built

  ### Removed File-Watch Trigger (`PortalExtensionDiscoveryService.cs`)
  - Removed the call to `PortalExtensionAddDependencyCommand.GenerateDependenciesClients` from the file watcher observer, since client generation now happens at build time

  ## Test plan
  - [ ] Build a microservice that has a dependent portal extension and verify `.ts` client files are generated in `<extension>/beamable/clients/`
  - [ ] Run `dotnet beam project generate pe-client` without `--service-name` and confirm it generates clients for all microservices with portal extension dependents
  - [ ] Run `dotnet beam project generate pe-client --service-name <name>` for a specific service and confirm only that service's dependents are updated
  - [ ] Run with a non-existent `--service-name` and verify a `CliException` is thrown
  - [ ] Verify `dotnet build` on a microservice project triggers the `GeneratePortalExtensionClients` target automatically
  - [ ] Confirm the existing federation data loading (`ReloadFederationsData`) still works correctly after the refactor
  - [ ] Run `dotnet test tests/` to check for regressions