### PR TITLE
Fix RC version auto-derivation by reading tags from the remote

### DIFF
--- a/.github/workflows/release-unity-rc.yml
+++ b/.github/workflows/release-unity-rc.yml
@@ -81,7 +81,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.commit }}
-          fetch-tags: true   # needed to auto-derive the next RC number from existing tags ~Claude
+          # Shallow clone is fine: RC auto-derivation reads tag names straight
+          # from the remote via git ls-remote, so no local history is needed. ~Claude
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -162,15 +163,15 @@ jobs:
 
           next_rc() {                       # $1 = tag prefix, e.g. unity-sdk-5.1.0
             local max
-            max=$(git tag --list "$1-PREVIEW.RC*" \
-                  | sed -nE 's/.*-PREVIEW\.RC([0-9]+)$/\1/p' \
+            max=$(git ls-remote --tags origin "$1-PREVIEW.RC*" \
+                  | sed -nE 's#.*refs/tags/.*-PREVIEW\.RC([0-9]+)$#\1#p' \
                   | sort -n | tail -1)
             if [ -z "$max" ]; then echo 1; else echo $((max + 1)); fi
           }
 
           guard_not_shipped() {             # refuse to cut an RC for an already-released line
             local tag="$1" file="$2" prefix="$3"
-            if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            if [ -n "$(git ls-remote --tags origin "refs/tags/$tag")" ]; then
               echo "::error file=$file::$prefix already shipped to production (tag $tag exists). Bump the changelog before cutting another RC." >&2
               exit 1
             fi


### PR DESCRIPTION
## Problem

The first `dryRun` of **RC Publish (Unity + CLI) for testing** resolved both artifacts to **RC1** instead of the expected next numbers (CLI RC8 / Unity RC11):

```
"nugetPackageVersion": "7.2.0-PREVIEW.RC1"
npm version 5.1.0-PREVIEW.RC1
```

## Cause

`actions/checkout` does a shallow clone (`fetch-depth: 1`), so `git tag --list` found no local tags and `next_rc()` fell back to RC1 for both lines. The "already shipped to production" guard was inert for the same reason. (`fetch-tags: true` on a shallow clone is unreliable and did not populate the tags.)

## Fix

Read tag names directly from the remote with `git ls-remote --tags origin`, keeping the shallow checkout.

A deep checkout (`fetch-depth: 0`) would also work but downloads ~1.1 GB of history (4,288 commits / 1,392 tags) purely to read tag names — wasteful in a workflow that already runs `Free Disk Space` to fit the multi-GB Unity image. `git ls-remote` costs a ~0.5s network call and zero disk.

Verified against the live remote: resolves CLI `7.2.0-PREVIEW.RC8` and Unity `5.1.0-PREVIEW.RC11`; the production guard finds no bare tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)