### PR TITLE
Add regression tests for null reference fields in microservice client responses

### DIFF
--- a/client/Packages/com.beamable/Tests/Runtime/Server/Runtime/MicroserviceClient/DeserializeResultNullDefaultsTests.cs
+++ b/client/Packages/com.beamable/Tests/Runtime/Server/Runtime/MicroserviceClient/DeserializeResultNullDefaultsTests.cs
@@ -1,0 +1,140 @@
+using Beamable.Common.Api;
+using Beamable.Common.Inventory;
+using Beamable.Tests.Runtime;
+using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine.TestTools;
+
+namespace Beamable.Server.Tests.Runtime
+{
+	/// <summary>
+	/// Document the non-null guarantees that <see cref="MicroserviceClientHelper.DeserializeResult{T}"/>
+	/// provided while it was backed by JsonUtility.FromJson (SDK 5.0.x and earlier).
+	///
+	/// A C# microservice serializes response DTOs with Newtonsoft using default NullValueHandling,
+	/// so an unassigned reference-type field arrives at the client as an explicit JSON null member,
+	/// for example {"name": null}. JsonUtility deserialized such a member to its Unity-serialization
+	/// default: an empty string, an empty array or list, or a default-constructed nested object.
+	/// Client code written against SDK 5.0.x and earlier relies on those fields never being null.
+	///
+	/// Members that are entirely absent from the JSON are a distinct case with a narrower
+	/// contract: JsonUtility treated absent string and string[] members as null, so no non-null
+	/// guarantee ever existed for those, but it default-constructed absent List and nested
+	/// object members. Absence occurs on the wire when a field is a valueless Optional, or when
+	/// a service hand-serializes its response with null-omitting settings.
+	/// </summary>
+	public class DeserializeResultNullDefaultsTests : BeamableTest
+	{
+		private const string ROUTE = "test";
+
+		[Serializable]
+		public class NestedPayload
+		{
+			public string label;
+		}
+
+		[Serializable]
+		public class PlayerStatusResponse
+		{
+			public int level;
+			public string name;
+			public string[] roles;
+			public List<string> tags;
+			public NestedPayload nested;
+			public ItemRef itemRef;
+		}
+
+		private const string EXPLICIT_NULLS_JSON =
+			"{\"level\": 3, \"name\": null, \"roles\": null, \"tags\": null, \"nested\": null, \"itemRef\": null}";
+
+		private static void AssertReferenceFieldsAreNotNull(PlayerStatusResponse result)
+		{
+			Assert.NotNull(result, "the response object itself should never be null");
+			Assert.NotNull(result.name, "an explicitly null string member should deserialize to an empty string, not null");
+			Assert.NotNull(result.roles, "an explicitly null array member should deserialize to an empty array, not null");
+			Assert.NotNull(result.tags, "an explicitly null list member should deserialize to an empty list, not null");
+			Assert.NotNull(result.nested, "an explicitly null object member should deserialize to a default instance, not null");
+			Assert.NotNull(result.itemRef, "an explicitly null content ref member should deserialize to a default instance, not null");
+		}
+
+		[Test]
+		public void ExplicitNullReferenceFields_DeserializeToNonNullDefaults()
+		{
+			var result = MicroserviceClientHelper.DeserializeResult<PlayerStatusResponse>(EXPLICIT_NULLS_JSON);
+
+			Assert.AreEqual(3, result.level);
+			AssertReferenceFieldsAreNotNull(result);
+			Assert.AreEqual(string.Empty, result.name);
+			Assert.AreEqual(0, result.roles.Length);
+			Assert.AreEqual(0, result.tags.Count);
+		}
+
+		[Test]
+		public void NestedObjectWithExplicitNullString_DeserializesToEmptyString()
+		{
+			var result = MicroserviceClientHelper.DeserializeResult<PlayerStatusResponse>("{\"nested\": {\"label\": null}}");
+
+			Assert.NotNull(result.nested);
+			Assert.NotNull(result.nested.label, "an explicitly null string member of a nested object should deserialize to an empty string, not null");
+		}
+
+		[Test]
+		public void ListOfObjects_ExplicitNullReferenceFields_DeserializeToNonNullDefaults()
+		{
+			var result = MicroserviceClientHelper.DeserializeResult<List<PlayerStatusResponse>>(
+				"[" + EXPLICIT_NULLS_JSON + "," + EXPLICIT_NULLS_JSON + "]");
+
+			Assert.AreEqual(2, result.Count);
+			AssertReferenceFieldsAreNotNull(result[0]);
+			AssertReferenceFieldsAreNotNull(result[1]);
+		}
+
+		[Test]
+		public void PopulatedReferenceFields_DeserializeToTheirValues()
+		{
+			var json = "{\"level\": 9, \"name\": \"beam\", \"roles\": [\"admin\"], \"tags\": [\"a\", \"b\"], " +
+					   "\"nested\": {\"label\": \"x\"}, \"itemRef\": {\"Id\": \"items.sword\"}}";
+			var result = MicroserviceClientHelper.DeserializeResult<PlayerStatusResponse>(json);
+
+			Assert.AreEqual(9, result.level);
+			Assert.AreEqual("beam", result.name);
+			Assert.AreEqual(new[] { "admin" }, result.roles);
+			Assert.AreEqual(new List<string> { "a", "b" }, result.tags);
+			Assert.AreEqual("x", result.nested.label);
+			Assert.AreEqual("items.sword", result.itemRef.Id);
+		}
+
+		[Test]
+		public void AbsentCollectionAndObjectFields_DeserializeToNonNullDefaults()
+		{
+			// absent string and string[] members deserialized to null even under JsonUtility,
+			// so only list, nested object, and content ref fields carry a non-null guarantee
+			// when a member is omitted from the JSON entirely.
+			var result = MicroserviceClientHelper.DeserializeResult<PlayerStatusResponse>("{\"level\": 3}");
+
+			Assert.AreEqual(3, result.level);
+			Assert.NotNull(result.tags, "an absent list member should deserialize to an empty list, not null");
+			Assert.NotNull(result.nested, "an absent object member should deserialize to a default instance, not null");
+			Assert.NotNull(result.itemRef, "an absent content ref member should deserialize to a default instance, not null");
+		}
+
+		[UnityTest]
+		public IEnumerator Request_ExplicitNullReferenceFields_DeserializeToNonNullDefaults()
+		{
+			var client = new TestClient(ROUTE, MockRequester);
+
+			MockRequester.MockRequest<PlayerStatusResponse>(Method.POST,
+					client.GetMockPath(MockApi.Token.Cid, MockApi.Token.Pid, ROUTE))
+				.WithRawResponse(EXPLICIT_NULLS_JSON);
+
+			var req = client.Request<PlayerStatusResponse>(ROUTE, new string[] { });
+
+			yield return req.ToYielder();
+			var result = req.GetResult();
+			Assert.AreEqual(3, result.level);
+			AssertReferenceFieldsAreNotNull(result);
+		}
+	}
+}

