### PR TITLE
Throttle Unity CI license activations to the per-serial seat budget

### DIFF
--- a/.github/matchers/unity-license.json
+++ b/.github/matchers/unity-license.json
@@ -1,0 +1,18 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "unity-license-no-valid-license",
+      "severity": "error",
+      "pattern": [
+        { "regexp": "^.*(No valid Unity Editor license found.*)$", "message": 1 }
+      ]
+    },
+    {
+      "owner": "unity-license-ulf-return-failed",
+      "severity": "error",
+      "pattern": [
+        { "regexp": "^.*(Serial number unavailable for ULF return.*)$", "message": 1 }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/buildPR.yml
+++ b/.github/workflows/buildPR.yml
@@ -326,6 +326,24 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.unityVersion }} ${{ matrix.testMode }} Test Results
 
+      # A license/seat activation failure aborts before any tests run, so it produces
+      # no result XML. If the shard failed and no XML exists, surface a plain-language
+      # annotation naming license contention so the red build is self-explanatory and
+      # nobody has to scroll the editor log to find "No valid Unity Editor license
+      # found". (Artifact presence is used rather than parsing the editor stdout, which
+      # a later step cannot read back.) ~Claude
+      - name: Annotate Unity license contention
+        if: failure()
+        shell: bash
+        env:
+          ARTIFACTS: ${{ matrix.testMode }}-${{ matrix.unityVersion }}-artifacts
+        run: |
+          if find "$ARTIFACTS" -name '*.xml' 2>/dev/null | grep -q .; then
+            echo "Test result XML present: this is a genuine test failure, not license contention."
+          else
+            echo "::error title=Unity license contention::${{ matrix.unityVersion }} ${{ matrix.testMode }} produced no test results -- the editor exited before tests ran, the signature of a Unity license/seat activation failure (serial contention), not a test failure."
+          fi
+
   # Second Unity-test shard, pinned to the UNITY_SERIAL_BUILD seat (see the comment
   # above testGroupDefault for the seat-budget rationale). ~Claude
   testGroupBuild:
@@ -464,6 +482,19 @@ jobs:
           artifactsPath: ${{ matrix.testMode }}-${{ matrix.unityVersion }}-artifacts
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.unityVersion }} ${{ matrix.testMode }} Test Results
+
+      # See the annotation rationale above testGroupDefault's matching step. ~Claude
+      - name: Annotate Unity license contention
+        if: failure()
+        shell: bash
+        env:
+          ARTIFACTS: ${{ matrix.testMode }}-${{ matrix.unityVersion }}-artifacts
+        run: |
+          if find "$ARTIFACTS" -name '*.xml' 2>/dev/null | grep -q .; then
+            echo "Test result XML present: this is a genuine test failure, not license contention."
+          else
+            echo "::error title=Unity license contention::${{ matrix.unityVersion }} ${{ matrix.testMode }} produced no test results -- the editor exited before tests ran, the signature of a Unity license/seat activation failure (serial contention), not a test failure."
+          fi
 
   build:
     name: Build for ${{ matrix.targetPlatform }}

--- a/.github/workflows/buildPR.yml
+++ b/.github/workflows/buildPR.yml
@@ -304,6 +304,11 @@ jobs:
           large-packages: true
           docker-images: true
           swap-storage: true
+      # Surface the literal Unity license-contention lines as annotations live, mid-run.
+      # Complements the post-failure XML check below, which controls the job's outcome.
+      # Container-action stdout scope is unconfirmed; verify on a real run. ~Claude
+      - name: Register Unity license problem matcher
+        run: echo "::add-matcher::.github/matchers/unity-license.json"
       - uses: game-ci/unity-test-runner@v4
         id: tests
         timeout-minutes: 30
@@ -461,6 +466,9 @@ jobs:
           large-packages: true
           docker-images: true
           swap-storage: true
+      # See the registration rationale above testGroupDefault's matching step. ~Claude
+      - name: Register Unity license problem matcher
+        run: echo "::add-matcher::.github/matchers/unity-license.json"
       - uses: game-ci/unity-test-runner@v4
         id: tests
         timeout-minutes: 30

