### PR TITLE
fix(content): recover poisoned manifest promise after a failed fetch

### DIFF
--- a/microservice/microservice/CHANGELOG.md
+++ b/microservice/microservice/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- C# microservice content resolution now retries transient HTTP failures and no longer caches failed content resolution tasks [#4599](https://github.com/beamable/BeamableProduct/issues/4599)
+
 ## [7.2.0] - 2026-05-23
 
 ### Changed

--- a/microservice/microservice/CHANGELOG.md
+++ b/microservice/microservice/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- C# microservice content manifest fetches now use bounded retries for transient failures, avoiding unbounded refetch loops after failed manifest requests [#4704](https://github.com/beamable/BeamableProduct/pull/4704)
+
 ## [7.2.0] - 2026-05-23
 
 ### Changed

--- a/microservice/microservice/CHANGELOG.md
+++ b/microservice/microservice/CHANGELOG.md
@@ -8,8 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- C# microservice content manifest fetches now use bounded retries for transient failures, avoiding unbounded refetch loops after failed manifest requests [#4704](https://github.com/beamable/BeamableProduct/pull/4704)
-- C# microservice content resolution now retries transient HTTP failures and no longer caches failed content resolution tasks [#4599](https://github.com/beamable/BeamableProduct/issues/4599)
+- Microservice content fetches now retry with bounded exponential backoff and jitter. This applies to both manifest and content entry fetches.
 
 ## [7.2.0] - 2026-05-23
 

--- a/microservice/microservice/Common/Cache.cs
+++ b/microservice/microservice/Common/Cache.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace microservice.Common
@@ -10,8 +11,8 @@ namespace microservice.Common
    {
       public delegate Task<TValue> Resolver(TKey key);
 
-      private ConcurrentDictionary<TKey, Task<TValue>> _data = new ConcurrentDictionary<TKey, Task<TValue>>();
-      private Resolver _resolver;
+      private readonly ConcurrentDictionary<TKey, Lazy<Task<TValue>>> _data = new();
+      private readonly Resolver _resolver;
 
       public Cache(Resolver resolver)
       {
@@ -39,17 +40,34 @@ namespace microservice.Common
          _data.TryRemove(key, out _);
       }
 
+      /// <summary>
+      /// Shares an in-flight resolver task and caches successful results. Faulted or canceled
+      /// tasks are removed so a later request can retry the resolver.
+      /// </summary>
       public Task<TValue> Get(TKey key)
       {
-         if (_data.TryGetValue(key, out var existing))
+         Lazy<Task<TValue>> candidate = null;
+         candidate = new Lazy<Task<TValue>>(
+            () => ResolveAndEvictOnFailure(key, candidate),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+         var entry = _data.GetOrAdd(key, candidate);
+         return entry.Value;
+      }
+
+      private async Task<TValue> ResolveAndEvictOnFailure(TKey key, Lazy<Task<TValue>> entry)
+      {
+         try
          {
-            return existing;
+            return await _resolver(key);
          }
-
-         var task = _resolver(key);
-         _data.AddOrUpdate(key, task, (_, oldValue) => task);
-
-         return task;
+         catch
+         {
+            // Remove only this failed entry. A newer value may have replaced it after a purge.
+            ((ICollection<KeyValuePair<TKey, Lazy<Task<TValue>>>>)_data)
+               .Remove(new KeyValuePair<TKey, Lazy<Task<TValue>>>(key, entry));
+            throw;
+         }
       }
    }
 }

