### PR TITLE
Fix content resolution retries and cache poisoning

### DIFF
--- a/microservice/microservice/CHANGELOG.md
+++ b/microservice/microservice/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- C# microservice content resolution now retries transient HTTP failures and no longer caches failed content resolution tasks [#4599](https://github.com/beamable/BeamableProduct/issues/4599)
+
 ## [7.2.0] - 2026-05-23
 
 ### Changed

--- a/microservice/microservice/Common/Cache.cs
+++ b/microservice/microservice/Common/Cache.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace microservice.Common
@@ -10,8 +11,8 @@ namespace microservice.Common
    {
       public delegate Task<TValue> Resolver(TKey key);
 
-      private ConcurrentDictionary<TKey, Task<TValue>> _data = new ConcurrentDictionary<TKey, Task<TValue>>();
-      private Resolver _resolver;
+      private readonly ConcurrentDictionary<TKey, Lazy<Task<TValue>>> _data = new();
+      private readonly Resolver _resolver;
 
       public Cache(Resolver resolver)
       {
@@ -39,17 +40,34 @@ namespace microservice.Common
          _data.TryRemove(key, out _);
       }
 
+      /// <summary>
+      /// Shares an in-flight resolver task and caches successful results. Faulted or canceled
+      /// tasks are removed so a later request can retry the resolver.
+      /// </summary>
       public Task<TValue> Get(TKey key)
       {
-         if (_data.TryGetValue(key, out var existing))
+         Lazy<Task<TValue>> candidate = null;
+         candidate = new Lazy<Task<TValue>>(
+            () => ResolveAndEvictOnFailure(key, candidate),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+         var entry = _data.GetOrAdd(key, candidate);
+         return entry.Value;
+      }
+
+      private async Task<TValue> ResolveAndEvictOnFailure(TKey key, Lazy<Task<TValue>> entry)
+      {
+         try
          {
-            return existing;
+            return await _resolver(key);
          }
-
-         var task = _resolver(key);
-         _data.AddOrUpdate(key, task, (_, oldValue) => task);
-
-         return task;
+         catch
+         {
+            // Remove only this failed entry. A newer value may have replaced it after a purge.
+            ((ICollection<KeyValuePair<TKey, Lazy<Task<TValue>>>>)_data)
+               .Remove(new KeyValuePair<TKey, Lazy<Task<TValue>>>(key, entry));
+            throw;
+         }
       }
    }
 }

--- a/microservice/microservice/Properties/AssemblyInfo.cs
+++ b/microservice/microservice/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("BeamableMicroserviceBaseTests")]

