### PR TITLE
Fix Account window first-run build config setup #4640

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Improved content sync resilience for transient SSL/socket reset download failures.
+- Fixed first-run Account window build config setup when `config-defaults.txt` is missing or has no PID.
 - Deserialization issue with `properties` field in Score Items of Events
 - Fixed an issue where the Unity Editor would not detect changes to Icon subObject (for Sprites in Multiple Mode) and thus not saving it correctly
 - Fixed CLI web command spamming `ObjectDisposedException` when the local CLI server is unreachable [4581](https://github.com/beamable/BeamableProduct/issues/4581)

--- a/client/Packages/com.beamable/Editor/BeamEditor.cs
+++ b/client/Packages/com.beamable/Editor/BeamEditor.cs
@@ -685,13 +685,14 @@ namespace Beamable
 
 			if (writeConfig)
 			{
+				var wasNewConfigFile = !File.Exists(path);
 				string directoryName = Path.GetDirectoryName(path);
 				if (!string.IsNullOrWhiteSpace(directoryName))
 				{
 					Directory.CreateDirectory(directoryName);
 				}
 
-				if (File.Exists(path))
+				if (!wasNewConfigFile)
 				{
 					var fileInfo = new FileInfo(path);
 					fileInfo.IsReadOnly = false;
@@ -708,25 +709,28 @@ namespace Beamable
 				}
 				
 				File.WriteAllText(path, asJson);
-				
-				// Import synchronously so Unity's AssetDatabase can see the newly-created
-				// Resources asset before callers continue. This matters for first-run setup,
-				// where config-defaults.txt may not have existed a moment earlier.
-				AssetDatabase.ImportAsset(path, ImportAssetOptions.ForceSynchronousImport | ImportAssetOptions.ForceUpdate);
-				
-				// ImportAsset can still fail to resolve the asset immediately in some editor
-				// timing cases, so fall back to a synchronous refresh before reloading config.
-				if (AssetDatabase.LoadAssetAtPath<TextAsset>(path) == null)
+				if (wasNewConfigFile)
 				{
-					AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+					// Import synchronously so Unity's AssetDatabase can see the newly-created
+					// Resources asset before callers continue. This matters for first-run setup,
+					// where config-defaults.txt may not have existed a moment earlier.
+					AssetDatabase.ImportAsset(path, ImportAssetOptions.ForceSynchronousImport | ImportAssetOptions.ForceUpdate);
+
+					// ImportAsset can still fail to resolve the asset immediately in some editor
+					// timing cases, so fall back to a synchronous refresh before reloading config.
+					if (AssetDatabase.LoadAssetAtPath<TextAsset>(path) == null)
+					{
+						AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+					}
+
+					// Keep the Project window in sync for editor-driven writes, but avoid repainting
+					// editor UI while Unity is in the build pipeline.
+					if (!BuildPipeline.isBuildingPlayer)
+					{
+						EditorApplication.RepaintProjectWindow();
+					}
 				}
 				
-				// Keep the Project window in sync for editor-driven writes, but avoid repainting
-				// editor UI while Unity is in the build pipeline.
-				if (!BuildPipeline.isBuildingPlayer)
-				{
-					EditorApplication.RepaintProjectWindow();
-				}
 				ServiceScope.GetService<ConfigDatabaseProvider>().Reload();
 			}
 		}

--- a/client/Packages/com.beamable/Editor/BeamEditor.cs
+++ b/client/Packages/com.beamable/Editor/BeamEditor.cs
@@ -629,19 +629,41 @@ namespace Beamable
 			await BeamCli.Login(host, cid, email, password);
 			ApplyRequesterToken();
 			OnUserChange?.Invoke(BeamCli.latestUser);