--- a/microservice/microservice/Content/ContentService.cs
+++ b/microservice/microservice/Content/ContentService.cs
@@ -145,11 +145,12 @@ namespace Beamable.Server.Content
 	   
 	   public Promise<ClientManifest> WaitForManifest()
 	   {
-		   var hasNoManifest = true;
 		   lock (_manifestLock)
 		   {
-			   hasNoManifest = _waitForManifest == null;
-			   if (hasNoManifest)
+			   // Refetch when there is no manifest yet, or when the cached promise settled in a
+			   // failed state (e.g. a 503 during a refresh). Without the IsFailed check the failed
+			   // promise would be re-awaited forever, breaking all content resolution until restart.
+			   if (_waitForManifest == null || _waitForManifest.IsFailed)
 			   {
 				   RefreshManifest();
 			   }

--- a/microservice/microservice/Content/ContentService.cs
+++ b/microservice/microservice/Content/ContentService.cs
@@ -115,6 +115,9 @@ namespace Beamable.Server.Content
 
    public class CachedContentManifest
    {
+	   private const int MaxManifestAttempts = 3;
+	   private static readonly TimeSpan MaxManifestRetryDelay = TimeSpan.FromSeconds(2);
+
 	   public string _name;
 	   private readonly MicroserviceRequester _requester;
 	   private readonly ConcurrentDictionary<string, ContentReference> _idToContentReference = new ConcurrentDictionary<string, ContentReference>();
@@ -173,17 +176,13 @@ namespace Beamable.Server.Content
 	   }
 
 	   
-      public void RefreshManifest()
+	   public void RefreshManifest()
       {
          lock (_manifestLock)
          {
             var oldPromise = _waitForManifest;
             // reset the manifest promise, so that if a content request comes while a manifest is being retrieved, we wait for the updated content to be served
-            _waitForManifest = _requester.Request<ContentManifest>(Method.GET, $"/basic/content/manifest?id={_name}")
-	            .RecoverFrom404(ex => new ContentManifest
-	            {
-		            id = _name, created = 0, references = new List<ContentReference>()
-	            })
+            _waitForManifest = RequestManifestWithRetries()
 	            .Map(manifest =>
                {
                   _idToContentReference.Clear();
@@ -227,6 +226,45 @@ namespace Beamable.Server.Content
             }
          }
       }
+
+	   private Promise<ContentManifest> RequestManifestWithRetries()
+	   {
+		   return RequestManifestWithRetriesAsync().ToPromise();
+	   }
+
+	   private async Task<ContentManifest> RequestManifestWithRetriesAsync()
+	   {
+		   for (var attempt = 1; attempt <= MaxManifestAttempts; attempt++)
+		   {
+			   try
+			   {
+				   return await _requester.Request<ContentManifest>(Method.GET, $"/basic/content/manifest?id={_name}")
+					   .RecoverFrom404(ex => new ContentManifest
+					   {
+						   id = _name, created = 0, references = new List<ContentReference>()
+					   });
+			   }
+			   catch (RequesterException ex) when (IsTransientManifestFailure(ex.Status) && attempt < MaxManifestAttempts)
+			   {
+				   await Task.Delay(GetManifestRetryDelay(attempt));
+			   }
+		   }
+
+		   // The loop either returns or rethrows the original final/non-transient exception.
+		   throw new InvalidOperationException("Unreachable manifest retry state.");
+	   }
+
+	   private static bool IsTransientManifestFailure(long status)
+	   {
+		   return status is 0 or 408 or 429 or 500 or 502 or 503 or 504;
+	   }
+
+	   private static TimeSpan GetManifestRetryDelay(int attempt)
+	   {
+		   var backoffMilliseconds = 200 * (1 << (attempt - 1));
+		   var delay = TimeSpan.FromMilliseconds(backoffMilliseconds + Random.Shared.Next(0, 101));
+		   return delay > MaxManifestRetryDelay ? MaxManifestRetryDelay : delay;
+	   }
    }
 
    public class ContentService : IMicroserviceContentApi

--- a/microservice/microservice/Content/ContentService.cs
+++ b/microservice/microservice/Content/ContentService.cs
@@ -234,24 +234,28 @@ namespace Beamable.Server.Content
 
 	   private async Task<ContentManifest> RequestManifestWithRetriesAsync()
 	   {
-		   for (var attempt = 1; attempt <= MaxManifestAttempts; attempt++)
+		   for (var attempt = 1; attempt < MaxManifestAttempts; attempt++)
 		   {
 			   try
 			   {
-				   return await _requester.Request<ContentManifest>(Method.GET, $"/basic/content/manifest?id={_name}")
-					   .RecoverFrom404(ex => new ContentManifest
-					   {
-						   id = _name, created = 0, references = new List<ContentReference>()
-					   });
+				   return await RequestManifestOnceAsync();
 			   }
-			   catch (RequesterException ex) when (IsTransientManifestFailure(ex.Status) && attempt < MaxManifestAttempts)
+			   catch (RequesterException ex) when (IsTransientManifestFailure(ex.Status))
 			   {
 				   await Task.Delay(GetManifestRetryDelay(attempt));
 			   }
 		   }
 
-		   // The loop either returns or rethrows the original final/non-transient exception.
-		   throw new InvalidOperationException("Unreachable manifest retry state.");
+		   return await RequestManifestOnceAsync();
+	   }
+
+	   private async Task<ContentManifest> RequestManifestOnceAsync()
+	   {
+		   return await _requester.Request<ContentManifest>(Method.GET, $"/basic/content/manifest?id={_name}")
+			   .RecoverFrom404(ex => new ContentManifest
+			   {
+				   id = _name, created = 0, references = new List<ContentReference>()
+			   });
 	   }
 
 	   private static bool IsTransientManifestFailure(long status)
@@ -261,7 +265,7 @@ namespace Beamable.Server.Content
 
 	   private static TimeSpan GetManifestRetryDelay(int attempt)
 	   {
-		   var backoffMilliseconds = 200 * (1 << (attempt - 1));
+		   var backoffMilliseconds = 200 * Math.Pow(2, attempt - 1);
 		   var delay = TimeSpan.FromMilliseconds(backoffMilliseconds + Random.Shared.Next(0, 101));
 		   return delay > MaxManifestRetryDelay ? MaxManifestRetryDelay : delay;
 	   }

--- a/microservice/microservice/Properties/AssemblyInfo.cs
+++ b/microservice/microservice/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("BeamableMicroserviceBaseTests")]

--- a/microservice/microservice/dbmicroservice/IContentResolver.cs
+++ b/microservice/microservice/dbmicroservice/IContentResolver.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
-using System.Threading.Tasks;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 
 namespace Beamable.Server
 {
@@ -13,10 +15,18 @@ namespace Beamable.Server
 
    public class DefaultContentResolver : IContentResolver
    {
-	   private HttpClient client;
-	   private string _suffixFilter;
+	   private const int MaxAttempts = 3;
+	   private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(2);
+
+	   private readonly HttpClient _client;
+	   private readonly string _suffixFilter;
 
 	   public DefaultContentResolver(IMicroserviceArgs args)
+		   : this(args, null)
+	   {
+	   }
+
+	   internal DefaultContentResolver(IMicroserviceArgs args, HttpClient httpClient)
 	   {
 		   if (string.IsNullOrEmpty(args?.Host) || args.Host.Contains("localhost"))
 		   {
@@ -33,10 +43,18 @@ namespace Beamable.Server
 			   if (idx != -1)
 				   _suffixFilter = _suffixFilter.Substring(0, idx);
 		   }
-		   
-		   var handler = new HttpClientHandler();
-		   handler.ServerCertificateCustomValidationCallback = ServerCertificateCustomValidationCallback;
-		   client = new HttpClient(handler);
+
+		   if (httpClient != null)
+		   {
+			   _client = httpClient;
+			   return;
+		   }
+
+		   var handler = new HttpClientHandler
+		   {
+			   ServerCertificateCustomValidationCallback = ServerCertificateCustomValidationCallback
+		   };
+		   _client = new HttpClient(handler);
 	   }
 
 	   public bool ServerCertificateCustomValidationCallback(HttpRequestMessage msg, X509Certificate2 cert, X509Chain chain, SslPolicyErrors errors)
@@ -46,9 +64,99 @@ namespace Beamable.Server
 		   return isBeamableAddr;
 	   }
 
-	   public Task<string> RequestContent(string uri)
+	   /// <summary>
+	   /// Downloads immutable content, retrying bounded transient HTTP and transport failures.
+	   /// </summary>
+	   public async Task<string> RequestContent(string uri)
 	   {
-		   return client.GetStringAsync(uri);
+		   for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+		   {
+			   HttpResponseMessage response;
+			   try
+			   {
+				   response = await _client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead);
+			   }
+			   catch (HttpRequestException ex)
+			   {
+				   if (attempt == MaxAttempts)
+				   {
+					   throw CreateFinalException(uri, ex.StatusCode, attempt, ex);
+				   }
+
+				   await Task.Delay(GetRetryDelay(null, attempt));
+				   continue;
+			   }
+
+			   using (response)
+			   {
+				   if (response.IsSuccessStatusCode)
+				   {
+					   return await response.Content.ReadAsStringAsync();
+				   }
+
+				   if (!IsTransient(response.StatusCode))
+				   {
+					   response.EnsureSuccessStatusCode();
+				   }
+
+				   if (attempt == MaxAttempts)
+				   {
+					   throw CreateFinalException(uri, response.StatusCode, attempt, null);
+				   }
+
+				   await Task.Delay(GetRetryDelay(response.Headers.RetryAfter, attempt));
+			   }
+		   }
+
+		   throw CreateFinalException(uri, null, MaxAttempts, null);
+	   }
+
+	   private static bool IsTransient(HttpStatusCode statusCode)
+	   {
+		   return statusCode is HttpStatusCode.RequestTimeout 
+			   or HttpStatusCode.TooManyRequests 
+			   or HttpStatusCode.InternalServerError 
+			   or HttpStatusCode.BadGateway 
+			   or HttpStatusCode.ServiceUnavailable 
+			   or HttpStatusCode.GatewayTimeout;
+	   }
+
+	   private static TimeSpan GetRetryDelay(
+		   System.Net.Http.Headers.RetryConditionHeaderValue retryAfter,
+		   int attempt)
+	   {
+		   TimeSpan delay;
+		   if (retryAfter?.Delta != null)
+		   {
+			   delay = retryAfter.Delta.Value;
+		   }
+		   else if (retryAfter?.Date != null)
+		   {
+			   delay = retryAfter.Date.Value - DateTimeOffset.UtcNow;
+		   }
+		   else
+		   {
+			   var backoffMilliseconds = 200 * (1 << (attempt - 1));
+			   delay = TimeSpan.FromMilliseconds(backoffMilliseconds + Random.Shared.Next(0, 101));
+		   }
+
+		   if (delay < TimeSpan.Zero)
+		   {
+			   return TimeSpan.Zero;
+		   }
+
+		   return delay > MaxRetryDelay ? MaxRetryDelay : delay;
+	   }
+
+	   private static HttpRequestException CreateFinalException(string uri, HttpStatusCode? statusCode, int attempts, Exception innerException)
+	   {
+		   var status = statusCode.HasValue
+			   ? $"{(int)statusCode.Value} {statusCode.Value}"
+			   : "unavailable";
+		   return new HttpRequestException(
+			   $"Content request failed. uri=[{uri}] status=[{status}] attempts=[{attempts}]",
+			   innerException,
+			   statusCode);
 	   }
    }
 }

