### PR TITLE
Stabilize Unity editor CLI refresh during Account login fix 4653

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Improved content sync resilience for transient SSL/socket reset download failures.
 - Fixed first-run Account window build config setup when `config-defaults.txt` is missing or has no PID.
+- Fixed intermittent Account login `TaskCanceledException` from overlapping Unity editor CLI refreshes.
 - Deserialization issue with `properties` field in Score Items of Events
 - Fixed an issue where the Unity Editor would not detect changes to Icon subObject (for Sprites in Multiple Mode) and thus not saving it correctly
 - Fixed CLI web command spamming `ObjectDisposedException` when the local CLI server is unreachable [4581](https://github.com/beamable/BeamableProduct/issues/4581)

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamCli.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamCli.cs
@@ -71,6 +71,7 @@ namespace Beamable.Editor.BeamCli
 		private ConfigRoutesWrapper _routesInvoke;
 		private ProjectAddUnityProjectWrapper _linkCommand;
 		private ProjectAddPathsWrapper _addPathsInvoke;
+		private Promise _refreshPromise;
 
 		// public Dictionary<string, BeamOrgRealmData> pidToRealm = new Dictionary<string, BeamOrgRealmData>();
 
@@ -105,6 +106,26 @@ namespace Beamable.Editor.BeamCli
 		}
 
 		public async Promise Refresh()
+		{
+			// Refresh owns shared command wrappers; overlapping refreshes cancel each other's requests.
+			if (_refreshPromise != null)
+			{
+				await _refreshPromise;
+				return;
+			}
+
+			_refreshPromise = RefreshImpl();
+			try
+			{
+				await _refreshPromise;
+			}
+			finally
+			{
+				_refreshPromise = null;
+			}
+		}
+
+		private async Promise RefreshImpl()
 		{
 			_addPathsInvoke?.Cancel();
 			var configPath = Path.Combine(latestConfig?.configPath ?? ".beamable", "config.beam.json");
@@ -348,6 +369,11 @@ namespace Beamable.Editor.BeamCli
 			
 			var initPromise = initInvoke.Run();
 			await initPromise;
+
+			if (!string.IsNullOrEmpty(latestLoginError))
+			{
+				return;
+			}
 
 			await Refresh();
 		}

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamWebCommand.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamWebCommand.cs
@@ -135,12 +135,12 @@ namespace Beamable.Editor.BeamCli
 			_serverCommand = null;
 		}
 
-		public void InvalidateServer(Exception cause)
+		public Promise InvalidateServer(Exception cause)
 		{
 			// Marshal back to the editor coroutine thread — port, _serverCommand,
 			// and discoveryRequest are all touched by ServerDiscoveryLoop and
 			// shouldn't race with an async continuation.
-			dispatcher.Schedule(() =>
+			var jobId = dispatcher.Schedule(() =>
 			{
 				_history.AddServerEvent(
 					$"Server invalidated: {cause.GetType().Name}: {cause.Message}");
@@ -149,6 +149,8 @@ namespace Beamable.Editor.BeamCli
 				port = _options.startPortOverride.GetOrElse(8432);
 				discoveryRequest++;
 			});
+
+			return dispatcher.WaitForJobIds(new List<long> { jobId });
 		}
 
 		public string GetServerProcess()
@@ -406,6 +408,21 @@ namespace Beamable.Editor.BeamCli
 		{
 			_history.UpdateResolvingHostTime(id);
 
+			try
+			{
+				await RunHttpRequestOnce();
+			}
+			catch (Exception ex) when (IsRecoverableLocalTransportFailure(ex))
+			{
+				_history.AddCustomLog(id, "[Unity] local CLI transport failed; rediscovering server and retrying once...");
+				await _factory.InvalidateServer(ex);
+				//await _factory.EnsureServerIsRunning();
+				await RunHttpRequestOnce();
+			}
+		}
+
+		private async Promise RunHttpRequestOnce()
+		{
 			await _factory.EnsureServerIsRunning();
 
 			_history.UpdateStartTime(id, _factory.ExecuteUrl);
@@ -495,7 +512,7 @@ namespace Beamable.Editor.BeamCli
 				// some of these as TaskCanceledException even though the token
 				// wasn't tripped \u2014 treat them as transport failures and force
 				// rediscovery before we keep hammering a dead endpoint.
-				_factory.InvalidateServer(ex);
+				//_factory.InvalidateServer(ex);
 				throw;
 			}
 			finally
@@ -528,6 +545,12 @@ namespace Beamable.Editor.BeamCli
 			       || ex is SocketException
 			       || ex is ObjectDisposedException
 			       || ex is IOException;
+		}
+
+		private bool IsRecoverableLocalTransportFailure(Exception ex)
+		{
+			return !_cts.IsCancellationRequested && 
+			       (IsTransportFailure(ex) || ex is OperationCanceledException);
 		}
 
 		public IBeamCommand On<T>(Func<ReportDataPointDescription, bool> predicate, Action<ReportDataPoint<T>> cb)

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamWebCommand.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamWebCommand.cs
@@ -381,6 +381,7 @@ namespace Beamable.Editor.BeamCli
 		private CancellationTokenSource _cts;
 		private BeamWebCliCommandHistory _history;
 		private Promise _runPromise;
