### PR TITLE
Fix Snapshot tab hang when snapshots in different realms share a name

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed the Content window Snapshot tab hanging at "Loading snapshots" when snapshots in different realm folders share a name (e.g. `LastPublished-global.json` auto snapshots from publishing to multiple realms) [4743](https://github.com/beamable/BeamableProduct/issues/4743)
+
 ## [5.1.1] - 2026-06-29
 
 ### Added

--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed the Content window Snapshot tab hanging at "Loading snapshots" when snapshots in different realm folders share a name (e.g. `LastPublished-global.json` auto snapshots from publishing to multiple realms) [4743](https://github.com/beamable/BeamableProduct/issues/4743)
+- Fixed the Content window Snapshot tab hanging at "Loading snapshots" when snapshots in different realm folders share a name (e.g. `LastPublished-global.json` auto snapshots from publishing to multiple realms)
 
 ## [5.1.1] - 2026-06-29
 

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_SnapshotManager.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_SnapshotManager.cs
@@ -598,13 +598,27 @@ namespace Beamable.Editor.UI.ContentWindow
 			_selectedSnapshotsPaths.Clear();
 			_snapshotSearchData = new SearchData();
 			_gatheringSnapshots = true;
-			var snapshotListResult = await _contentService.GetContentSnapshots();
-			_sharedSnapshots = snapshotListResult.SharedSnapshots.ToDictionary(item => item.Name, item => item);
-			_localSnapshots = snapshotListResult.LocalSnapshots.ToDictionary(item => item.Name, item => item);
-			_allSnapshots.Clear();
-			_localSnapshots.Values.ToList().ForEach(snapshot => _allSnapshots.Add(snapshot.Path, snapshot));
-			_sharedSnapshots.Values.ToList().ForEach(snapshot => _allSnapshots.Add(snapshot.Path, snapshot));
-			_gatheringSnapshots = false;
+			try
+			{
+				var snapshotListResult = await _contentService.GetContentSnapshots();
+				_sharedSnapshots = BuildSnapshotLookup(snapshotListResult.SharedSnapshots);
+				_localSnapshots = BuildSnapshotLookup(snapshotListResult.LocalSnapshots);
+				_allSnapshots.Clear();
+				_localSnapshots.Values.ToList().ForEach(snapshot => _allSnapshots.Add(snapshot.Path, snapshot));
+				_sharedSnapshots.Values.ToList().ForEach(snapshot => _allSnapshots.Add(snapshot.Path, snapshot));
+			}
+			finally
+			{
+				// Always clear the flag, otherwise the window is stuck on "Loading snapshots". ~Claude
+				_gatheringSnapshots = false;
+			}
+		}
+
+		// Snapshots in different realm folders can share a file name (auto snapshots are
+		// always named "LastPublished-<manifestId>"), so the lookup must key by path. ~Claude
+		public static Dictionary<string, BeamManifestSnapshotItem> BuildSnapshotLookup(IEnumerable<BeamManifestSnapshotItem> snapshots)
+		{
+			return snapshots.ToDictionary(item => item.Path, item => item);
 		}
 		
 	}

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_SnapshotManager.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_SnapshotManager.cs
@@ -609,13 +609,13 @@ namespace Beamable.Editor.UI.ContentWindow
 			}
 			finally
 			{
-				// Always clear the flag, otherwise the window is stuck on "Loading snapshots". ~Claude
+				// Always clear the flag, otherwise the window is stuck on "Loading snapshots".
 				_gatheringSnapshots = false;
 			}
 		}
 
 		// Snapshots in different realm folders can share a file name (auto snapshots are