--- a/microservice/microserviceTests/microservice/Common/CacheTests.cs
+++ b/microservice/microserviceTests/microservice/Common/CacheTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using microservice.Common;
+using NUnit.Framework;
+
+namespace microserviceTests.microservice.Common;
+
+[TestFixture]
+public class CacheTests
+{
+   [Test]
+   public async Task FaultedTaskIsRemovedAndNextGetRetries()
+   {
+      var calls = 0;
+      var cache = new Cache<string, int>(_ =>
+      {
+         calls++;
+         return calls == 1
+            ? Task.FromException<int>(new InvalidOperationException("temporary failure"))
+            : Task.FromResult(42);
+      });
+
+      Assert.ThrowsAsync<InvalidOperationException>(async () => await cache.Get("key"));
+
+      Assert.That(await cache.Get("key"), Is.EqualTo(42));
+      Assert.That(calls, Is.EqualTo(2));
+   }
+
+   [Test]
+   public async Task CanceledTaskIsRemovedAndNextGetRetries()
+   {
+      var calls = 0;
+      var canceledToken = new CancellationToken(true);
+      var cache = new Cache<string, int>(_ =>
+      {
+         calls++;
+         return calls == 1
+            ? Task.FromCanceled<int>(canceledToken)
+            : Task.FromResult(42);
+      });
+
+      Assert.ThrowsAsync<TaskCanceledException>(async () => await cache.Get("key"));
+
+      Assert.That(await cache.Get("key"), Is.EqualTo(42));
+      Assert.That(calls, Is.EqualTo(2));
+   }
+
+   [Test]
+   public async Task SuccessfulTaskRemainsCached()
+   {
+      var calls = 0;
+      var cache = new Cache<string, int>(_ =>
+      {
+         calls++;
+         return Task.FromResult(42);
+      });
+
+      Assert.That(await cache.Get("key"), Is.EqualTo(42));
+      Assert.That(await cache.Get("key"), Is.EqualTo(42));
+      Assert.That(calls, Is.EqualTo(1));
+   }
+
+   [Test]
+   public async Task ConcurrentCallersShareOneResolverTask()
+   {
+      var calls = 0;
+      var completion = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+      var cache = new Cache<string, int>(_ =>
+      {
+         Interlocked.Increment(ref calls);
+         return completion.Task;
+      });
+
+      var requests = new List<Task<int>>();
+      for (var i = 0; i < 20; i++)
+      {
+         requests.Add(cache.Get("key"));
+      }
+
+      completion.SetResult(42);
+
+      Assert.That(await Task.WhenAll(requests), Is.All.EqualTo(42));
+      Assert.That(calls, Is.EqualTo(1));
+   }
+
+   [Test]
+   public async Task OldFailureDoesNotRemoveNewerEntry()
+   {
+      var calls = 0;
+      var first = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+      var second = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+      var cache = new Cache<string, int>(_ =>
+      {
+         calls++;
+         return calls == 1 ? first.Task : second.Task;
+      });
+
+      var oldTask = cache.Get("key");
+      cache.Purge("key");
+      var newTask = cache.Get("key");
+
+      first.SetException(new InvalidOperationException("old failure"));
+      Assert.ThrowsAsync<InvalidOperationException>(async () => await oldTask);
+
+      second.SetResult(42);
+      Assert.That(await newTask, Is.EqualTo(42));
+      Assert.That(await cache.Get("key"), Is.EqualTo(42));
+      Assert.That(calls, Is.EqualTo(2));
+   }
+}