+		private const int MaxPreResponseTransportRetries = 2;
 
 		public BeamWebCommand(BeamWebCommandFactory factory, BeamWebCliCommandHistory history)
 		{
@@ -408,16 +409,28 @@ namespace Beamable.Editor.BeamCli
 		{
 			_history.UpdateResolvingHostTime(id);
 
-			try
+			for (var attempt = 0;; attempt++)
 			{
-				await RunHttpRequestOnce();
-			}
-			catch (Exception ex) when (IsRecoverableLocalTransportFailure(ex))
-			{
-				_history.AddCustomLog(id, "[Unity] local CLI transport failed; rediscovering server and retrying once...");
-				await _factory.InvalidateServer(ex);
-				//await _factory.EnsureServerIsRunning();
-				await RunHttpRequestOnce();
+				try
+				{
+					await RunHttpRequestOnce();
+					return;
+				}
+				catch (PreResponseTransportException ex) when (attempt < MaxPreResponseTransportRetries)
+				{
+					if (attempt == 0)
+					{
+						_history.AddCustomLog(id,
+							$"[Unity] local CLI transport failed before response; confirming server before retry. attempt=[{attempt + 1}]");
+						await _factory.EnsureServerIsRunning();
+					}
+					else
+					{
+						_history.AddCustomLog(id,
+							$"[Unity] local CLI transport failed before response; invalidating server before retry. attempt=[{attempt + 1}]");
+						await _factory.InvalidateServer(ex.InnerException ?? ex);
+					}
+				}
 			}
 		}
 
@@ -434,6 +447,7 @@ namespace Beamable.Editor.BeamCli
 			CliLogger.Log("Sending cli web request, " + json);
 			var dispatchedIds = new List<long>();
 			var p = new Promise();
+			var responseStarted = false;
 
 			try
 			{
@@ -447,6 +461,7 @@ namespace Beamable.Editor.BeamCli
 				_history.AddCustomLog(id, "[Unity] sent request...");
 
 				using HttpResponseMessage response = await sendTask;
+				responseStarted = true;
 				_history.AddCustomLog(id, "[Unity] opened response...");
 
 				using Stream streamToReadFrom = await response.Content.ReadAsStreamAsync();
@@ -503,17 +518,9 @@ namespace Beamable.Editor.BeamCli
 				}
 
 			}
