### PR TITLE
Backfill 4.3.7 and 4.3.8 entries in the CLI changelog

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -274,6 +274,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue in which running `beam deploy release` when CID was an alias resulted in an error in execution.
 - Fixed `useLocal: true` in Scheduler Microservice invocation when the C#MS is remotely deployed.
 
+## [4.3.8] - 2026-06-24
+
+### Fixed
+- Backported microservice content resilience: manifest and content-entry fetches now retry transient failures (timeouts, 429, 5xx, transport errors) with bounded exponential backoff and jitter, and a failed fetch no longer poisons the in-memory content cache.
+
+## [4.3.7] - 2026-04-10
+
+### Fixed
+- Backported possible `IndexOutOfBounds` error when running `beam project ps` due to nameless docker containers
+
 ## [4.3.6] - 2026-03-13
 
 ### Fixed


### PR DESCRIPTION
The 4.3.7 and 4.3.8 maintenance patches shipped from the `release/2.4.x` line and were documented in `cli/cli/CHANGELOG.md` on that branch, but the entries were never added on `main`.

`main` owns the changelog file that feeds the public changelog (changes.beamable.com), so without these entries a subsequent main-line release overwrites the public file without them and the patches never appear publicly. This adds the two entries in the 4.3.x region to keep the public changelog complete across release lines.

Related: #4711, #4712.

🤖 Generated with [Claude Code](https://claude.com/claude-code)