--- a/microservice/microserviceTests/microservice/Content/ContentResilienceStressTests.cs
+++ b/microservice/microserviceTests/microservice/Content/ContentResilienceStressTests.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Beamable.Common;
+using Beamable.Common.Content;
+using Beamable.Common.Inventory;
+using Beamable.Common.Reflection;
+using Beamable.Microservice.Tests.Socket;
+using Beamable.Server;
+using Beamable.Server.Content;
+using microserviceTests.microservice.Util;
+using NUnit.Framework;
+
+namespace microserviceTests.microservice.Content;
+
+[TestFixture]
+public class ContentResilienceStressTests
+{
+   private const int ConcurrentCallCount = 100;
+
+   private ReflectionCache _cache;
+
+   [SetUp]
+   public void Setup()
+   {
+      _cache = new ReflectionCache();
+      var contentTypeCache = new ContentTypeReflectionCache();
+      _cache.RegisterTypeProvider(contentTypeCache);
+      _cache.RegisterReflectionSystem(contentTypeCache);
+
+      var asms = AppDomain.CurrentDomain.GetAssemblies().Select(asm => asm.GetName().Name).ToList();
+      _cache.GenerateReflectionCache(asms);
+
+      LoggingUtil.InitTestCorrelator();
+   }
+
+   [Test]
+   public async Task ConcurrentContentRequestsShareBoundedManifestRetryAndResolvedContentCache()
+   {
+      var manifestAttempts = 0;
+      var contentResolverCalls = 0;
+      var contentResolver = new TestContentResolver(async _ =>
+      {
+         Interlocked.Increment(ref contentResolverCalls);
+         await Task.Delay(50);
+         return SerializeItemContent("foo");
+      });
+
+      using var harness = CreateContentService(
+         contentResolver,
+         req =>
+         {
+            var attempt = Interlocked.Increment(ref manifestAttempts);
+            if (attempt <= 2)
+            {
+               return TransientManifestFailure(req, HttpStatusCode.ServiceUnavailable);
+            }
+
+            return ManifestSuccess(req);
+         },
+         MessageFrequency.Exactly(3));
+
+      var requests = Enumerable
+         .Range(0, ConcurrentCallCount)
+         .Select(_ => Task.Run(async () => await harness.ContentService.GetContent("items.foo")))
+         .ToArray();
+
+      var results = await Task.WhenAll(requests);
+
+      Assert.That(results.Select(result => result.Id), Is.All.EqualTo("items.foo"));
+      Assert.That(manifestAttempts, Is.EqualTo(3), "all callers should share one bounded manifest retry group");
+      Assert.That(contentResolverCalls, Is.EqualTo(1), "all callers should share one resolved content cache task");
+      Assert.That(harness.TestSocket.AllMocksCalled(), Is.True);
+   }
+
+   [Test]
+   public async Task ConcurrentContentRequestsShareOneBoundedResolvedContentDownloadRetry()
+   {
+      var content = SerializeItemContent("foo");
+      var handler = new CountingHttpMessageHandler(async attempt =>
+      {
+         await Task.Delay(25);
+         return attempt <= 2
+            ? Response(HttpStatusCode.ServiceUnavailable)
+            : Response(HttpStatusCode.OK, content);
+      });
+      var contentResolver = new DefaultContentResolver(new TestArgs(), new HttpClient(handler));
+
+      using var harness = CreateContentService(
+         contentResolver,
+         ManifestSuccess,
+         MessageFrequency.Exactly(1));
+
+      var requests = Enumerable
+         .Range(0, ConcurrentCallCount)
+         .Select(_ => Task.Run(async () => await harness.ContentService.GetContent("items.foo")))
+         .ToArray();
+
+      var results = await Task.WhenAll(requests);
+
+      Assert.That(results.Select(result => result.Id), Is.All.EqualTo("items.foo"));
+      Assert.That(handler.CallCount, Is.EqualTo(3), "resolved content should be downloaded by one shared cache task with bounded HTTP retry");
+      Assert.That(harness.TestSocket.AllMocksCalled(), Is.True);
+   }
+
+   private ContentServiceHarness CreateContentService(
+      IContentResolver contentResolver,
+      TestSocketResponseGenerator manifestResponder,
+      MessageFrequencyRequirements manifestFrequency)
+   {
+      var args = new TestArgs();
+      var reqCtx = new RequestContext(args.CustomerID, args.ProjectName, 1, 200, 1, "path", "GET", "");
+      TestSocket testSocket = null;
+      var socketProvider = new TestSocketProvider(socket =>
+      {
+         testSocket = socket;
+         socket.AddMessageHandler(
+            MessageMatcher
+               .WithRouteContains("basic/content/manifest")
+               .WithGet(),
+            manifestResponder,
+            manifestFrequency);
+         socket.SetAuthentication(true);
+      });
+
+      var socket = socketProvider.Create("test", args);
+      var socketCtx = new SocketRequesterContext(() => Promise<IConnection>.Successful(socket));
+      var requester = new MicroserviceRequester(args, reqCtx, socketCtx, false, new NoopActivityProvider());
+      (_, socketCtx.Daemon) =
+         MicroserviceAuthenticationDaemon.Start(args, requester, new CancellationTokenSource());
+
+      var contentService = new ContentService(requester, socketCtx, contentResolver, _cache);
+
+      testSocket.Connect();
+      testSocket.OnMessage((_, data, id) =>
+      {
+         data.TryBuildRequestContext(args, out var rc);
+         socketCtx.HandleMessage(null, rc).Wait();
+      });
+
+      return new ContentServiceHarness(contentService, testSocket, socketCtx);
+   }
+
+   private static WebsocketResponse ManifestSuccess(WebsocketResponse req)
+   {
+      return req.Succeed(new ContentManifest
+      {
+         id = "global",
+         created = 1,
+         references = new List<ContentReference>
+         {
+            new ContentReference
+            {
+               id = "items.foo",
+               version = "123",
+               uri = "https://content.beamable.com/items.foo.json",
+               visibility = "public"
+            }
+         }
+      });
+   }
+
+   private static WebsocketResponse TransientManifestFailure(WebsocketResponse req, HttpStatusCode statusCode)
+   {
+      return new WebsocketResponse
+      {
+         id = req.id,
+         from = 0,
+         status = (int)statusCode,
+         body = new WebsocketErrorResponse
+         {
+            status = (int)statusCode,
+            service = "content",
+            error = statusCode.ToString(),
+            message = ((int)statusCode).ToString()
+         }
+      };
+   }
+
+   private static string SerializeItemContent(string name)
+   {
+      var content = new ItemContent();
+      content.SetContentName(name);
+      return new MicroserviceContentSerializer().Serialize(content);
+   }
+
+   private static HttpResponseMessage Response(HttpStatusCode statusCode, string content = "")
+   {
+      return new HttpResponseMessage(statusCode)
+      {
+         Content = new StringContent(content)
+      };
+   }
+
+   private sealed class CountingHttpMessageHandler : HttpMessageHandler
+   {
+      private readonly Func<int, Task<HttpResponseMessage>> _responseFactory;
+      private int _callCount;
+
+      public CountingHttpMessageHandler(Func<int, Task<HttpResponseMessage>> responseFactory)
+      {
+         _responseFactory = responseFactory;
+      }
+
+      public int CallCount => Volatile.Read(ref _callCount);
+
+      protected override Task<HttpResponseMessage> SendAsync(
+         HttpRequestMessage request,
+         CancellationToken cancellationToken)
+      {
+         var attempt = Interlocked.Increment(ref _callCount);
+         return _responseFactory(attempt);
+      }
+   }
+
+   private sealed class ContentServiceHarness : IDisposable
+   {
+      public ContentServiceHarness(
+         ContentService contentService,
+         TestSocket testSocket,
+         SocketRequesterContext socketContext)
+      {
+         ContentService = contentService;
+         TestSocket = testSocket;
+         SocketContext = socketContext;
+      }
+
+      public ContentService ContentService { get; }
+      public TestSocket TestSocket { get; }
+      private SocketRequesterContext SocketContext { get; }
+
+      public void Dispose()
+      {
+         SocketContext.Daemon.KillAuthThread();
+      }
+   }
+}

