### PR TITLE
Detect more Unity license-contention signatures and cover the device-build job

### DIFF
--- a/.github/matchers/unity-license.json
+++ b/.github/matchers/unity-license.json
@@ -13,6 +13,20 @@
       "pattern": [
         { "regexp": "^.*(Serial number unavailable for ULF return.*)$", "message": 1 }
       ]
+    },
+    {
+      "owner": "unity-license-no-entitlements",
+      "severity": "error",
+      "pattern": [
+        { "regexp": "^.*(Found 0 entitlement groups and 0 free entitlements.*)$", "message": 1 }
+      ]
+    },
+    {
+      "owner": "unity-license-access-token-unavailable",
+      "severity": "error",
+      "pattern": [
+        { "regexp": "^.*(Access token is unavailable; failed to update.*)$", "message": 1 }
+      ]
     }
   ]
 }

--- a/.github/workflows/buildPR.yml
+++ b/.github/workflows/buildPR.yml
@@ -611,6 +611,11 @@ jobs:
           large-packages: true
           docker-images: true
           swap-storage: true
+      # Surface the literal Unity license-contention lines as annotations live, mid-run.
+      # Complements the post-failure output check below. Container-action stdout scope is
+      # unconfirmed; verify on a real run. ~Claude
+      - name: Register Unity license problem matcher
+        run: echo "::add-matcher::.github/matchers/unity-license.json"
       - uses: game-ci/unity-builder@v4
         timeout-minutes: 60
         env:
@@ -629,3 +634,20 @@ jobs:
           allowDirtyBuild: true
           buildsPath: dist
           buildMethod: BuildSampleProject.Development
+
+      # A license/seat activation failure aborts before the player is built, so dist/
+      # stays empty. If the job failed and produced no build output, the license problem
+      # matcher annotations above (if container stdout was in scope) pin the cause; this
+      # step adds a plain-language annotation so the red build is self-explanatory either
+      # way. Unlike the test shards' XML check, empty dist/ also describes a genuine build
+      # break, so the message points back at the matcher rather than asserting contention
+      # outright. ~Claude
+      - name: Annotate Unity license contention
+        if: failure()
+        shell: bash
+        run: |
+          if find dist -type f 2>/dev/null | grep -q .; then
+            echo "Build output present in dist/: this is a genuine build failure, not license contention."
+          else
+            echo "::error title=Possible Unity license contention::Build for ${{ matrix.targetPlatform }} produced no output in dist/ -- the editor may have exited before the build ran. Check the license annotations above for serial-contention errors; absent those, treat this as a genuine build failure."
+          fi


### PR DESCRIPTION
Follow-up to #4702. The serial-throttling (max-parallel: 1) is the real fix and should keep these gates from tripping — this PR just makes the detection solid for the cases where they do.

#4702 added a problem matcher plus a post-failure annotation to the two Unity **test** shards, but left two gaps:

### 1. The matcher missed the leading contention signature
It recognized only `No valid Unity Editor license found` and the ULF-return tail. The actual leading symptom of a lost seat is the licensing subsystem's `Found 0 entitlement groups and 0 free entitlements` 404, preceded by `Access token is unavailable; failed to update`. That 404 (plus the downstream `com.unity.editor.headless was not found`) is what headlined the contention failures, yet none of it matched — so the live annotations never named the real cause.

This adds two matcher patterns: `unity-license-no-entitlements` and `unity-license-access-token-unavailable`.

### 2. The device-build job had no detection at all
`Build for {iOS,Android,StandaloneWindows,StandaloneOSX}` shares the `UNITY_SERIAL_DEVOPS` seat and is exactly where contention surfaced, but it had neither the matcher registration nor an annotation step — only the test shards did.

This registers the matcher in the `build` job and adds an annotation step. The build job keys off an empty `dist/` (a seat failure aborts before the player is built). Because an empty `dist/` *also* describes a genuine build break, that message points back at the license annotations rather than asserting contention outright — unlike the test shards' XML check.

### Notes
- Problem-matcher annotations are informational; they do not change job outcome (still controlled by step exit codes), so a stray match can't turn a green build red.
- Container-action stdout scope for the matcher is still unconfirmed (same caveat #4702 carries); the artifact-absence annotation is the reliable fallback either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)