-			catch (Exception ex) when (
-				(IsTransportFailure(ex) || ex is OperationCanceledException)
-				&& !_cts.IsCancellationRequested)
+			catch (Exception ex) when (IsRecoverableLocalTransportFailure(ex) && !responseStarted)
 			{
-				// The loopback connection to the CLI server is unhealthy
-				// (server died, port stale, half-closed socket). Mono surfaces
-				// some of these as TaskCanceledException even though the token
-				// wasn't tripped \u2014 treat them as transport failures and force
-				// rediscovery before we keep hammering a dead endpoint.
-				//_factory.InvalidateServer(ex);
-				throw;
+				throw new PreResponseTransportException(ex);
 			}
 			finally
 			{
@@ -549,8 +556,16 @@ namespace Beamable.Editor.BeamCli
 
 		private bool IsRecoverableLocalTransportFailure(Exception ex)
 		{
-			return !_cts.IsCancellationRequested && 
+			return !_cts.IsCancellationRequested &&
 			       (IsTransportFailure(ex) || ex is OperationCanceledException);
+		}
+
+		private class PreResponseTransportException : Exception
+		{
+			public PreResponseTransportException(Exception innerException)
+				: base(innerException.Message, innerException)
+			{
+			}
 		}
 
 		public IBeamCommand On<T>(Func<ReportDataPointDescription, bool> predicate, Action<ReportDataPoint<T>> cb)


### PR DESCRIPTION
Fixes #4653 

### Summary

Fixes an intermittent `TaskCanceledException` in the Unity editor Account login flow caused by overlapping local Beam CLI web-command refreshes and transient local CLI transport failures.

The issue was most visible during repeated Account login/logout testing, especially after login triggered the post-login `BeamCli.Refresh()` burst. Failed login attempts were also able to reach the refresh path, which created extra noise and made the transport issue easier to hit.

### What Changed

- Added bounded retry handling for local CLI web-command failures that happen before response headers are received.
- Kept retries limited to pre-response transport failures to avoid re-running commands that may have already started producing streamed results.
- Made the first retry non-destructive by confirming the local CLI server before invalidating it.
- Invalidates/re-discovers the local CLI server only after a repeated pre-response transport failure.
- Coalesced overlapping `BeamCli.Refresh()` calls so concurrent refresh requests share the same in-flight refresh instead of canceling each other.
- Prevented failed login attempts from continuing into the post-login refresh path.

### Investigation Notes

This started as an intermittent Account window issue where Unity logged:

```text
System.Threading.Tasks.TaskCanceledException: A task was canceled.
System.Net.Http.MonoWebRequestHandler.SendAsync
Beamable.Editor.BeamCli.BeamWebCommand.RunHttpRequestOnce
Beamable.Editor.BeamCli.BeamCli.Refresh
Beamable.Editor.BeamCli.BeamCli.Login
```

The first pass added a retry around local CLI transport failures. That reduced the issue, but testing showed that a single retry was not enough in some login-refresh timing cases.

The next iteration narrowed the retry condition so it only applies before response headers are opened. This protects commands with side effects from being retried after the CLI may have already started processing or streaming results.

Further testing showed wrong-password attempts could still enter the post-login refresh path. That was fixed by returning early when the login command reports a login error.

The remaining intermittent failures appeared only after repeated successful login/logout cycles. At that point, the stack still pointed to `BeamCli.Refresh()`. The root cause was overlapping refresh calls: Refresh() owns shared command wrapper fields and cancels existing command wrappers at the start of a new refresh. When two refreshes overlap, the second refresh can cancel the first refresh's active `config, me, routes`, or related local CLI request, surfacing as `TaskCanceledException`.
The final fix coalesces refresh calls with an in-flight `_refreshPromise`, so overlapping callers await the same refresh instead of canceling each other.

## Validation

Tested in Unity with:
- Repeated successful login/logout cycles.
- Multi-game Account login.
- Realm selection after login.
- Realm switching.
- Wrong password login attempts.
- Wrong username/CID-style invalid login attempts.

After the final refresh coalescing change, repeated focused testing no longer reproduced the TaskCanceledException.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