--- a/microservice/microserviceTests/microservice/Content/ContentResolverRetryTests.cs
+++ b/microservice/microserviceTests/microservice/Content/ContentResolverRetryTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Beamable.Server;
+using NUnit.Framework;
+
+namespace microserviceTests.microservice.Content;
+
+[TestFixture]
+public class ContentResolverRetryTests
+{
+   [Test]
+   public async Task ServiceUnavailableThenSuccessRetries()
+   {
+      var handler = new QueueHttpMessageHandler(
+         Response(HttpStatusCode.ServiceUnavailable),
+         Response(HttpStatusCode.OK, "content"));
+      var resolver = CreateResolver(handler);
+
+      var result = await resolver.RequestContent("https://content.beamable.com/content.json");
+
+      Assert.That(result, Is.EqualTo("content"));
+      Assert.That(handler.CallCount, Is.EqualTo(2));
+   }
+
+   [TestCase(HttpStatusCode.RequestTimeout)]
+   [TestCase(HttpStatusCode.TooManyRequests)]
+   [TestCase(HttpStatusCode.InternalServerError)]
+   [TestCase(HttpStatusCode.BadGateway)]
+   [TestCase(HttpStatusCode.GatewayTimeout)]
+   public async Task OtherTransientStatusThenSuccessRetries(HttpStatusCode statusCode)
+   {
+      var handler = new QueueHttpMessageHandler(
+         Response(statusCode),
+         Response(HttpStatusCode.OK, "content"));
+      var resolver = CreateResolver(handler);
+
+      var result = await resolver.RequestContent("https://content.beamable.com/content.json");
+
+      Assert.That(result, Is.EqualTo("content"));
+      Assert.That(handler.CallCount, Is.EqualTo(2));
+   }
+
+   [Test]
+   public void RepeatedServiceUnavailableFailsAfterThreeAttemptsWithContext()
+   {
+      var uri = "https://content.beamable.com/content.json";
+      var handler = new QueueHttpMessageHandler(
+         Response(HttpStatusCode.ServiceUnavailable),
+         Response(HttpStatusCode.ServiceUnavailable),
+         Response(HttpStatusCode.ServiceUnavailable));
+      var resolver = CreateResolver(handler);
+
+      var exception = Assert.ThrowsAsync<HttpRequestException>(async () => await resolver.RequestContent(uri));
+
+      Assert.That(handler.CallCount, Is.EqualTo(3));
+      Assert.That(exception!.Message, Does.Contain(uri));
+      Assert.That(exception.Message, Does.Contain("503"));
+      Assert.That(exception.Message, Does.Contain("3"));
+   }
+
+   [Test]
+   public void NotFoundDoesNotRetry()
+   {
+      var handler = new QueueHttpMessageHandler(Response(HttpStatusCode.NotFound));
+      var resolver = CreateResolver(handler);
+
+      var exception = Assert.ThrowsAsync<HttpRequestException>(
+         async () => await resolver.RequestContent("https://content.beamable.com/missing.json"));
+
+      Assert.That(exception!.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+      Assert.That(handler.CallCount, Is.EqualTo(1));
+   }
+
+   [Test]
+   public async Task TransportFailureThenSuccessRetries()
+   {
+      var handler = new QueueHttpMessageHandler(
+         Exception(new HttpRequestException("connection reset")),
+         Response(HttpStatusCode.OK, "content"));
+      var resolver = CreateResolver(handler);
+
+      var result = await resolver.RequestContent("https://content.beamable.com/content.json");
+
+      Assert.That(result, Is.EqualTo("content"));
+      Assert.That(handler.CallCount, Is.EqualTo(2));
+   }
+
+   [Test]
+   public async Task RetryAfterDelayIsCapped()
+   {
+      var retryResponse = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+      retryResponse.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(TimeSpan.FromSeconds(30));
+      var handler = new QueueHttpMessageHandler(
+         () => Task.FromResult(retryResponse),
+         Response(HttpStatusCode.OK, "content"));
+      var resolver = CreateResolver(handler);
+      var stopwatch = Stopwatch.StartNew();
+
+      var result = await resolver.RequestContent("https://content.beamable.com/content.json");
+
+      stopwatch.Stop();
+      Assert.That(result, Is.EqualTo("content"));
+      Assert.That(handler.CallCount, Is.EqualTo(2));
+      Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(5)));
+      Assert.That(stopwatch.Elapsed, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1.8)));
+   }
+
+   private static DefaultContentResolver CreateResolver(HttpMessageHandler handler)
+   {
+      return new DefaultContentResolver(new TestArgs(), new HttpClient(handler));
+   }
+
+   private static Func<Task<HttpResponseMessage>> Response(HttpStatusCode statusCode, string content = "")
+   {
+      return () => Task.FromResult(new HttpResponseMessage(statusCode)
+      {
+         Content = new StringContent(content)
+      });
+   }
+
+   private static Func<Task<HttpResponseMessage>> Exception(Exception exception)
+   {
+      return () => Task.FromException<HttpResponseMessage>(exception);
+   }
+
+   private sealed class QueueHttpMessageHandler : HttpMessageHandler
+   {
+      private readonly Queue<Func<Task<HttpResponseMessage>>> _responses;
+
+      public QueueHttpMessageHandler(params Func<Task<HttpResponseMessage>>[] responses)
+      {
+         _responses = new Queue<Func<Task<HttpResponseMessage>>>(responses);
+      }
+
+      public int CallCount { get; private set; }
+
+      protected override Task<HttpResponseMessage> SendAsync(
+         HttpRequestMessage request,
+         CancellationToken cancellationToken)
+      {
+         CallCount++;
+         return _responses.Dequeue()();
+      }
+   }
+}

--- a/microservice/microserviceTests/microservice/Content/GetContentTests.cs
+++ b/microservice/microserviceTests/microservice/Content/GetContentTests.cs
@@ -116,11 +116,10 @@ namespace microserviceTests.microservice.Content
       }
 
       [Test]