--- a/microservice/microservice/dbmicroservice/IContentResolver.cs
+++ b/microservice/microservice/dbmicroservice/IContentResolver.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
-using System.Threading.Tasks;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 
 namespace Beamable.Server
 {
@@ -13,10 +15,18 @@ namespace Beamable.Server
 
    public class DefaultContentResolver : IContentResolver
    {
-	   private HttpClient client;
-	   private string _suffixFilter;
+	   private const int MaxAttempts = 3;
+	   private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(2);
+
+	   private readonly HttpClient _client;
+	   private readonly string _suffixFilter;
 
 	   public DefaultContentResolver(IMicroserviceArgs args)
+		   : this(args, null)
+	   {
+	   }
+
+	   internal DefaultContentResolver(IMicroserviceArgs args, HttpClient httpClient)
 	   {
 		   if (string.IsNullOrEmpty(args?.Host) || args.Host.Contains("localhost"))
 		   {
@@ -33,10 +43,18 @@ namespace Beamable.Server
 			   if (idx != -1)
 				   _suffixFilter = _suffixFilter.Substring(0, idx);
 		   }
-		   
-		   var handler = new HttpClientHandler();
-		   handler.ServerCertificateCustomValidationCallback = ServerCertificateCustomValidationCallback;
-		   client = new HttpClient(handler);
+
+		   if (httpClient != null)
+		   {
+			   _client = httpClient;
+			   return;
+		   }
+
+		   var handler = new HttpClientHandler
+		   {
+			   ServerCertificateCustomValidationCallback = ServerCertificateCustomValidationCallback
+		   };
+		   _client = new HttpClient(handler);
 	   }
 
 	   public bool ServerCertificateCustomValidationCallback(HttpRequestMessage msg, X509Certificate2 cert, X509Chain chain, SslPolicyErrors errors)
@@ -46,9 +64,99 @@ namespace Beamable.Server
 		   return isBeamableAddr;
 	   }
 
-	   public Task<string> RequestContent(string uri)
+	   /// <summary>
+	   /// Downloads immutable content, retrying bounded transient HTTP and transport failures.
+	   /// </summary>
+	   public async Task<string> RequestContent(string uri)
 	   {
-		   return client.GetStringAsync(uri);
+		   for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+		   {
+			   HttpResponseMessage response;
+			   try
+			   {
+				   response = await _client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead);
+			   }
+			   catch (HttpRequestException ex)
+			   {
+				   if (attempt == MaxAttempts)
+				   {
+					   throw CreateFinalException(uri, ex.StatusCode, attempt, ex);
+				   }
+
+				   await Task.Delay(GetRetryDelay(null, attempt));
+				   continue;
+			   }
+
+			   using (response)
+			   {
+				   if (response.IsSuccessStatusCode)
+				   {
+					   return await response.Content.ReadAsStringAsync();
+				   }
+
+				   if (!IsTransient(response.StatusCode))
+				   {
+					   response.EnsureSuccessStatusCode();
+				   }
+
+				   if (attempt == MaxAttempts)
+				   {
+					   throw CreateFinalException(uri, response.StatusCode, attempt, null);
+				   }
+
+				   await Task.Delay(GetRetryDelay(response.Headers.RetryAfter, attempt));
+			   }
+		   }
+
+		   throw CreateFinalException(uri, null, MaxAttempts, null);
+	   }
+
+	   private static bool IsTransient(HttpStatusCode statusCode)
+	   {
+		   return statusCode is HttpStatusCode.RequestTimeout 
+			   or HttpStatusCode.TooManyRequests 
+			   or HttpStatusCode.InternalServerError 
+			   or HttpStatusCode.BadGateway 
+			   or HttpStatusCode.ServiceUnavailable 
+			   or HttpStatusCode.GatewayTimeout;
+	   }
+
+	   private static TimeSpan GetRetryDelay(
+		   System.Net.Http.Headers.RetryConditionHeaderValue retryAfter,
+		   int attempt)
+	   {
+		   TimeSpan delay;
+		   if (retryAfter?.Delta != null)
+		   {
+			   delay = retryAfter.Delta.Value;
+		   }
+		   else if (retryAfter?.Date != null)
+		   {
+			   delay = retryAfter.Date.Value - DateTimeOffset.UtcNow;
+		   }
+		   else
+		   {
+			   var backoffMilliseconds = 200 * (1 << (attempt - 1));
+			   delay = TimeSpan.FromMilliseconds(backoffMilliseconds + Random.Shared.Next(0, 101));
+		   }
+
+		   if (delay < TimeSpan.Zero)
+		   {
+			   return TimeSpan.Zero;
+		   }
+
+		   return delay > MaxRetryDelay ? MaxRetryDelay : delay;
+	   }
+
+	   private static HttpRequestException CreateFinalException(string uri, HttpStatusCode? statusCode, int attempts, Exception innerException)
+	   {
+		   var status = statusCode.HasValue
+			   ? $"{(int)statusCode.Value} {statusCode.Value}"
+			   : "unavailable";
+		   return new HttpRequestException(
+			   $"Content request failed. uri=[{uri}] status=[{status}] attempts=[{attempts}]",
+			   innerException,
+			   statusCode);
 	   }
    }
 }

