### PR TITLE
Always-publish RC workflow: drop dryRun, resolve versions up front

### DIFF
--- a/.github/workflows/release-unity-rc.yml
+++ b/.github/workflows/release-unity-rc.yml
@@ -66,77 +66,25 @@ jobs:
     outputs:
       unityVersion: ${{ steps.version.outputs.UNITY_VERSION }}
     steps:
-      - name: review options
-        run: |
-          echo commit=${{ inputs.commit }}
-          echo cliVersionOverride=${{ inputs.cliVersionOverride }}
-          echo unityVersionOverride=${{ inputs.unityVersionOverride }}
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.commit }}
           # Shallow clone is fine: RC auto-derivation reads tag names straight
           # from the remote via git ls-remote, so no local history is needed. ~Claude
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 10.0.x
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Update npm
-        run: npm install -g npm@latest
-      - name: Check Npm version
-        run: npm --version
-
-      - name: Install JQ
-        run: |
-          sudo apt-get update
-          sudo apt-get install jq
-          jq --version
-
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.24.1
-          cache-dependency-path: ./otel-collector/beamable-collector/go.sum
-
-      - name: Build Otel Collector
-        working-directory: ./otel-collector
-        run: |
-          OUTPUT_DIRECTORY="$(pwd)/../otel-bin" bash ./build.sh
-
-      - name: Add collector version
-        run: |
-            sh ./build/bin/set-collector-version-property.sh
-
-      - name: Install CLI
-        working-directory: ./
-        run: |
-          bash ./setup.sh
-          bash ./dev.sh
-
-      - name: Check CLI
-        run: beam version
-
-      # Resolve both RC versions with as little human input as possible.
+      # Resolve both RC versions first, before any build, so the run fails fast
+      # on a bad changelog/override/already-shipped line and prints the versions
+      # up front instead of ~5 minutes in.
       #   prefix  <- top "## [x.y.z]" entry of each changelog (the human-maintained
       #              source of truth; package.json is 0.0.0 on main)
-      #   rc      <- highest existing matching git tag + 1, computed independently
-      #              per artifact (CLI and Unity SDK ride separate version lines)
+      #   rc      <- highest existing matching tag + 1, read straight from the
+      #              remote, computed independently per artifact (CLI and Unity
+      #              SDK ride separate version lines)
       # An explicit *VersionOverride input short-circuits derivation for that
-      # artifact (used when patching an older line, e.g. 2.4.6-PREVIEW.RC1). ~Claude
+      # artifact (used when patching an older line, e.g. 2.4.6-PREVIEW.RC1).
+      # The version string is assembled directly as <prefix>-PREVIEW.RC<n> rather
+      # than via `beam version construct`, so this needs no built CLI and runs
+      # first. This workflow only cuts RCs, so that format is fixed. ~Claude
       - name: Resolve RC versions
         id: version
         env:
@@ -191,29 +139,82 @@ jobs:
             unity_rc=$(next_rc "unity-sdk-$unity_prefix")
           fi
 