-      public async Task FirstManifestBreaksWith503_RecoversOnNextRequest()
+      public async Task FirstManifestBreaksWith503_RetriesAndSucceedsOnSameRequest()
       {
-         // A 503 while fetching the manifest leaves the cached manifest promise in a failed
-         // state. The next content request must discard that poisoned promise and refetch,
-         // rather than re-awaiting the failure forever (which previously required a restart).
+         // A transient 503 while fetching the manifest should be retried inside the same
+         // content request. Otherwise caller traffic becomes the retry policy.
          var args = new TestArgs();
          var reqCtx = new RequestContext(args.CustomerID, args.ProjectName, 1, 200, 1, "path", "GET", "");
          var contentResolver = new TestContentResolver(async (uri) =>
@@ -134,41 +133,53 @@ namespace microserviceTests.microservice.Content
          });
 
          TestSocket testSocket = null;
+         var manifestAttempts = 0;
+         var manifestFrequency = MessageFrequency.Exactly(2);
          var socketProvider = new TestSocketProvider(socket =>
          {
             testSocket = socket;
 
-            // first manifest fetch fails with a 503 (non-gateway), which is NOT auto-recovered
-            // by the requester, so the cached manifest promise settles in a failed state.
             socket.AddMessageHandler(
                MessageMatcher
                   .WithRouteContains("basic/content/manifest")
-                  .WithReqId(-1)
                   .WithGet(),
-               MessageResponder.Custom(req => new WebsocketResponse
+               MessageResponder.Custom(req =>
                {
-                  id = req.id,
-                  from = 0,
-                  status = 503,
-                  body = new WebsocketErrorResponse
+                  manifestAttempts++;
+                  if (manifestAttempts == 1)
                   {
-                     status = 503,
-                     service = "content",
-                     error = "ServiceUnavailable",
-                     message = "503"
+                     return new WebsocketResponse
+                     {
+                        id = req.id,
+                        from = 0,
+                        status = 503,
+                        body = new WebsocketErrorResponse
+                        {
+                           status = 503,
+                           service = "content",
+                           error = "ServiceUnavailable",
+                           message = "503"
+                        }
+                     };
                   }
-               }),
-               MessageFrequency.OnlyOnce()
-            );
 
-            // the second manifest fetch (triggered by the next content request) succeeds.
-            socket.AddInitialContentMessageHandler(-2, new ContentReference
-            {
-               id = "items.foo",
-               version = "123",
-               uri = "items.foo",
-               visibility = "public"
-            });
+                  return req.Succeed(new ContentManifest
+                  {
+                     id = "global",
+                     created = 1,
+                     references = new List<ContentReference>
+                     {
+                        new ContentReference
+                        {
+                           id = "items.foo",
+                           version = "123",
+                           uri = "items.foo",
+                           visibility = "public"
+                        }
+                     }
+                  });
+               }),
+               manifestFrequency);
             socket.SetAuthentication(true);
          });
 
@@ -191,19 +202,231 @@ namespace microserviceTests.microservice.Content
 
          await contentService.Init();
 
-         // first request fails because of the 503 manifest fetch.
-         var firstPromise = contentService.GetContent("items.foo");
-         var firstTask = Task.Run(async () => await firstPromise);
-         try { firstTask.Wait(1000); } catch { /* expected: the 503 propagates */ }
-         Assert.IsTrue(firstPromise.IsFailed, "first content request should fail due to the 503 manifest fetch");
+         var fetchPromise = contentService.GetContent("items.foo");
+         var fetchTask = Task.Run(async () => await fetchPromise);
+         fetchTask.Wait(1500);
+         Assert.IsTrue(fetchPromise.IsCompleted, "content request should complete after one transient manifest retry");
+         Assert.IsFalse(fetchPromise.IsFailed, "content request should succeed after transient manifest retry");
+         Assert.AreEqual("items.foo", fetchPromise.GetResult().Id);
+         Assert.AreEqual(2, manifestAttempts);
+         Assert.AreEqual(2, manifestFrequency.CallCount);
 