--- a/microservice/microserviceTests/microservice/Common/CacheTests.cs
+++ b/microservice/microserviceTests/microservice/Common/CacheTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using microservice.Common;
+using NUnit.Framework;
+
+namespace microserviceTests.microservice.Common;
+
+[TestFixture]
+public class CacheTests
+{
+   [Test]
+   public async Task FaultedTaskIsRemovedAndNextGetRetries()
+   {
+      var calls = 0;
+      var cache = new Cache<string, int>(_ =>
+      {
+         calls++;
+         return calls == 1
+            ? Task.FromException<int>(new InvalidOperationException("temporary failure"))
+            : Task.FromResult(42);
+      });
+
+      Assert.ThrowsAsync<InvalidOperationException>(async () => await cache.Get("key"));
+
+      Assert.That(await cache.Get("key"), Is.EqualTo(42));
+      Assert.That(calls, Is.EqualTo(2));
+   }
+
+   [Test]
+   public async Task CanceledTaskIsRemovedAndNextGetRetries()
+   {
+      var calls = 0;
+      var canceledToken = new CancellationToken(true);
+      var cache = new Cache<string, int>(_ =>
+      {
+         calls++;
+         return calls == 1
+            ? Task.FromCanceled<int>(canceledToken)
+            : Task.FromResult(42);
+      });
+
+      Assert.ThrowsAsync<TaskCanceledException>(async () => await cache.Get("key"));
+
+      Assert.That(await cache.Get("key"), Is.EqualTo(42));
+      Assert.That(calls, Is.EqualTo(2));
+   }
+
+   [Test]
+   public async Task SuccessfulTaskRemainsCached()
+   {
+      var calls = 0;
+      var cache = new Cache<string, int>(_ =>
+      {
+         calls++;
+         return Task.FromResult(42);
+      });
+
+      Assert.That(await cache.Get("key"), Is.EqualTo(42));
+      Assert.That(await cache.Get("key"), Is.EqualTo(42));
+      Assert.That(calls, Is.EqualTo(1));
+   }
+
+   [Test]
+   public async Task ConcurrentCallersShareOneResolverTask()
+   {
+      var calls = 0;
+      var completion = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+      var cache = new Cache<string, int>(_ =>
+      {
+         Interlocked.Increment(ref calls);
+         return completion.Task;
+      });
+
+      var requests = new List<Task<int>>();
+      for (var i = 0; i < 20; i++)
+      {
+         requests.Add(cache.Get("key"));
+      }
+
+      completion.SetResult(42);
+
+      Assert.That(await Task.WhenAll(requests), Is.All.EqualTo(42));
+      Assert.That(calls, Is.EqualTo(1));
+   }
+
+   [Test]
+   public async Task OldFailureDoesNotRemoveNewerEntry()
+   {
+      var calls = 0;
+      var first = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+      var second = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+      var cache = new Cache<string, int>(_ =>
+      {
+         calls++;
+         return calls == 1 ? first.Task : second.Task;
+      });
+
+      var oldTask = cache.Get("key");
+      cache.Purge("key");
+      var newTask = cache.Get("key");
+
+      first.SetException(new InvalidOperationException("old failure"));
+      Assert.ThrowsAsync<InvalidOperationException>(async () => await oldTask);
+
+      second.SetResult(42);
+      Assert.That(await newTask, Is.EqualTo(42));
+      Assert.That(await cache.Get("key"), Is.EqualTo(42));
+      Assert.That(calls, Is.EqualTo(2));
+   }
+}

