### PR TITLE
Emit bash language token for CLI usage fences

### DIFF
--- a/cli/cli/Services/Docs/DocService.cs
+++ b/cli/cli/Services/Docs/DocService.cs
@@ -128,7 +128,7 @@ public class DocService
 	public string GetUsage(BeamCommandDescriptor desc)
 	{
 		var sb = new StringBuilder();
-		sb.Append("```shell\n");
+		sb.Append("```bash\n");
 		sb.Append(desc.executionPath);
 		foreach (var arg in desc.command.Arguments)
 		{


### PR DESCRIPTION
## What

`DocService.GetUsage` (`cli/cli/Services/Docs/DocService.cs`) wraps each command's usage template in a ` ```shell ` fence. This changes it to ` ```bash `.

## Why

The docs site standardizes on **`bash`** as the single language token for typed shell commands (the hand-written CLI guides were just normalized `shell`/`sh` → `bash` in beamable/docs). The generated CLI command reference is regenerated from this code, so its ~200-per-branch usage fences can only be standardized here — editing the generated Markdown in the docs repo would be overwritten on the next regen.

`shell`, `sh`, and `bash` all resolve to the same Pygments Bash lexer, so **rendering is unchanged**; this is a source-consistency fix that lets the whole docs site use one token per language.

## Scope

One-line string change; the usage block is a typed command template (`beam <command> [options]`), so `bash` is the correct token. No behavior change beyond the emitted token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)