-         // second request must refetch the manifest and succeed (proves the poisoned promise was discarded).
-         var secondPromise = contentService.GetContent("items.foo");
-         var secondTask = Task.Run(async () => await secondPromise);
-         secondTask.Wait(1000);
-         Assert.IsTrue(secondPromise.IsCompleted, "second content request should complete after refetch");
-         Assert.IsFalse(secondPromise.IsFailed, "second content request should succeed after refetch");
-         Assert.AreEqual("items.foo", secondPromise.GetResult().Id);
+         socketCtx.Daemon.KillAuthThread();
+         Assert.IsTrue(testSocket.AllMocksCalled());
+      }
+
+      [Test]
+      public async Task Manifest503StopsAfterThreeAttemptsAndNextRequestStartsNewAttemptGroup()
+      {
+         var args = new TestArgs();
+         var reqCtx = new RequestContext(args.CustomerID, args.ProjectName, 1, 200, 1, "path", "GET", "");
+         var contentResolver = new TestContentResolver(async _ => "{}");
+
+         TestSocket testSocket = null;
+         var manifestAttempts = 0;
+         var manifestFrequency = MessageFrequency.Exactly(4);
+         var socketProvider = new TestSocketProvider(socket =>
+         {
+            testSocket = socket;
+            socket.AddMessageHandler(
+               MessageMatcher
+                  .WithRouteContains("basic/content/manifest")
+                  .WithGet(),
+               MessageResponder.Custom(req =>
+               {
+                  manifestAttempts++;
+                  if (manifestAttempts <= 3)
+                  {
+                     return new WebsocketResponse
+                     {
+                        id = req.id,
+                        from = 0,
+                        status = 503,
+                        body = new WebsocketErrorResponse
+                        {
+                           status = 503,
+                           service = "content",
+                           error = "ServiceUnavailable",
+                           message = "503"
+                        }
+                     };
+                  }
+
+                  return req.Succeed(new ContentManifest
+                  {
+                     id = "global",
+                     created = 1,
+                     references = new List<ContentReference>()
+                  });
+               }),
+               manifestFrequency);
+            socket.SetAuthentication(true);
+         });
+
+         var socket = socketProvider.Create("test", args);
+         var socketCtx = new SocketRequesterContext(() => Promise<IConnection>.Successful(socket));
+
+         var requester = new MicroserviceRequester(args, reqCtx, socketCtx, false, new NoopActivityProvider());
+         (_, socketCtx.Daemon) =
+            MicroserviceAuthenticationDaemon.Start(args, requester, new CancellationTokenSource());
+
+         var contentService = new ContentService(requester, socketCtx, contentResolver, _cache);
+
+         testSocket.Connect();
+         testSocket.OnMessage((_, data, id) =>
+         {
+            data.TryBuildRequestContext(args, out var rc);
+            socketCtx.HandleMessage(null, rc).Wait();
+         });
+
+         await contentService.Init();
+
+         var failedPromise = contentService.GetContent("items.foo");
+         var failedTask = Task.Run(async () => await failedPromise);
+         try { failedTask.Wait(2000); } catch { /* expected: the 503 propagates after bounded attempts */ }
+         Assert.IsTrue(failedPromise.IsFailed, "content request should fail after bounded manifest retries are exhausted");
+         Assert.AreEqual(3, manifestAttempts);
+
+         var nextPromise = contentService.GetContent("items.foo");
+         var nextTask = Task.Run(async () => await nextPromise);
+         try { nextTask.Wait(1500); } catch { /* expected: manifest succeeded but content id is absent */ }
+         Assert.IsTrue(nextPromise.IsFailed, "second request should use a new manifest attempt group and then fail because content is absent");
+         Assert.AreEqual(4, manifestAttempts);
+         Assert.AreEqual(4, manifestFrequency.CallCount);
+
+         socketCtx.Daemon.KillAuthThread();
+         Assert.IsTrue(testSocket.AllMocksCalled());
+      }
+
+      [Test]
+      public async Task Manifest400DoesNotRetry()
+      {
+         var args = new TestArgs();
+         var reqCtx = new RequestContext(args.CustomerID, args.ProjectName, 1, 200, 1, "path", "GET", "");
+         var contentResolver = new TestContentResolver(async _ => "{}");
+
+         TestSocket testSocket = null;
+         var manifestAttempts = 0;
+         var manifestFrequency = MessageFrequency.Exactly(1);
+         var socketProvider = new TestSocketProvider(socket =>
+         {
+            testSocket = socket;
+            socket.AddMessageHandler(
+               MessageMatcher
+                  .WithRouteContains("basic/content/manifest")
+                  .WithGet(),
+               MessageResponder.Custom(req =>
+               {
+                  manifestAttempts++;
+                  return new WebsocketResponse
+                  {
+                     id = req.id,
+                     from = 0,
+                     status = 400,
+                     body = new WebsocketErrorResponse
+                     {
+                        status = 400,
+                        service = "content",
+                        error = "BadRequest",
+                        message = "400"
+                     }
+                  };
+               }),
+               manifestFrequency);
+            socket.SetAuthentication(true);
+         });
+
+         var socket = socketProvider.Create("test", args);
+         var socketCtx = new SocketRequesterContext(() => Promise<IConnection>.Successful(socket));
+
+         var requester = new MicroserviceRequester(args, reqCtx, socketCtx, false, new NoopActivityProvider());
+         (_, socketCtx.Daemon) =
+            MicroserviceAuthenticationDaemon.Start(args, requester, new CancellationTokenSource());
+
+         var contentService = new ContentService(requester, socketCtx, contentResolver, _cache);
+
+         testSocket.Connect();
+         testSocket.OnMessage((_, data, id) =>
+         {
+            data.TryBuildRequestContext(args, out var rc);
+            socketCtx.HandleMessage(null, rc).Wait();
+         });
+
+         await contentService.Init();
+
+         var fetchPromise = contentService.GetContent("items.foo");
+         var fetchTask = Task.Run(async () => await fetchPromise);
+         try { fetchTask.Wait(1000); } catch { /* expected: 400 propagates */ }
+         Assert.IsTrue(fetchPromise.IsFailed, "non-transient manifest failure should fail fast");
+         Assert.AreEqual(1, manifestAttempts);
+         Assert.AreEqual(1, manifestFrequency.CallCount);
+
+         socketCtx.Daemon.KillAuthThread();
+         Assert.IsTrue(testSocket.AllMocksCalled());
+      }
+
+      [Test]
+      public async Task Manifest404RecoversAsEmptyManifestAndDoesNotRetry()
+      {
+         var args = new TestArgs();
+         var reqCtx = new RequestContext(args.CustomerID, args.ProjectName, 1, 200, 1, "path", "GET", "");
+         var contentResolver = new TestContentResolver(async _ => "{}");
+
+         TestSocket testSocket = null;
+         var manifestAttempts = 0;
+         var manifestFrequency = MessageFrequency.Exactly(1);
+         var socketProvider = new TestSocketProvider(socket =>
+         {
+            testSocket = socket;
+            socket.AddMessageHandler(
+               MessageMatcher
+                  .WithRouteContains("basic/content/manifest")
+                  .WithGet(),
+               MessageResponder.Custom(req =>
+               {
+                  manifestAttempts++;
+                  return new WebsocketResponse
+                  {
+                     id = req.id,
+                     from = 0,
+                     status = 404,
+                     body = new WebsocketErrorResponse
+                     {
+                        status = 404,
+                        service = "content",
+                        error = "NotFound",
+                        message = "404"
+                     }
+                  };
+               }),
+               manifestFrequency);
+            socket.SetAuthentication(true);
+         });
+
+         var socket = socketProvider.Create("test", args);
+         var socketCtx = new SocketRequesterContext(() => Promise<IConnection>.Successful(socket));
+
+         var requester = new MicroserviceRequester(args, reqCtx, socketCtx, false, new NoopActivityProvider());
+         (_, socketCtx.Daemon) =
+            MicroserviceAuthenticationDaemon.Start(args, requester, new CancellationTokenSource());
+
+         var contentService = new ContentService(requester, socketCtx, contentResolver, _cache);
+
+         testSocket.Connect();
+         testSocket.OnMessage((_, data, id) =>
+         {
+            data.TryBuildRequestContext(args, out var rc);
+            socketCtx.HandleMessage(null, rc).Wait();
+         });
+
+         await contentService.Init();
+
+         var fetchPromise = contentService.GetContent("items.foo");
+         var fetchTask = Task.Run(async () => await fetchPromise);
+         try { fetchTask.Wait(1000); } catch { /* expected: empty manifest has no requested content */ }
+         Assert.IsTrue(fetchPromise.IsFailed, "404 manifest recovery should produce an empty manifest, not retry");
+         Assert.AreEqual(1, manifestAttempts);
+         Assert.AreEqual(1, manifestFrequency.CallCount);
 
          socketCtx.Daemon.KillAuthThread();
          Assert.IsTrue(testSocket.AllMocksCalled());

--- a/microservice/microserviceTests/microservice/Content/GetContentTests.cs
+++ b/microservice/microserviceTests/microservice/Content/GetContentTests.cs
@@ -115,7 +115,101 @@ namespace microserviceTests.microservice.Content
          Assert.IsTrue(testSocket.AllMocksCalled());
       }
 