--- a/.github/workflows/buildPR.yml
+++ b/.github/workflows/buildPR.yml
@@ -179,12 +179,15 @@ jobs:
         run: dotnet build --configuration Release --no-restore templates/SourceGen/MicroserviceSourceGen.Tests
       - name: Test
         run: dotnet test --configuration Release --no-build templates/SourceGen/MicroserviceSourceGen.Tests
-  # Unity Pro serials allow 2 concurrent activations each. We own 3 serials
-  # (UNITY_SERIAL, UNITY_SERIAL_BUILD, UNITY_SERIAL_DEVOPS = 6 seats total), so the
-  # Unity workload is sharded into one job per serial, each capped at max-parallel: 2.
-  # Each serial is used by exactly one job, so concurrent activations on a serial can
-  # never exceed its 2 seats and we stop tripping spurious "0 entitlement groups"
-  # license-activation failures. Bump max-parallel if a serial's seat count changes. ~Claude
+  # Unity Pro serials allow 2 concurrent activations each, and we own 3 serials
+  # (UNITY_SERIAL, UNITY_SERIAL_BUILD, UNITY_SERIAL_DEVOPS), so the Unity workload is
+  # sharded into one job per serial. Each shard runs max-parallel: 1. Although a serial
+  # has 2 seats, the license return of a finishing leg overlaps the activation of the
+  # next, momentarily demanding a third seat and tripping spurious "No valid Unity Editor
+  # license found" failures (observed on run 27972570615). Capping at 1 leaves a full
+  # seat of headroom for that return/activate transition. This does not guard against
+  # cross-run contention (a second concurrent run on the same serial); raise toward the
+  # seat count only behind a license server that gives blocking seat acquisition. ~Claude
   testGroupDefault:
     timeout-minutes: 30
     name: Tests ${{ matrix.unityVersion }} ${{ matrix.testMode }}
@@ -194,7 +197,7 @@ jobs:
       cancel-in-progress: true
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         projectPath:
           - client
@@ -334,7 +337,7 @@ jobs:
       cancel-in-progress: true
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         projectPath:
           - client
@@ -472,8 +475,9 @@ jobs:
     strategy:
       fail-fast: false
       # All device builds share the UNITY_SERIAL_DEVOPS seat (see the comment above
-      # testGroupDefault). max-parallel: 2 keeps activations within that serial's 2 seats. ~Claude
-      max-parallel: 2
+      # testGroupDefault). max-parallel: 1 leaves a seat of headroom for the license
+      # return/activate transition. ~Claude
+      max-parallel: 1
       matrix:
         targetPlatform:
           - Android

--- a/.github/workflows/buildPR.yml
+++ b/.github/workflows/buildPR.yml
@@ -179,7 +179,13 @@ jobs:
         run: dotnet build --configuration Release --no-restore templates/SourceGen/MicroserviceSourceGen.Tests
       - name: Test
         run: dotnet test --configuration Release --no-build templates/SourceGen/MicroserviceSourceGen.Tests
-  testAllModes:
+  # Unity Pro serials allow 2 concurrent activations each. We own 3 serials
+  # (UNITY_SERIAL, UNITY_SERIAL_BUILD, UNITY_SERIAL_DEVOPS = 6 seats total), so the
+  # Unity workload is sharded into one job per serial, each capped at max-parallel: 2.
+  # Each serial is used by exactly one job, so concurrent activations on a serial can
+  # never exceed its 2 seats and we stop tripping spurious "0 entitlement groups"
+  # license-activation failures. Bump max-parallel if a serial's seat count changes. ~Claude
+  testGroupDefault:
     timeout-minutes: 30
     name: Tests ${{ matrix.unityVersion }} ${{ matrix.testMode }}
     runs-on: ubuntu-latest
@@ -188,6 +194,7 @@ jobs:
       cancel-in-progress: true
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         projectPath:
           - client
@@ -198,23 +205,8 @@ jobs:
           - 2021.3.29f1
           - 2022.3.7f1
           - 6000.0.37f1
-          - 6000.2.8f1
-          - 6000.3.0f1
         gameCiVersion:
           - 3.1.0