-          # Format the canonical version strings through the CLI so the suffix
-          # matches the rest of the pipeline (x.y.z-PREVIEW.RCn).
-          IFS=. read -r cmaj cmin cpat <<< "$cli_prefix"
-          IFS=. read -r umaj umin upat <<< "$unity_prefix"
-          beam version construct "$cmaj" "$cmin" "$cpat" --rc "$cli_rc" > cli-version.txt
-          beam version construct "$umaj" "$umin" "$upat" --rc "$unity_rc" > unity-version.txt
+          # Assemble the canonical RC strings directly (fixed format for RCs).
+          cli_version="$cli_prefix-PREVIEW.RC$cli_rc"
+          unity_version="$unity_prefix-PREVIEW.RC$unity_rc"
+
+          echo "commit=${{ inputs.commit }}"
+          echo "Resolved CLI:   $cli_version"
+          echo "Resolved Unity: $unity_version"
 
           {
-            echo "CLI_VERSION=$(jq -r .data.versionString cli-version.txt)"
-            echo "CLI_VERSION_PREFIX=$(jq -r .data.versionPrefix cli-version.txt)"
-            echo "CLI_VERSION_SUFFIX=$(jq -r .data.versionSuffix cli-version.txt)"
-            echo "UNITY_VERSION=$(jq -r .data.versionString unity-version.txt)"
-            echo "UNITY_VERSION_PREFIX=$(jq -r .data.versionPrefix unity-version.txt)"
-            echo "UNITY_VERSION_SUFFIX=$(jq -r .data.versionSuffix unity-version.txt)"
+            echo "CLI_VERSION=$cli_version"
+            echo "CLI_VERSION_PREFIX=$cli_prefix"
+            echo "CLI_VERSION_SUFFIX=PREVIEW.RC$cli_rc"
+            echo "UNITY_VERSION=$unity_version"
+            echo "UNITY_VERSION_PREFIX=$unity_prefix"
+            echo "UNITY_VERSION_SUFFIX=PREVIEW.RC$unity_rc"
           } >> "$GITHUB_OUTPUT"
 
           {
             echo "### RC versions resolved"
             echo "| Artifact | Version | Source |"
             echo "|---|---|---|"
-            echo "| CLI | \`$(jq -r .data.versionString cli-version.txt)\` | ${CLI_OVERRIDE:+override}${CLI_OVERRIDE:-changelog + tags} |"
-            echo "| Unity SDK | \`$(jq -r .data.versionString unity-version.txt)\` | ${UNITY_OVERRIDE:+override}${UNITY_OVERRIDE:-changelog + tags} |"
+            echo "| CLI | \`$cli_version\` | ${CLI_OVERRIDE:+override}${CLI_OVERRIDE:-changelog + tags} |"
+            echo "| Unity SDK | \`$unity_version\` | ${UNITY_OVERRIDE:+override}${UNITY_OVERRIDE:-changelog + tags} |"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKER_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm
+        run: npm install -g npm@latest
+      - name: Check Npm version
+        run: npm --version
+
+      - name: Install JQ
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq
+          jq --version
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.1
+          cache-dependency-path: ./otel-collector/beamable-collector/go.sum
+
+      - name: Build Otel Collector
+        working-directory: ./otel-collector
+        run: |
+          OUTPUT_DIRECTORY="$(pwd)/../otel-bin" bash ./build.sh
+
+      - name: Add collector version
+        run: |
+            sh ./build/bin/set-collector-version-property.sh
+
+      - name: Install CLI
+        working-directory: ./
+        run: |
+          bash ./setup.sh
+          bash ./dev.sh
+
+      - name: Check CLI
+        run: beam version
 
       # ---- CLI nuget release (RC) ----
 

--- a/.github/workflows/release-unity-rc.yml
+++ b/.github/workflows/release-unity-rc.yml
@@ -40,13 +40,8 @@ on:
         description: "Optional. Force a Unity SDK version e.g. 2.4.6-PREVIEW.RC1. Blank = auto: Unity changelog prefix + next RC from tags."
         required: false
         default: ""
-      dryRun:
-        type: boolean
-        description: When true, nothing is published, tagged, or uploaded
-        required: true
-        default: false
 
-run-name: "RC Publish from ${{ inputs.commit }} by @${{ github.actor }}${{ inputs.dryRun == true && ' [dry run]' || '' }}"
+run-name: "RC Publish from ${{ inputs.commit }} by @${{ github.actor }}"
 
 env:
   DOCKER_REGISTRY: ghcr.io
@@ -73,10 +68,9 @@ jobs:
     steps:
       - name: review options
         run: |
-          echo dryRun=${{ inputs.dryRun }}
           echo commit=${{ inputs.commit }}
-          echo cli=${{ inputs.cliMajor }}.${{ inputs.cliMinor }}.${{ inputs.cliPatch }} RC${{ inputs.cliRc }}
-          echo unity=${{ inputs.unityMajor }}.${{ inputs.unityMinor }}.${{ inputs.unityPatch }} RC${{ inputs.unityRc }}
+          echo cliVersionOverride=${{ inputs.cliVersionOverride }}
+          echo unityVersionOverride=${{ inputs.unityVersionOverride }}
 
       - uses: actions/checkout@v4
         with:
@@ -228,34 +222,28 @@ jobs:
         run: find . -type f ! -name '*.gz' -exec gzip -k -9 {} \;
 
       - name: Upload Collector to S3
-        if: ${{ inputs.dryRun == false }}
         working-directory: otel-bin
         run: |
           AWS_ACCESS_KEY_ID=${{secrets.AWS_KEY_ID}} AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY}} AWS_REGION=us-west-2 aws s3 cp --recursive ./ s3://beamable-otel-collector-ch/version/${{ steps.version.outputs.CLI_VERSION }} --exclude "*" --include "*.gz" --acl public-read
 
       - name: Prepare Cloudfront Invalidation
-        if: ${{ inputs.dryRun == false }}
         run: |
           CLOUD_DISTRO=E3S54OWVMS4PQH
           CALLER_REFERENCE=$(date -u +"%Y%m%d%H%M%S")
           echo '{"DistributionId":"'${CLOUD_DISTRO}'","InvalidationBatch":{"CallerReference":"'${CALLER_REFERENCE}'","Paths":{"Quantity":1,"Items":["/version/${{ steps.version.outputs.CLI_VERSION }}/*"]}}}' >> cloudfront-invalidation.json
           cat cloudfront-invalidation.json
       - name: Do Cloudfront Invalidation
-        if: ${{ inputs.dryRun == false }}
         run: AWS_ACCESS_KEY_ID=${{secrets.AWS_KEY_ID}} AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY}} AWS_REGION=us-west-2 aws cloudfront create-invalidation --cli-input-json file://cloudfront-invalidation.json
 
       - name: Publish Nuget Packages