-      
+      [Test]
+      public async Task FirstManifestBreaksWith503_RecoversOnNextRequest()
+      {
+         // A 503 while fetching the manifest leaves the cached manifest promise in a failed
+         // state. The next content request must discard that poisoned promise and refetch,
+         // rather than re-awaiting the failure forever (which previously required a restart).
+         var args = new TestArgs();
+         var reqCtx = new RequestContext(args.CustomerID, args.ProjectName, 1, 200, 1, "path", "GET", "");
+         var contentResolver = new TestContentResolver(async (uri) =>
+         {
+            var content = new ItemContent();
+            content.SetContentName("foo");
+
+            var serializer = new MicroserviceContentSerializer();
+            var json = serializer.Serialize(content);
+            return json;
+         });
+
+         TestSocket testSocket = null;
+         var socketProvider = new TestSocketProvider(socket =>
+         {
+            testSocket = socket;
+
+            // first manifest fetch fails with a 503 (non-gateway), which is NOT auto-recovered
+            // by the requester, so the cached manifest promise settles in a failed state.
+            socket.AddMessageHandler(
+               MessageMatcher
+                  .WithRouteContains("basic/content/manifest")
+                  .WithReqId(-1)
+                  .WithGet(),
+               MessageResponder.Custom(req => new WebsocketResponse
+               {
+                  id = req.id,
+                  from = 0,
+                  status = 503,
+                  body = new WebsocketErrorResponse
+                  {
+                     status = 503,
+                     service = "content",
+                     error = "ServiceUnavailable",
+                     message = "503"
+                  }
+               }),
+               MessageFrequency.OnlyOnce()
+            );
+
+            // the second manifest fetch (triggered by the next content request) succeeds.
+            socket.AddInitialContentMessageHandler(-2, new ContentReference
+            {
+               id = "items.foo",
+               version = "123",
+               uri = "items.foo",
+               visibility = "public"
+            });
+            socket.SetAuthentication(true);
+         });
+
+         var socket = socketProvider.Create("test", args);
+         var socketCtx = new SocketRequesterContext(() => Promise<IConnection>.Successful(socket));
+
+         var requester = new MicroserviceRequester(args, reqCtx, socketCtx, false, new NoopActivityProvider());
+         (_, socketCtx.Daemon) =
+            MicroserviceAuthenticationDaemon.Start(args, requester, new CancellationTokenSource());
+
+         var contentService = new ContentService(requester, socketCtx, contentResolver, _cache);
+
+         testSocket.Connect();
+
+         testSocket.OnMessage((_, data, id) =>
+         {
+            data.TryBuildRequestContext(args, out var rc);
+            socketCtx.HandleMessage(null, rc).Wait();
+         });
+
+         await contentService.Init();
+
+         // first request fails because of the 503 manifest fetch.
+         var firstPromise = contentService.GetContent("items.foo");
+         var firstTask = Task.Run(async () => await firstPromise);
+         try { firstTask.Wait(1000); } catch { /* expected: the 503 propagates */ }
+         Assert.IsTrue(firstPromise.IsFailed, "first content request should fail due to the 503 manifest fetch");
+
+         // second request must refetch the manifest and succeed (proves the poisoned promise was discarded).
+         var secondPromise = contentService.GetContent("items.foo");
+         var secondTask = Task.Run(async () => await secondPromise);
+         secondTask.Wait(1000);
+         Assert.IsTrue(secondPromise.IsCompleted, "second content request should complete after refetch");
+         Assert.IsFalse(secondPromise.IsFailed, "second content request should succeed after refetch");
+         Assert.AreEqual("items.foo", secondPromise.GetResult().Id);
+
+         socketCtx.Daemon.KillAuthThread();
+         Assert.IsTrue(testSocket.AllMocksCalled());
+      }
+
+
       [Test]
       public void Simple()
       {


### PR DESCRIPTION
## Problem

In deployed microservices, content/inventory reads start failing spontaneously with `503 (Service Unavailable)` and only recover when the service is restarted. The production stacktrace lands in `FifaCore.Inventory.InventoryManager.ViewToItems` → `Beamable.Common.PromiseExtensions.Recover`.

## Root cause

`CachedContentManifest.WaitForManifest()` (in `microservice/microservice/Content/ContentService.cs`) caches the manifest as a `Promise<ClientManifest>` and only refetched it when that field was **null**:

```csharp
hasNoManifest = _waitForManifest == null;
if (hasNoManifest) RefreshManifest();
```

`RefreshManifest()` builds the promise from `GET /basic/content/manifest` with only `.RecoverFrom404(...)`. A **503** (e.g. a content-publish refresh coinciding with a platform blip) is not a 404, so it propagates and `_waitForManifest` completes in a **failed** state. Because the field is now non-null, it is never discarded — every later `GetContent` re-awaits the same poisoned promise via `WaitForManifest().FlatMap(...)`, so **all** content resolution fails until the process restarts (fresh `ContentService`, which is registered as a singleton) or a later content-publish event happens to succeed. Caller-side retry loops can't help because each retry re-awaits the identical cached failure.

## Fix

Discard a cached promise that has settled in a failed state, so the next caller triggers a fresh fetch:

```csharp
if (_waitForManifest == null || _waitForManifest.IsFailed)
{
    RefreshManifest();
}
```

- `IsFailed` is `done && err != null` — true only for a settled, failed promise. Null, in-flight, and successful promises are untouched, so the happy path and the existing fetched-once / cache-purged-on-publish behavior are unchanged.
- `RefreshManifest()` already replaces `_waitForManifest` under `_manifestLock`; its `!oldPromise.IsCompleted` guard skips success-forwarding for an already-completed (failed) old promise, so there is no double-complete.
- Recovery is on-demand and lock-serialized: concurrent callers share one in-flight refetch.

## Test

Adds `FirstManifestBreaksWith503_RecoversOnNextRequest` to `GetContentTests.cs`: the first manifest fetch returns a non-gateway 503 (which the requester does **not** auto-recover, unlike a gateway auth failure), asserts the first content request fails, then asserts the next request refetches and succeeds.

Verified locally:
- With the fix: all 7 GetContentTests pass (including the existing `FirstManifestBreaksWithAuth`, `CachePurgedOnNewManifest`, `ContentOnlyFetchedOnce`).
- Without the fix (temporarily reverted): the new test fails exactly as the production bug does — the second `GetContent` re-throws the cached 503 — confirming it's a genuine regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LNB9NCnEknRSqze3BYgrR

---
_Generated by [Claude Code](https://claude.ai/code/session_017LNB9NCnEknRSqze3BYgrR)_