### PR TITLE
Trim RC publish workflow input descriptions

### DIFF
--- a/.github/workflows/release-unity-rc.yml
+++ b/.github/workflows/release-unity-rc.yml
@@ -28,16 +28,16 @@ on:
     inputs:
       commit:
         type: string
-        description: "Commit / branch to build from. Point at a maintenance branch to patch an older line."
+        description: "Branch / ref to build from"
         default: main
       cliVersionOverride:
         type: string
-        description: "Optional. Force a CLI version e.g. 2.4.6-PREVIEW.RC1. Blank = auto: CLI changelog prefix + next RC from tags."
+        description: "(optional) Force CLI ver like 5.6.7-PREVIEW.RC8"
         required: false
         default: ""
       unityVersionOverride:
         type: string
-        description: "Optional. Force a Unity SDK version e.g. 2.4.6-PREVIEW.RC1. Blank = auto: Unity changelog prefix + next RC from tags."
+        description: "(optional) Force Unity ver like 1.2.3-PREVIEW.RC4"
         required: false
         default: ""
       dryRun:

--- a/.github/workflows/release-unity-rc.yml
+++ b/.github/workflows/release-unity-rc.yml
@@ -42,7 +42,7 @@ on:
         default: ""
       dryRun:
         type: boolean
-        description: When true, nothing is published, tagged, or uploaded
+        description: "Dry Run: build but don't publish, tag, or upload"
         required: true
         default: false
 

--- a/.github/workflows/release-unity-rc.yml
+++ b/.github/workflows/release-unity-rc.yml
@@ -42,7 +42,7 @@ on:
         default: ""
       dryRun:
         type: boolean
-        description: "Dry Run: build but don't publish, tag, or upload"
+        description: When true, nothing is published, tagged, or uploaded
         required: true
         default: false
 


### PR DESCRIPTION
Parked / not urgent — held aside per request.

The `workflow_dispatch` form for **RC Publish (Unity + CLI) for testing** is word-dense (see the Run-workflow dropdown). This trims the input labels to assume the operator already knows the basics:

| Input | Before | After |
|---|---|---|
| ref | `Commit / branch to build from. Point at a maintenance branch to patch an older line.` | `Branch / ref to build from` |
| CLI override | `Optional. Force a CLI version e.g. 2.4.6-PREVIEW.RC1. Blank = auto: CLI changelog prefix + next RC from tags.` | `(optional) Force CLI ver like 5.6.7-PREVIEW.RC8` |
| Unity override | `Optional. Force a Unity SDK version e.g. 2.4.6-PREVIEW.RC1. Blank = auto: Unity changelog prefix + next RC from tags.` | `(optional) Force Unity ver like 1.2.3-PREVIEW.RC4` |

Cosmetic only — no behavior change. Branched off `main`; the `dryRun` label trim was dropped because #4659 removes that input. Non-overlapping with #4659, so they merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)