### PR TITLE
Recover faulted promises in Promise.Recover (backport from main)

### DIFF
--- a/cli/beamable.common/Runtime/Promise.cs
+++ b/cli/beamable.common/Runtime/Promise.cs
@@ -1049,7 +1049,17 @@ namespace Beamable.Common
 		{
 			var result = new Promise<T>();
 			promise.Then(value => result.CompleteSuccess(value))
-			   .Error(err => result.CompleteSuccess(callback(err)));
+			   .Error(err =>
+			   {
+				   try
+				   {
+					   result.CompleteSuccess(callback(err));
+				   }
+				   catch (Exception ex)
+				   {
+					   result.CompleteError(ex);
+				   }
+			   });
 			return result;
 		}
 

--- a/microservice/microserviceTests/microservice/Content/ContentResilienceStressTests.cs
+++ b/microservice/microserviceTests/microservice/Content/ContentResilienceStressTests.cs
@@ -39,7 +39,6 @@ public class ContentResilienceStressTests
    }
 
    [Test]
-   [Ignore("Socket-harness integration test relies on platform request/retry plumbing that differs on the 2.4.x release line; does not port from main. Core fix is covered by CacheTests and ContentResolverRetryTests.")]
    public async Task ConcurrentContentRequestsShareBoundedManifestRetryAndResolvedContentCache()
    {
       var manifestAttempts = 0;
@@ -79,7 +78,6 @@ public class ContentResilienceStressTests
    }
 
    [Test]
-   [Ignore("Socket-harness integration test relies on platform request/retry plumbing that differs on the 2.4.x release line; does not port from main. Core fix is covered by CacheTests and ContentResolverRetryTests.")]
    public async Task ConcurrentContentRequestsShareOneBoundedResolvedContentDownloadRetry()
    {
       var content = SerializeItemContent("foo");

--- a/microservice/microserviceTests/microservice/Content/GetContentTests.cs
+++ b/microservice/microserviceTests/microservice/Content/GetContentTests.cs
@@ -111,7 +111,6 @@ namespace microserviceTests.microservice.Content
       }
 
       [Test]
-      [Ignore("Socket-harness integration test relies on platform request/retry plumbing that differs on the 2.4.x release line; does not port from main. Core fix is covered by CacheTests and ContentResolverRetryTests.")]
       public async Task FirstManifestBreaksWith503_RetriesAndSucceedsOnSameRequest()
       {
          // A transient 503 while fetching the manifest should be retried inside the same
@@ -212,7 +211,6 @@ namespace microserviceTests.microservice.Content
       }
 
       [Test]
-      [Ignore("Socket-harness integration test relies on platform request/retry plumbing that differs on the 2.4.x release line; does not port from main. Core fix is covered by CacheTests and ContentResolverRetryTests.")]
       public async Task Manifest503StopsAfterThreeAttemptsAndNextRequestStartsNewAttemptGroup()
       {
          var args = new TestArgs();
@@ -296,7 +294,6 @@ namespace microserviceTests.microservice.Content
       }
 
       [Test]
-      [Ignore("Socket-harness integration test relies on platform request/retry plumbing that differs on the 2.4.x release line; does not port from main. Core fix is covered by CacheTests and ContentResolverRetryTests.")]
       public async Task Manifest400DoesNotRetry()
       {
          var args = new TestArgs();
@@ -364,7 +361,6 @@ namespace microserviceTests.microservice.Content
       }
 
       [Test]
-      [Ignore("Socket-harness integration test relies on platform request/retry plumbing that differs on the 2.4.x release line; does not port from main. Core fix is covered by CacheTests and ContentResolverRetryTests.")]
       public async Task Manifest404RecoversAsEmptyManifestAndDoesNotRetry()
       {
          var args = new TestArgs();


### PR DESCRIPTION
### What
Backport `main`'s `Promise.Recover` `try/catch` to `release/2.4.x`.

On `release/2.4.x`, `Promise.Recover`'s `.Error` handler does not wrap the recovery callback in `try/catch`. When the callback re-throws — as `RecoverFrom404`/`RecoverFromStatus` do for a status they don't recover — the throw escapes and the derived promise is left **pending forever** instead of faulting. `RecoverWith` (just below `Recover`) already has this guard; `Recover` was missing it. `main` already carries the fix.

### Why
This makes the manifest-retry path added in #4704 actually work on this line. `RequestManifestOnceAsync` awaits `Request(...).RecoverFrom404(...)`; on a transient 5xx the inner promise previously hung instead of surfacing the error, so the bounded retry loop never engaged and manifest resolution stalled on a transient failure — the very condition the change set out to harden.

More broadly, any `.Recover` / `RecoverFrom404` / `RecoverFromStatus` consumer on this line hangs on a non-recovered error rather than faulting.

### Evidence
- A direct `Request(...)` on a 503 faults correctly, isolating the defect to `Recover`/`RecoverFrom404`.
- The six content-resilience socket tests from #4704 (including the 100-concurrent stress tests) hang without this fix and pass with it. This PR removes their `[Ignore]` markers.
- Full `microserviceTests` suite: 207/207, 0 skipped.

Base is `release/2.4.x` because `main` already contains this fix.

Refs #4704, #4599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)