-
-			if (!ConfigDatabaseProvider.HasConfigFile())
+			// When the account has exactly one game, there is no game-selection step.
+			// Use that game's production/root PID as the first-run build PID. Multi-game
+			// accounts wait for the user to choose a game/realm before we write build config.
+			if (BeamCli.latestGames?.VisibleGames?.Length == 1)
 			{
-				CommitConfigDefaults();
+				var productionPid = BeamCli.latestGames.VisibleGames[0].Pid;
+				CommitProductionBuildConfigDefaultsIfMissing(productionPid);
 			}
 		}
 
-		public void CommitConfigDefaults()
+		public void CommitProductionBuildConfigDefaultsIfMissing(string productionPid = null)
+		{
+			var config = ServiceScope.GetService<ConfigDatabaseProvider>();
+			config.Reload();
+			
+			if (!string.IsNullOrEmpty(config.Pid))
+			{
+				return;
+			}
+
+			productionPid ??= BeamCli.CurrentRealm?.FindRoot()?.Pid;
+			if (string.IsNullOrEmpty(productionPid))
+			{
+				return;
+			}
+
+			CommitConfigDefaults(productionPid);
+		}
+		
+		public void CommitConfigDefaults(string pidOverride = null)
 		{
 			var config = new ConfigData()
 			{
 				cid = BeamCli.Cid,
-				pid = BeamCli.Pid,
+				pid = pidOverride ?? BeamCli.Pid,
 				alias = BeamCli.Alias,
 				host = BeamCli.HostUrl,
 				portalUrl = BeamCli.PortalUrl
@@ -684,8 +706,27 @@ namespace Beamable
 						Debug.LogWarning($"Unable to checkout: {path}");
 					}
 				}
-
+				
 				File.WriteAllText(path, asJson);
+				
+				// Import synchronously so Unity's AssetDatabase can see the newly-created
+				// Resources asset before callers continue. This matters for first-run setup,
+				// where config-defaults.txt may not have existed a moment earlier.
+				AssetDatabase.ImportAsset(path, ImportAssetOptions.ForceSynchronousImport | ImportAssetOptions.ForceUpdate);
+				
+				// ImportAsset can still fail to resolve the asset immediately in some editor
+				// timing cases, so fall back to a synchronous refresh before reloading config.
+				if (AssetDatabase.LoadAssetAtPath<TextAsset>(path) == null)
+				{
+					AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+				}
+				
+				// Keep the Project window in sync for editor-driven writes, but avoid repainting
+				// editor UI while Unity is in the build pipeline.
+				if (!BuildPipeline.isBuildingPlayer)
+				{
+					EditorApplication.RepaintProjectWindow();
+				}
 				ServiceScope.GetService<ConfigDatabaseProvider>().Reload();
 			}
 		}

--- a/client/Packages/com.beamable/Editor/Toolbar/MenuItems/BeamableRealmMenuItem.cs
+++ b/client/Packages/com.beamable/Editor/Toolbar/MenuItems/BeamableRealmMenuItem.cs
@@ -86,7 +86,8 @@ namespace Beamable.Editor.ToolbarExtender
 				});
 				if(!sameEditorAndBuildPids)
 				{
-					menu.AddItem(new GUIContent(rootDisplay.text + "/Save to config-defaults"), false, editor.CommitConfigDefaults);
+					menu.AddItem(new GUIContent(rootDisplay.text + "/Save to config-defaults"), false, 
+					             () => editor.CommitConfigDefaults());
 				}
 			}
 		}