-        if: ${{ inputs.dryRun == false }}
         run: sh ./build/bin/release-nuget.sh
         env:
           VERSION: ${{ steps.version.outputs.CLI_VERSION }}
           VERSION_PREFIX: ${{ steps.version.outputs.CLI_VERSION_PREFIX }}
           VERSION_SUFFIX: ${{ steps.version.outputs.CLI_VERSION_SUFFIX }}
-          DRY_RUN: ${{ inputs.dryRun }}
           NUGET_TOOLS_KEY: ${{ secrets.NUGET_TOOLS_KEY }}
 
       - name: Publish CLI Changelog
-        if: ${{ inputs.dryRun == false }}
         run: sh ./build/bin/upload-changelogs.sh
         env:
           COPY_UNITY_SDK: 'false'
@@ -267,7 +255,6 @@ jobs:
           BRANCH: staging
 
       - name: Create CLI Release
-        if: ${{ inputs.dryRun == false }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -378,7 +365,6 @@ jobs:
         run: cp client/Packages/com.beamable/.npmrc ./client/build/package_dist/.npmrc
 
       - name: Release com.beamable UPM Package to Nexus
-        if: ${{ inputs.dryRun == false }}
         run: npm publish ./com.beamable/com.beamable-${{ steps.version.outputs.UNITY_VERSION }}.tgz --tag rc
         working-directory: ./client/build/package_dist/
         env:
@@ -387,14 +373,12 @@ jobs:
           NPM_REGISTRY: https://nexus.beamable.com/nexus/content/repositories/unity-preview
 
       - name: Release com.beamable UPM Package to Public
-        if: ${{ inputs.dryRun == false }}
         run: npm publish ./com.beamable/com.beamable-${{ steps.version.outputs.UNITY_VERSION }}.tgz --tag rc
         working-directory: ./client/build/package_dist/
         env:
           NPM_REGISTRY: https://registry.npmjs.org
 
       - name: Release com.beamable.server UPM Package
-        if: ${{ inputs.dryRun == false }}
         run: npm publish --tag rc
         working-directory: ./client/Packages/com.beamable.server
         env:
@@ -403,7 +387,6 @@ jobs:
           NPM_REGISTRY: https://nexus.beamable.com/nexus/content/repositories/unity-preview
 
       - name: Publish Unity SDK Changelog
-        if: ${{ inputs.dryRun == false }}
         run: sh ./build/bin/upload-changelogs.sh
         env:
           COPY_UNITY_SDK: 'true'
@@ -415,7 +398,6 @@ jobs:
           BRANCH: staging
 
       - name: Create Unity SDK Release
-        if: ${{ inputs.dryRun == false }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -429,7 +411,6 @@ jobs:
 
   lightbeam:
     needs: publish
-    if: ${{ inputs.dryRun == false }}
     uses: ./.github/workflows/lightBeamRelease.yml
     with:
       customTag: unity-sdk-${{ needs.publish.outputs.unityVersion }}


### PR DESCRIPTION
Two related changes that make **RC Publish (Unity + CLI) for testing** always do a real publish and fail fast.

## 1. Remove `dryRun`

A dry run cannot exercise the Unity pack without first publishing the CLI nuget — the Unity build 404s on the unpublished version and dies after ~10 min of retries ([example](https://github.com/beamable/BeamableProduct/actions/runs/27370275673)). So it only ever validated version resolution and the CLI/collector build, coverage already in `buildPR.yml`; and a wrong resolution is caught anyway by a tag/version collision at publish time.

- Remove the `dryRun` input and every `if: ${{ inputs.dryRun == false }}` guard, so the workflow always publishes (CLI nuget + changelog + release, Unity UPM + changelog + release, collector to S3, lightbeam).
- Drop the unused `DRY_RUN` env on the nuget step (`release-nuget.sh` publishes when it is not `"true"`).

## 2. Resolve versions first, without the CLI

Resolution used to sit ~5 minutes into the run because it called `beam version construct`, which needs the collector + CLI built first. Everything else it does (changelog parse, `git ls-remote` tag query) is available at checkout. Since this workflow only ever cuts RCs, the version format is fixed, so the string is now assembled directly as `<prefix>-PREVIEW.RC<n>`.

- Move "Resolve RC versions" to immediately after `checkout`.
- Assemble the version string in bash; no `beam` dependency.
- The run now fails fast on a bad changelog / typo'd override / already-shipped line in seconds, and prints the resolved versions up front (and to the run summary). This replaces the old `review options` step, which also still echoed inputs (`cliMajor`, etc.) removed in the earlier auto-derivation redesign.

Verified against the live remote: resolves CLI `7.2.0-PREVIEW.RC8` and Unity `5.1.0-PREVIEW.RC11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)