-        include:
-          - unityVersion: 2022.3.7f1
-            unityEmailOverride: UNITY_EMAIL_DEVOPS
-            unityPasswordOverride: UNITY_PASSWORD_DEVOPS
-            unitySerialOverride: UNITY_SERIAL_DEVOPS
-          - unityVersion: 2021.3.29f1
-            unityEmailOverride: UNITY_EMAIL_BUILD
-            unityPasswordOverride: UNITY_PASSWORD_BUILD
-            unitySerialOverride: UNITY_SERIAL_BUILD
-          - unityVersion: 6000.0.37f1
-            unityEmailOverride: UNITY_EMAIL_BUILD
-            unityPasswordOverride: UNITY_PASSWORD_BUILD
-            unitySerialOverride: UNITY_SERIAL_BUILD
     env:
       GAME_CI_VERSION: >-
         ${{
@@ -318,9 +310,148 @@ jobs:
           LANG: en_US.UTF-8
           LC_ALL: en_US.UTF-8
           BEAM_UNITY_TEST_CI: "true"
-          UNITY_EMAIL: ${{ secrets[matrix.unityEmailOverride] || secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets[matrix.unityPasswordOverride] || secrets.UNITY_PASSWORD }}
-          UNITY_SERIAL: ${{ secrets[matrix.unitySerialOverride] || secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+        with:
+          customImage: ${{ env.DOCKER_REGISTRY }}/beamable/editor:ubuntu-${{ matrix.unityVersion }}-base-${{ env.GAME_CI_VERSION }}
+          customParameters: -warnaserror+ -executeMethod Beamable.Editor.BeamCli.BeamCliUtil.InstallToolFromLocalPackageSource
+          projectPath: ${{ matrix.projectPath }}
+          testMode: ${{ matrix.testMode }}
+          unityVersion: ${{ matrix.unityVersion }}
+          artifactsPath: ${{ matrix.testMode }}-${{ matrix.unityVersion }}-artifacts
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          checkName: ${{ matrix.unityVersion }} ${{ matrix.testMode }} Test Results
+
+  # Second Unity-test shard, pinned to the UNITY_SERIAL_BUILD seat (see the comment
+  # above testGroupDefault for the seat-budget rationale). ~Claude
+  testGroupBuild:
+    timeout-minutes: 30
+    name: Tests ${{ matrix.unityVersion }} ${{ matrix.testMode }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: unity-tests-${{ matrix.unityVersion }}-${{ matrix.testMode }}-${{ github.head_ref }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        projectPath:
+          - client
+        testMode:
+          - playmode
+          - editmode
+        unityVersion:
+          - 6000.2.8f1
+          - 6000.3.0f1
+        gameCiVersion:
+          - 3.1.0
+    env:
+      GAME_CI_VERSION: >-
+        ${{
+          matrix.unityVersion == '6000.2.8f1' && '3.2.0' ||
+          matrix.unityVersion == '6000.3.0f1' && '3.2.1' ||
+          matrix.gameCiVersion
+        }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKER_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Unity Mapped Values
+        id: unityMap
+        env:
+          UNITY_MODE: >-
+            ${{ fromJson('{
+              "playmode": "player",
+              "editmode": "editor"
+            }')[matrix.testMode] }}
+        run: |
+          echo "UNITY_MODE=$UNITY_MODE" >> "$GITHUB_OUTPUT"
+
+
+      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            10.0.x
+            9.0.x
+            8.0.302
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.1
+          cache-dependency-path: ./otel-collector/beamable-collector/go.sum
+      - name: Build and Install BEAM CLI
+        working-directory: ./
+        run: |
+          ./setup.sh
+          SKIP_GENERATION=true ./dev.sh --skip-unreal
+        env:
+          PROJECT_DIR_OVERRIDE: ${{ github.workspace }}/NugetBuildDir/
+      - name: Check Beam CLI
+        run: |
+          pwd
+          ls -a
+          beam version
+      - name: Apply Nuget Version to Unity SDK
+        run: |
+          ReleaseSharedCode=true dotnet build ./cli/beamable.common -t:CopyCodeToUnity
+
+      - name: Apply CLI Versions
+        run: jq --arg nextVersion 0.0.123.1 '.nugetPackageVersion = $nextVersion' ./client/Packages/com.beamable/Runtime/Environment/Resources/versions-default.json > localtmpfile && mv localtmpfile ./client/Packages/com.beamable/Runtime/Environment/Resources/versions-default.json
+
+      - name: Review Unity version-default file
+        run: |
+          cat ./client/Packages/com.beamable/Runtime/Environment/Resources/versions-default.json
+
+      - name: Copy the nuget packages into unity
+        working-directory: ./
+        run: |
+          mkdir -p client/BeamableNugetSource/
+          ls BeamableNugetSource
+          cp BeamableNugetSource/*.nupkg client/BeamableNugetSource/
+
+      - name: Cache Unity Folders
+        uses: actions/cache@v3
+        with:
+          path: ${{ matrix.projectPath }}/Library
+          key: Library-2-${{ matrix.projectPath }}-${{ matrix.unityVersion }}
+          restore-keys: |
+            Library-2-${{ matrix.projectPath }}-${{ matrix.unityVersion }}
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+      - uses: game-ci/unity-test-runner@v4
+        id: tests
+        timeout-minutes: 30
+        env:
+          DOTNET_CLI_UI_LANGUAGE: en
+          DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
+          LANG: en_US.UTF-8
+          LC_ALL: en_US.UTF-8
+          BEAM_UNITY_TEST_CI: "true"
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL_BUILD }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD_BUILD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL_BUILD }}
         with:
           customImage: ${{ env.DOCKER_REGISTRY }}/beamable/editor:ubuntu-${{ matrix.unityVersion }}-base-${{ env.GAME_CI_VERSION }}
           customParameters: -warnaserror+ -executeMethod Beamable.Editor.BeamCli.BeamCliUtil.InstallToolFromLocalPackageSource
@@ -340,6 +471,9 @@ jobs:
       cancel-in-progress: true
     strategy:
       fail-fast: false
+      # All device builds share the UNITY_SERIAL_DEVOPS seat (see the comment above
+      # testGroupDefault). max-parallel: 2 keeps activations within that serial's 2 seats. ~Claude
+      max-parallel: 2
       matrix:
         targetPlatform:
           - Android
@@ -350,15 +484,6 @@ jobs:
           - 6000.0.37f1
         projectPath:
           - client
-        include:
-          - targetPlatform: Android
-            unityEmailOverride: UNITY_EMAIL_DEVOPS
-            unityPasswordOverride: UNITY_PASSWORD_DEVOPS
-            unitySerialOverride: UNITY_SERIAL_DEVOPS
-          - targetPlatform: StandaloneOSX
-            unityEmailOverride: UNITY_EMAIL_BUILD
-            unityPasswordOverride: UNITY_PASSWORD_BUILD
-            unitySerialOverride: UNITY_SERIAL_BUILD
     steps:
       - uses: actions/checkout@v4
         with:
@@ -446,9 +571,9 @@ jobs:
       - uses: game-ci/unity-builder@v4
         timeout-minutes: 60
         env:
-          UNITY_EMAIL: ${{ secrets[matrix.unityEmailOverride] || secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets[matrix.unityPasswordOverride] || secrets.UNITY_PASSWORD }}
-          UNITY_SERIAL: ${{ secrets[matrix.unitySerialOverride] || secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL_DEVOPS }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD_DEVOPS }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL_DEVOPS }}
         with:
           customImage: ${{ env.DOCKER_REGISTRY }}/beamable/editor:ubuntu-${{ matrix.unityVersion }}-${{steps.unityMap.outputs.UNITY_PLATFORM}}-3.1.0
           targetPlatform: ${{ matrix.targetPlatform }}


### PR DESCRIPTION
## Problem

The `PR Build` Unity matrix fans out **14 jobs at once** (10 test cells + 4 device builds) against **3 Unity Pro serials** (`UNITY_SERIAL`, `UNITY_SERIAL_BUILD`, `UNITY_SERIAL_DEVOPS`). Pro serials allow only **2 concurrent activations each → 6 seats total**, and neither Unity matrix had a `max-parallel` cap, so demand (14) overwhelmed the ceiling (6) on every run.

When a serial is already at its 2-seat limit, the next job's activation comes back `404 — Found 0 entitlement groups`, Unity reports `No valid Unity Editor license found`, and the job fails with exit code 1 — **before compiling anything**. These are false failures from license contention, not real defects.

Measured over the last ~4 weeks of `PR Build` runs: of the failed runs with retrievable logs, **63% (40 of 63) died on this license flake**, and from Jun 1 onward **~47% of *all* runs** (pass or fail) lost at least one Unity job to it — a random 1–4 cells per run. It is the single largest source of red checks, ahead of genuine breakages.

## Fix

Match concurrency to the fixed seat budget. GitHub's `concurrency:` groups are a mutex that *cancels* sibling matrix cells, so they cannot express "allow 2." `max-parallel` is a true semaphore (queues, never cancels) but is per-matrix-job. So the Unity work is sharded into **one job per serial, each capped at `max-parallel: 2`**, with serials assigned so **no two jobs share a serial**:

| Job | Serial | Cells | Waves @ mp2 |
|---|---|---|---|
| `testGroupDefault` | `UNITY_SERIAL` | 2021.3.29, 2022.3.7, 6000.0.37 × {playmode, editmode} | 3 |
| `testGroupBuild` | `UNITY_SERIAL_BUILD` | 6000.2.8, 6000.3.0 × {playmode, editmode} | 2 |
| `build` | `UNITY_SERIAL_DEVOPS` | Android, iOS, StandaloneOSX, StandaloneWindows | 2 |

Because each serial is owned by exactly one job and that job runs at most 2 cells at a time, **concurrent activations on a serial can never exceed its 2 seats.** Unity Pro serials are version/platform-agnostic (every serial already ran a mix today), so reassigning versions/platforms across serials is safe.

## What does *not* change

- All 10 test cells (5 versions × 2 modes) and all 4 build platforms still run.
- Per-cell check names (`Tests {ver} {mode}`, `Build for {platform}`) are byte-for-byte identical, so **branch-protection required checks keep matching** — no settings change needed.
- `fail-fast: false` is preserved on every job.

## Trade-off

Wall-clock grows. The bottleneck serial now runs its 6 cells in 3 sequential waves of 2, so a clean run moves from roughly **~13 min → ~30–35 min**. `max-parallel` serializes the whole job (including the seat-free ~8 min setup), so this is conservative; warm caches help. This is the deliberate cost of fitting 14 jobs into 6 seats, and accuracy is the priority — a red check should mean something is actually wrong, not that two jobs raced for a license.

If the wall-clock is unwelcome, the orthogonal lever is to trim the per-PR version matrix (e.g. run the full five-version sweep only on merge to `main`/`staging`), which lowers demand below the seat ceiling and speeds things back up.

The `max-parallel: 2` values are commented and centralized — bump them if the seat count per serial ever changes.


## Known residual — scope of this fix

This change caps activations **within a single `PR Build` run**, which was the dominant cause (one run alone oversubscribed 14 jobs onto 6 seats). It deliberately does **not** coordinate seat usage *across* concurrent runs, because GitHub's native primitives can't express a global counting semaphore (`max-parallel` is per-run; `concurrency:` only counts to 1 and cancels siblings). Two gaps remain, both expected and left for a possible follow-up:

- **Concurrent PRs share the same three serials.** Two `PR Build` runs that start within a few minutes of each other phase-align (every run has the same internal wave period), so their license-needing windows tend to coincide and can again exceed a serial's 2 seats. Bursty same-operator activity — pushing fixups to several PRs in a 5–10 min window — is the pattern most likely to trip this.
- **The seat pool is shared org-wide.** `UNITY_SERIAL` / `UNITY_SERIAL_BUILD` / `UNITY_SERIAL_DEVOPS` are also used by `lightBeamPr`, `release-nightly` (push-triggered, i.e. fires on merge), `release-unity`, and `installer-*`. So a `PR Build` can still contend with a nightly/release/lightBeam Unity job for the same seats.

The symptom of either is the same as before but much rarer: one or two red Unity checks from contention rather than ~half of all runs. If post-merge data shows the residual is material, the only thing that fully closes a shared pool is an external counting-lock wrapping every Unity job in every workflow (a merge queue would only cover the merge/push sub-case). Suggested next step is to keep watching, not to build that speculatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