-		// always named "LastPublished-<manifestId>"), so the lookup must key by path. ~Claude
+		// always named "LastPublished-<manifestId>"), so the lookup must key by path.
 		public static Dictionary<string, BeamManifestSnapshotItem> BuildSnapshotLookup(IEnumerable<BeamManifestSnapshotItem> snapshots)
 		{
 			return snapshots.ToDictionary(item => item.Path, item => item);

--- a/client/Packages/com.beamable/Tests/Editor/ContentWindowSnapshotTests.cs
+++ b/client/Packages/com.beamable/Tests/Editor/ContentWindowSnapshotTests.cs
@@ -1,0 +1,54 @@
+using Beamable.Editor.BeamCli.Commands;
+using Beamable.Editor.UI.ContentWindow;
+using NUnit.Framework;
+using System.Linq;
+
+namespace Beamable.Editor.Tests
+{
+	public class ContentWindowSnapshotTests
+	{
+		private static BeamManifestSnapshotItem Snapshot(string name, string path)
+		{
+			return new BeamManifestSnapshotItem { Name = name, Path = path };
+		}
+
+		[Test]
+		public void BuildSnapshotLookup_DuplicateNamesAcrossRealms_KeepsAllSnapshots()
+		{
+			// Auto snapshots share the name "LastPublished-<manifestId>" across realm folders. ~Claude
+			var snapshots = new[]
+			{
+				Snapshot("LastPublished-global", ".beamable/content-snapshots/DE_111/LastPublished-global.json"),
+				Snapshot("LastPublished-global", ".beamable/content-snapshots/DE_222/LastPublished-global.json"),
+			};
+
+			var lookup = ContentWindow.BuildSnapshotLookup(snapshots);
+
+			Assert.AreEqual(2, lookup.Count);
+			CollectionAssert.AreEquivalent(snapshots.Select(item => item.Path), lookup.Keys);
+		}
+
+		[Test]
+		public void BuildSnapshotLookup_KeysByPath()
+		{
+			var snapshots = new[]
+			{
+				Snapshot("my-snapshot", ".beamable/content-snapshots/DE_111/my-snapshot.json"),
+				Snapshot("other-snapshot", ".beamable/temp/content-snapshots/DE_111/other-snapshot.json"),
+			};
+
+			var lookup = ContentWindow.BuildSnapshotLookup(snapshots);
+
+			Assert.AreSame(snapshots[0], lookup[snapshots[0].Path]);
+			Assert.AreSame(snapshots[1], lookup[snapshots[1].Path]);
+		}
+
+		[Test]
+		public void BuildSnapshotLookup_EmptyInput_ReturnsEmptyLookup()
+		{
+			var lookup = ContentWindow.BuildSnapshotLookup(System.Array.Empty<BeamManifestSnapshotItem>());
+
+			Assert.AreEqual(0, lookup.Count);
+		}
+	}
+}

--- a/client/Packages/com.beamable/Tests/Editor/ContentWindowSnapshotTests.cs
+++ b/client/Packages/com.beamable/Tests/Editor/ContentWindowSnapshotTests.cs
@@ -15,7 +15,7 @@ namespace Beamable.Editor.Tests
 		[Test]
 		public void BuildSnapshotLookup_DuplicateNamesAcrossRealms_KeepsAllSnapshots()
 		{
-			// Auto snapshots share the name "LastPublished-<manifestId>" across realm folders. ~Claude
+			// Auto snapshots share the name "LastPublished-<manifestId>" across realm folders.
 			var snapshots = new[]
 			{
 				Snapshot("LastPublished-global", ".beamable/content-snapshots/DE_111/LastPublished-global.json"),

--- a/client/Packages/com.beamable/Tests/Editor/ContentWindowSnapshotTests.cs.meta
+++ b/client/Packages/com.beamable/Tests/Editor/ContentWindowSnapshotTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6826f76d647f44c6a110dcdee7992df0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant:


### PR DESCRIPTION
Fixes #4743

### Problem

The Snapshot tab of the Beam Content window hangs at "Loading snapshots" forever when two realm folders contain snapshots with the same file name. This happens routinely once "On Publish Auto Snapshot Type" is enabled and content is published to more than one realm, because every publish writes `LastPublished-<manifestId>.json` into that realm's snapshot folder.

Root cause, in `ContentWindow_SnapshotManager.CacheSnapshots()`:

- The shared and local snapshot lookups were built with `ToDictionary(item => item.Name)`, and snapshot names are not unique across realm folders, so `ToDictionary` threw `ArgumentException`.
- The method is invoked fire-and-forget (`_ = CacheSnapshots();`), so the exception was swallowed, and `_gatheringSnapshots` (cleared only on the method's last line) stayed `true` - which makes the window draw the "Loading snapshots" block on every repaint.

### Fix

- Key the shared/local snapshot lookups by file path, which is unique and matches how the adjacent `_allSnapshots` dictionary was already keyed. The lookups are only consumed via `.Values`, so no other behavior changes.
- Clear `_gatheringSnapshots` in a `finally` block so no failure during the cache rebuild can wedge the tab again.
- Changelog entry under `[Unreleased]`.

### Tests

Added `ContentWindowSnapshotTests` (editor editmode) covering the duplicate-name-across-realms case, path keying, and empty input. Ran locally via Unity batch mode: 3/3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
