### PR TITLE
Add RC conveniences to release-unity.yml

### DIFF
--- a/.github/workflows/release-unity.yml
+++ b/.github/workflows/release-unity.yml
@@ -24,9 +24,14 @@ on:
         default: 0
       rcNumber:
         type: number
-        description: Rc version number, if required, 0.0.0-PREVIEW.RCX
+        description: "Rc version number (0 = auto: next RC after the latest tag)"
         required: false
         default: 0
+      nugetVersion:
+        type: string
+        description: "CLI nuget version to bundle. Blank = keep the SDK's current dependency."
+        required: false
+        default: ""
       releaseType:
         type: choice
         description: What type of release is this?
@@ -76,8 +81,38 @@ jobs:
           echo releaseType=${{ inputs.releaseType }}
          
       - uses: actions/checkout@v4
-        with: 
+        with:
           ref: ${{ github.event.inputs.commit }}
+
+      # For an RC with rcNumber 0, derive the next RC from existing tags (read
+      # from the remote, so a shallow clone is fine). Lets you cut RC2..N without
+      # tracking the number. An explicit rcNumber > 0 wins. ~Claude
+      - name: Resolve RC number
+        id: rc
+        if: ${{ inputs.releaseType == 'rc' }}
+        run: |
+          set -euo pipefail
+          rc="${{ inputs.rcNumber }}"
+          if [ "$rc" = "0" ] || [ -z "$rc" ]; then
+            max=$(git ls-remote --tags origin "unity-sdk-${{ inputs.major }}.${{ inputs.minor }}.${{ inputs.patch }}-PREVIEW.RC*" \
+                  | sed -nE 's#.*-PREVIEW\.RC([0-9]+)$#\1#p' | sort -n | tail -1)
+            if [ -z "$max" ]; then rc=1; else rc=$((max + 1)); fi
+          fi
+          echo "NUMBER=$rc" >> "$GITHUB_OUTPUT"
+          echo "Resolved RC number: $rc"
+
+      # Fail fast, before any build, if the changelog's top entry does not match
+      # the version line being cut. ~Claude
+      - name: Guard changelog freshness
+        if: ${{ inputs.releaseType == 'rc' || inputs.releaseType == 'production' }}
+        run: |
+          want="${{ inputs.major }}.${{ inputs.minor }}.${{ inputs.patch }}"
+          top=$(grep -m1 -oP '^##\s*\[\K[0-9]+\.[0-9]+\.[0-9]+' client/Packages/com.beamable/CHANGELOG.md || true)
+          if [ "$top" != "$want" ]; then
+            echo "::error file=client/Packages/com.beamable/CHANGELOG.md::Changelog top entry '$top' does not match $want. Update the changelog before releasing."
+            exit 1
+          fi
+          echo "Changelog OK: $top"
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -136,8 +171,8 @@ jobs:
         run: beam version construct 0 0 0 --nightly > version.txt
       
       - name: Get Version Number (RC)
-        if: ${{ inputs.releaseType == 'rc' }} 
-        run: beam version construct ${{ inputs.major }} ${{ inputs.minor }} ${{ inputs.patch }} --rc ${{ inputs.rcNumber }} > version.txt
+        if: ${{ inputs.releaseType == 'rc' }}
+        run: beam version construct ${{ inputs.major }} ${{ inputs.minor }} ${{ inputs.patch }} --rc ${{ steps.rc.outputs.NUMBER }} > version.txt
       
       - name: Get Version Number (Exp)
         if: ${{ inputs.releaseType == 'exp' }} 
@@ -194,6 +229,17 @@ jobs:
           VERSION: ${{ steps.version.outputs.VERSION }}
           ENVIRONMENT: ${{steps.version.outputs.BUILD_ENV}}
           
+      # Point the SDK at a specific CLI nuget version without hand-editing the
+      # committed file. Blank input keeps the current dependency (reuse the
+      # previous CLI artifact when the CLI has not changed). ~Claude
+      - name: Override bundled CLI nuget version
+        if: ${{ inputs.nugetVersion != '' }}
+        run: |
+          jq --arg v "${{ inputs.nugetVersion }}" '.nugetPackageVersion = $v' \
+            client/Packages/com.beamable/Runtime/Environment/Resources/versions-default.json > tmp.json \
+            && mv tmp.json client/Packages/com.beamable/Runtime/Environment/Resources/versions-default.json
+          cat client/Packages/com.beamable/Runtime/Environment/Resources/versions-default.json
+
       - name: Apply Nuget Version to Unity SDK
         run: |
           beam unity download-all-nuget-packages ./client --logs v


### PR DESCRIPTION
Folds the useful parts of the (now retired, #4660) combined RC workflow into the real **Release Unity SDK** workflow — keeping CLI and Unity decoupled, and keeping the npm trusted publisher intact (this is the trusted filename, so public-npm publishing keeps working).

## Changes

**1. `nugetVersion` input (the deep-file fix + reuse-prior-CLI)**
Optional. When set, jq-writes `nugetPackageVersion` in `versions-default.json` at build time — no more hand-editing that deeply-nested file. **Blank keeps the SDK's current dependency**, i.e. reuse the previous CLI artifact when the CLI has not changed (per Chris). Provide a value only when bundling a freshly cut CLI.

**2. Auto RC number**
For `releaseType: rc`, `rcNumber: 0` (the default) derives the next RC from existing `unity-sdk-<maj.min.patch>-PREVIEW.RC*` tags (read via `git ls-remote`, so a shallow clone is fine). An explicit `rcNumber > 0` always wins. Cut RC2..N without tracking the number.

**3. Fail-fast changelog guard**
For `rc`/`production`, the changelog's top `## [x.y.z]` entry must match `major.minor.patch`, checked right after checkout before any build. nightly/exp are unaffected.

## Notes
- Non-rc modes are otherwise unchanged.
- The orphaned `com.beamable@5.1.0-PREVIEW.RC11` on Nexus (from the retired workflow) means auto-RC would compute `11` and collide. Cut the next Unity RC with **`rcNumber: 12`** explicitly until that line moves on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)