--- a/microservice/microserviceTests/microservice/Content/ContentResolverRetryTests.cs
+++ b/microservice/microserviceTests/microservice/Content/ContentResolverRetryTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Beamable.Server;
+using NUnit.Framework;
+
+namespace microserviceTests.microservice.Content;
+
+[TestFixture]
+public class ContentResolverRetryTests
+{
+   [Test]
+   public async Task ServiceUnavailableThenSuccessRetries()
+   {
+      var handler = new QueueHttpMessageHandler(
+         Response(HttpStatusCode.ServiceUnavailable),
+         Response(HttpStatusCode.OK, "content"));
+      var resolver = CreateResolver(handler);
+
+      var result = await resolver.RequestContent("https://content.beamable.com/content.json");
+
+      Assert.That(result, Is.EqualTo("content"));
+      Assert.That(handler.CallCount, Is.EqualTo(2));
+   }
+
+   [TestCase(HttpStatusCode.RequestTimeout)]
+   [TestCase(HttpStatusCode.TooManyRequests)]
+   [TestCase(HttpStatusCode.InternalServerError)]
+   [TestCase(HttpStatusCode.BadGateway)]
+   [TestCase(HttpStatusCode.GatewayTimeout)]
+   public async Task OtherTransientStatusThenSuccessRetries(HttpStatusCode statusCode)
+   {
+      var handler = new QueueHttpMessageHandler(
+         Response(statusCode),
+         Response(HttpStatusCode.OK, "content"));
+      var resolver = CreateResolver(handler);
+
+      var result = await resolver.RequestContent("https://content.beamable.com/content.json");
+
+      Assert.That(result, Is.EqualTo("content"));
+      Assert.That(handler.CallCount, Is.EqualTo(2));
+   }
+
+   [Test]
+   public void RepeatedServiceUnavailableFailsAfterThreeAttemptsWithContext()
+   {
+      var uri = "https://content.beamable.com/content.json";
+      var handler = new QueueHttpMessageHandler(
+         Response(HttpStatusCode.ServiceUnavailable),
+         Response(HttpStatusCode.ServiceUnavailable),
+         Response(HttpStatusCode.ServiceUnavailable));
+      var resolver = CreateResolver(handler);
+
+      var exception = Assert.ThrowsAsync<HttpRequestException>(async () => await resolver.RequestContent(uri));
+
+      Assert.That(handler.CallCount, Is.EqualTo(3));
+      Assert.That(exception!.Message, Does.Contain(uri));
+      Assert.That(exception.Message, Does.Contain("503"));
+      Assert.That(exception.Message, Does.Contain("3"));
+   }
+
+   [Test]
+   public void NotFoundDoesNotRetry()
+   {
+      var handler = new QueueHttpMessageHandler(Response(HttpStatusCode.NotFound));
+      var resolver = CreateResolver(handler);
+
+      var exception = Assert.ThrowsAsync<HttpRequestException>(
+         async () => await resolver.RequestContent("https://content.beamable.com/missing.json"));
+
+      Assert.That(exception!.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+      Assert.That(handler.CallCount, Is.EqualTo(1));
+   }
+
+   [Test]
+   public async Task TransportFailureThenSuccessRetries()
+   {
+      var handler = new QueueHttpMessageHandler(
+         Exception(new HttpRequestException("connection reset")),
+         Response(HttpStatusCode.OK, "content"));
+      var resolver = CreateResolver(handler);
+
+      var result = await resolver.RequestContent("https://content.beamable.com/content.json");
+
+      Assert.That(result, Is.EqualTo("content"));
+      Assert.That(handler.CallCount, Is.EqualTo(2));
+   }
+
+   [Test]
+   public async Task RetryAfterDelayIsCapped()
+   {
+      var retryResponse = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+      retryResponse.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(TimeSpan.FromSeconds(30));
+      var handler = new QueueHttpMessageHandler(
+         () => Task.FromResult(retryResponse),
+         Response(HttpStatusCode.OK, "content"));
+      var resolver = CreateResolver(handler);
+      var stopwatch = Stopwatch.StartNew();
+
+      var result = await resolver.RequestContent("https://content.beamable.com/content.json");
+
+      stopwatch.Stop();
+      Assert.That(result, Is.EqualTo("content"));
+      Assert.That(handler.CallCount, Is.EqualTo(2));
+      Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(5)));
+      Assert.That(stopwatch.Elapsed, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1.8)));
+   }
+
+   private static DefaultContentResolver CreateResolver(HttpMessageHandler handler)
+   {
+      return new DefaultContentResolver(new TestArgs(), new HttpClient(handler));
+   }
+
+   private static Func<Task<HttpResponseMessage>> Response(HttpStatusCode statusCode, string content = "")
+   {
+      return () => Task.FromResult(new HttpResponseMessage(statusCode)
+      {
+         Content = new StringContent(content)
+      });
+   }
+
+   private static Func<Task<HttpResponseMessage>> Exception(Exception exception)
+   {
+      return () => Task.FromException<HttpResponseMessage>(exception);
+   }
+
+   private sealed class QueueHttpMessageHandler : HttpMessageHandler
+   {
+      private readonly Queue<Func<Task<HttpResponseMessage>>> _responses;
+
+      public QueueHttpMessageHandler(params Func<Task<HttpResponseMessage>>[] responses)
+      {
+         _responses = new Queue<Func<Task<HttpResponseMessage>>>(responses);
+      }
+
+      public int CallCount { get; private set; }
+
+      protected override Task<HttpResponseMessage> SendAsync(
+         HttpRequestMessage request,
+         CancellationToken cancellationToken)
+      {
+         CallCount++;
+         return _responses.Dequeue()();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #4599 

Adds bounded retry handling for transient content download failures in microservices and prevents failed or canceled resolver tasks from poisoning the content cache.

## What changed:
- Retry transient HTTP failures during content resolution: 408, 429, 5xx, and transport errors.
- Respect Retry-After, capped at 2 seconds.
- Evict faulted or canceled cache entries so the next request can recover.
- Preserve single-flight cache behavior for concurrent callers.
- Add focused resolver and cache regression tests.
- Document the fix in the changelog for #4599.

## Verification:
```
dotnet restore microservice/microserviceTests
dotnet build --configuration Release --no-restore microservice/microserviceTests
dotnet test --configuration Release --no-build microservice/microserviceTests
```
`Result:` 234 tests passed.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