--- a/client/Packages/com.beamable/Tests/Runtime/Server/Runtime/MicroserviceClient/DeserializeResultNullDefaultsTests.cs.meta
+++ b/client/Packages/com.beamable/Tests/Runtime/Server/Runtime/MicroserviceClient/DeserializeResultNullDefaultsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9d6909b60ca9940d3984c49efbe5fe01

--- a/microservice/microserviceTests/microservice/ResponseSerializationNullFieldsTests.cs
+++ b/microservice/microserviceTests/microservice/ResponseSerializationNullFieldsTests.cs
@@ -1,0 +1,43 @@
+using Beamable.Server;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace microserviceTests.microservice;
+
+/// <summary>
+/// Document what a C# microservice puts on the wire for a [Callable] response DTO whose
+/// reference-type fields were never assigned. The DefaultResponseSerializer serializes with
+/// Newtonsoft using default NullValueHandling, so a null reference field is emitted as an
+/// explicit JSON null: the member is present with a null value, not omitted. Any client
+/// deserializer therefore has to decide what a null member means for a reference-type field.
+/// </summary>
+public class ResponseSerializationNullFieldsTests
+{
+	[System.Serializable]
+	public class PlayerStatusResponse
+	{
+		public int level;
+		public string name;
+		public string[] roles;
+		public List<string> tags;
+	}
+
+	[Test]
+	public void NullReferenceFields_AreEmittedAsExplicitNulls()
+	{
+		var serializer = new DefaultResponseSerializer(useLegacySerialization: false);
+		var ctx = new RequestContext("cid", "pid", 1, 200, 1, "path", "POST", "");
+
+		var json = serializer.SerializeResponse(ctx, new PlayerStatusResponse { level = 3 });
+
+		var body = JObject.Parse(json)["body"] as JObject;
+		Assert.NotNull(body, "response envelope should carry the DTO in its body member");
+		Assert.AreEqual(3, (int)body["level"]);
+		foreach (var member in new[] { "name", "roles", "tags" })
+		{
+			Assert.IsTrue(body.ContainsKey(member), $"the {member} member should be present in the wire JSON");
+			Assert.AreEqual(JTokenType.Null, body[member].Type, $"the {member} member should be an explicit JSON null");
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Unity SDK 5.1.0 changed the object fallback of `MicroserviceClientHelper.DeserializeResult<T>` from `JsonUtility.FromJson<T>(json)` to SmallerJSON `Json.Deserialize<T>(json)` (74dcc190e). The new mapper preserves explicit JSON nulls as C# `null` and leaves absent members at CLR defaults, where JsonUtility produced non-null defaults. Client code written against 5.0.x relies on those non-null guarantees for response DTO reference fields and now throws NullReferenceException.

This PR adds tests only - it documents the 5.0.x contract so a fix can be developed against it. On this branch the four object-path tests fail; all six pass when the same file is run against `unity-sdk-5.0.1`.

## The 5.0.x contract under test

The default microservice response serializer (Newtonsoft, default `NullValueHandling`) emits unassigned reference fields as explicit JSON nulls, identically on 4.3.8 and current - covered by the new `microserviceTests` case. So the dominant wire shape is explicit-null members:

| Member on the wire | JsonUtility (5.0.x) | SmallerJSON (5.1.0+) |
|---|---|---|
| `"name": null` (string) | `""` | `null` |
| `"roles": null` (array) | `[]` (empty) | `null` |
| `"tags": null` (List) | empty list | `null` |
| `"nested": null` / `"itemRef": null` (object / ContentRef) | default instance | `null` |
| absent `List`, nested object, ContentRef member | default instance | `null` |
| absent `string`, `string[]` member | `null` (unchanged) | `null` |

Absent members occur when a field is a valueless `Optional` or a service hand-serializes its response with null-omitting settings; strings and plain arrays never had a non-null guarantee for absence, so the absent-member test covers only the field types that did.

## Test results

| Test | unity-sdk-5.0.1 | this branch |
|---|---|---|
| Object response, explicit-null reference fields | pass | fail |
| Nested object with explicit-null string member | pass | fail |
| Object response, absent list/nested/ref members | pass | fail |
| List of objects with explicit-null members | pass | pass (list path unchanged) |
| Fully populated object round trip | pass | pass |
| End-to-end request through MicroserviceClient | pass | pass at 5.0.1, fail here |
| Server emits explicit nulls (microserviceTests) | pass at cli-4.3.8 | pass |

JsonUtility reference behavior was verified with a standalone probe on Unity 2021.3.45f2 and 6000.3.12f1 with identical results, so the documented contract is not editor-version specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)