--- a/client/Packages/com.beamable/Editor/UI/AccountWindow/AccountWindow_Games.cs
+++ b/client/Packages/com.beamable/Editor/UI/AccountWindow/AccountWindow_Games.cs
@@ -10,6 +10,8 @@ namespace Beamable.Editor.Accounts
 {
 	public partial class AccountWindow
 	{
+		private bool _isSelectingRealm;
+		
 		public bool needsGameSelection;
 		public int gameSelectionIndex = 0;
 		public int realmSelectionIndex = 0;
@@ -104,14 +106,28 @@ namespace Beamable.Editor.Accounts
 				EditorGUILayout.Space(24);
 
 				{
-					GUI.enabled = realmSelectionIndex >= 0;
+					GUI.enabled = realmSelectionIndex >= 0 && !_isSelectingRealm;
 					var wasClicked = BeamGUI.PrimaryButton(new GUIContent("Continue"), allowEnterKeyToClick: true);
 					GUI.enabled = true;
 					
 					if (wasClicked)
 					{
-						var _ = context.SwitchRealm(availableRealms[realmSelectionIndex].Pid);
-						needsGameSelection = false;
+						_isSelectingRealm = true;
+						
+						var selectedPid = availableRealms[realmSelectionIndex].Pid;
+						var switchPromise = context.SwitchRealm(selectedPid);
+						switchPromise.Then(_ =>
+						{
+							context.CommitProductionBuildConfigDefaultsIfMissing();
+							needsGameSelection = false;
+							_isSelectingRealm = false;
+						});
+
+						switchPromise.Error(ex =>
+						{
+							_isSelectingRealm = false;
+							Debug.LogError($"[AccountWindow_Games] Failed to switch realm: {ex}");
+						});
 					}
 				}
 				

--- a/client/Packages/com.beamable/Editor/UI/AccountWindow/AccountWindow_SignedIn.cs
+++ b/client/Packages/com.beamable/Editor/UI/AccountWindow/AccountWindow_SignedIn.cs
@@ -1,3 +1,4 @@
+using Beamable.Common.Api.Realms;
 using Beamable.Config;
 using Beamable.Editor.BeamCli;
 using Beamable.Editor.Content;
@@ -69,14 +70,14 @@ namespace Beamable.Editor.Accounts
 						RenderLabel("Runtime Host", config.HostUrl, "No value set");
 						RenderLabel("Runtime Cid", config.Cid, "No value set");
 
-						var realmDisplay = config.Pid;
-						if (cli.pidToRealm.TryGetValue(config.Pid, out var realm))
+						string realmDisplay = config.Pid;
+						if (!string.IsNullOrEmpty(config.Pid) && cli.pidToRealm.TryGetValue(config.Pid, out RealmView realm))
 						{
 							realmDisplay = realm.GetDisplayName();
 						}
 						RenderLabel("Runtime Realm", realmDisplay, "No value set");
 
-						List<string> missingRuntimeFields = new List<string>();
+						var missingRuntimeFields = new List<string>();
 						if (string.IsNullOrEmpty(config.HostUrl))
 						{
 							missingRuntimeFields.Add("host");

--- a/client/Packages/com.beamable/Editor/UI/AccountWindow/AccountWindow_SignedIn.cs
+++ b/client/Packages/com.beamable/Editor/UI/AccountWindow/AccountWindow_SignedIn.cs
@@ -70,7 +70,7 @@ namespace Beamable.Editor.Accounts
 						RenderLabel("Runtime Host", config.HostUrl, "No value set");
 						RenderLabel("Runtime Cid", config.Cid, "No value set");
 
-						string realmDisplay = config.Pid;
+						var realmDisplay = config.Pid;
 						if (!string.IsNullOrEmpty(config.Pid) && cli.pidToRealm.TryGetValue(config.Pid, out RealmView realm))
 						{
 							realmDisplay = realm.GetDisplayName();


### PR DESCRIPTION
Fixes #4640 

https://github.com/beamable/BeamableProduct/issues/4640

# Brief Description

## Summary
- Guard Account window runtime realm lookup when `config-defaults.txt` has no PID.
- Auto-create first-run build config with the production/root PID for single-game accounts.
- For multi-game accounts, wait for game/realm selection before writing build config.
- Import the generated `config-defaults.txt` synchronously so Unity sees the new Resources asset.

## Testing
- Verified fresh single-game login creates `config-defaults.txt` with the production/root PID.
- Verified multi-game login writes build config after selecting a game/realm.
- Verified missing `config-defaults.txt` no longer throws `ArgumentNullException` in the Account window.

# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
