### PR TITLE
Add publish history to the Content Manager #4509

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleasd
+
+- Added Content Manager publish history with diff inspection, pagination, preview, and local file restoration.
+
 ## [5.1.1] - 2026-06-29
 
 ### Added

--- a/client/Packages/com.beamable/Editor/BeamCli/UI/LogUtil/LogViewUtil.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/UI/LogUtil/LogViewUtil.cs
@@ -238,7 +238,7 @@ namespace Beamable.Editor.BeamCli.UI.LogHelpers
 		public Action onEndCheck;
 	}
 
-	internal static class SearchBarClearInteraction
+	public static class SearchBarClearInteraction
 	{
 		public static bool IsClearClick(EventType eventType, bool isPointerOverClearGlyph)
 		{

--- a/client/Packages/com.beamable/Editor/BeamCli/UI/LogUtil/LogViewUtil.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/UI/LogUtil/LogViewUtil.cs
@@ -237,7 +237,21 @@ namespace Beamable.Editor.BeamCli.UI.LogHelpers
 		[NonSerialized]
 		public Action onEndCheck;
 	}
-	
+
+	internal static class SearchBarClearInteraction
+	{
+		public static bool IsClearClick(EventType eventType, bool isPointerOverClearGlyph)
+		{
+			return eventType == EventType.MouseDown && isPointerOverClearGlyph;
+		}
+
+		public static void Clear(SearchData searchData)
+		{
+			searchData.searchText = null;
+			searchData.onEndCheck?.Invoke();
+		}
+	}
+
 	public static class CliLogMessageExtensions
 	{
 		public static CliLogLevel GetLogLevel(this CliLogMessage log)
@@ -621,33 +635,36 @@ namespace Beamable.Editor.BeamCli.UI.LogHelpers
 				                               searchRect.height, searchRect.height);
 
 				EditorGUIUtility.AddCursorRect(searchClearRect, MouseCursor.Link);
-				var isButtonHover = searchClearRect.Contains(Event.current.mousePosition);
-				var clearButtonClicked = isButtonHover && Event.current.rawType == EventType.MouseDown;
 				if (searchData != null)
 				{
+					// The text field covers the clear-glyph rect. Capture its mouse-down before the
+					// field processes the event, otherwise the later visual button cannot receive it.
+					var clearClicked = !string.IsNullOrEmpty(searchData.searchText) &&
+					                   SearchBarClearInteraction.IsClearClick(Event.current.type,
+						                   searchClearRect.Contains(Event.current.mousePosition));
+
 					if (textFieldName != null)
 						GUI.SetNextControlName(textFieldName);
 					searchData.searchText = EditorGUI.TextField(searchRect, searchData.searchText, searchStyle);
-					if (EditorGUI.EndChangeCheck())
-					{
-						searchData.onEndCheck?.Invoke();
-					}
+					var searchTextChanged = EditorGUI.EndChangeCheck();
 
 					if (!string.IsNullOrEmpty(searchData.searchText))
 					{
+						// This is intentionally visual-only; EditorGUI.TextField owns the event.
 						GUI.Button(searchClearRect, GUIContent.none, "SearchCancelButton");
+					}
 
-						if (clearButtonClicked)
-						{
-							window.AddDelayedAction(() =>
-							{
-								searchData.searchText = null;
-								GUIUtility.hotControl = 0;
-								GUIUtility.keyboardControl = 0;
-								searchData.onEndCheck?.Invoke();
-								window.Repaint();
-							});
-						}
+					if (clearClicked)
+					{
+						SearchBarClearInteraction.Clear(searchData);
+						GUIUtility.hotControl = 0;
+						GUIUtility.keyboardControl = 0;
+						Event.current.Use();
+						window.Repaint();
+					}
+					else if (searchTextChanged)
+					{
+						searchData.onEndCheck?.Invoke();
 					}
 				}
 			}

--- a/client/Packages/com.beamable/Editor/ContentService/CliContentService.History.cs
+++ b/client/Packages/com.beamable/Editor/ContentService/CliContentService.History.cs
@@ -210,7 +210,7 @@ namespace Beamable.Editor.ContentService
 			}
 		}
 
-		internal void CancelContentHistoryRequests()
+		public void CancelContentHistoryRequests()
 		{
 			_contentHistoryChangesRequest.CancelActive();
 			_contentHistoryPreviewRequest.CancelActive();
@@ -320,7 +320,7 @@ namespace Beamable.Editor.ContentService
 		}
 	}
 
-	internal static class ContentHistoryRequestFactory
+	public static class ContentHistoryRequestFactory
 	{
 		public static ContentHistorySyncContentArgs CreateContentSync(string manifestUid, string contentId)
 		{
@@ -332,7 +332,7 @@ namespace Beamable.Editor.ContentService
 		}
 	}
 
-	internal sealed class ContentHistoryRequestSlot<TRequest> where TRequest : class
+	public sealed class ContentHistoryRequestSlot<TRequest> where TRequest : class
 	{
 		private readonly Action<TRequest> _cancel;
 		private TRequest _activeRequest;

--- a/client/Packages/com.beamable/Editor/ContentService/CliContentService.History.cs
+++ b/client/Packages/com.beamable/Editor/ContentService/CliContentService.History.cs
@@ -10,6 +10,10 @@ namespace Beamable.Editor.ContentService
 	public partial class CliContentService
 	{
 		private ContentHistoryWrapper _contentHistoryWatcher;
+		private readonly ContentHistoryRequestSlot<ContentHistorySyncChangelistWrapper> _contentHistoryChangesRequest =
+			new(request => request.Cancel());
+		private readonly ContentHistoryRequestSlot<ContentHistorySyncContentWrapper> _contentHistoryPreviewRequest =
+			new(request => request.Cancel());
 		private readonly ContentHistoryEntryCache _contentHistoryEntryCache = new();
 
 		/// <summary>
@@ -73,6 +77,7 @@ namespace Beamable.Editor.ContentService
 		/// </summary>
 		public void StopContentHistory()
 		{
+			CancelContentHistoryRequests();
 			if (_contentHistoryWatcher == null)
 			{
 				return;
@@ -89,31 +94,42 @@ namespace Beamable.Editor.ContentService
 		/// <param name="manifestUid">The historical manifest UID to inspect.</param>
 		public async Task<BeamContentHistoryChangelistEntry[]> GetContentHistoryChanges(string manifestUid)
 		{
-			var wrapper = _cli.ContentHistorySyncContent(new ContentHistoryArgs
+			var wrapper = _cli.ContentHistorySyncChangelist(new ContentHistoryArgs
 			{
 				manifestIds = GetSelectedManifestIdsCliOption()
-			}, new ContentHistorySyncContentArgs
+			}, new ContentHistorySyncChangelistArgs
 			{
 				manifestUid = manifestUid
 			});
-			BeamContentHistoryChangelistEntry[] changes = null;
+			_contentHistoryChangesRequest.Replace(wrapper);
+			string changelistStreamJson = null;
 			try
 			{
 				wrapper.Command.On(report =>
 				{
-					if (ContentHistoryStreamParser.TryParseChanges(report.json, out var entries))
+					if (_contentHistoryChangesRequest.IsCurrent(wrapper) && report.type == "stream")
 					{
-						changes = entries;
+						changelistStreamJson = report.json;
 					}
 				});
 
 				await wrapper.Run();
-				if (changes == null)
+				if (!_contentHistoryChangesRequest.IsCurrent(wrapper))
+				{
+					throw new OperationCanceledException();
+				}
+
+				var parseResult = await Task.Run(() =>
+				{
+					var wasParsed = ContentHistoryStreamParser.TryParseChangelist(changelistStreamJson, out var entries);
+					return (wasParsed, entries);
+				});
+				if (!parseResult.wasParsed)
 				{
 					throw new InvalidOperationException("The CLI completed without delivering a usable content-history changelist stream response.");
 				}
 
-				return changes;
+				return parseResult.entries;
 			}
 			catch (Exception exception)
 			{
@@ -122,6 +138,10 @@ namespace Beamable.Editor.ContentService
 					"Unable to load changes for this publish. Check your connection and try again.",
 					manifestUid,
 					exception);
+			}
+			finally
+			{
+				_contentHistoryChangesRequest.Release(wrapper);
 			}
 		}
 
@@ -132,9 +152,33 @@ namespace Beamable.Editor.ContentService
 		/// <param name="contentId">The full content ID to preview.</param>
 		public async Task<string> GetContentHistoryJson(string manifestUid, string contentId)
 		{
+			var wrapper = _cli.ContentHistorySyncContent(new ContentHistoryArgs
+			{
+				manifestIds = GetSelectedManifestIdsCliOption()
+			}, ContentHistoryRequestFactory.CreateContentSync(manifestUid, contentId));
+			_contentHistoryPreviewRequest.Replace(wrapper);
+			BeamContentHistoryChangelistEntry[] entries = null;
 			try
 			{
-				var entries = await GetContentHistoryChanges(manifestUid);
+				wrapper.Command.On(report =>
+				{
+					if (_contentHistoryPreviewRequest.IsCurrent(wrapper) &&
+						ContentHistoryStreamParser.TryParseChanges(report.json, out var parsedEntries))
+					{
+						entries = parsedEntries;
+					}
+				});
+
+				await wrapper.Run();
+				if (!_contentHistoryPreviewRequest.IsCurrent(wrapper))
+				{
+					throw new OperationCanceledException();
+				}
+				if (entries == null)
+				{
+					throw new InvalidOperationException("The CLI completed without delivering a usable historical content response.");
+				}
+
 				foreach (var entry in entries)
 				{
 					if (entry.FullId != contentId)
@@ -160,6 +204,16 @@ namespace Beamable.Editor.ContentService
 					manifestUid,
 					exception);
 			}
+			finally
+			{
+				_contentHistoryPreviewRequest.Release(wrapper);
+			}
+		}
+
+		internal void CancelContentHistoryRequests()
+		{
+			_contentHistoryChangesRequest.CancelActive();
+			_contentHistoryPreviewRequest.CancelActive();
 		}
 
 		/// <summary>
@@ -263,6 +317,60 @@ namespace Beamable.Editor.ContentService
 					null,
 					exception));
 			}
+		}
+	}
+
+	internal static class ContentHistoryRequestFactory
+	{
+		public static ContentHistorySyncContentArgs CreateContentSync(string manifestUid, string contentId)
+		{
+			return new ContentHistorySyncContentArgs
+			{
+				manifestUid = manifestUid,
+				contentIds = new[] { contentId }
+			};
+		}
+	}
+
+	internal sealed class ContentHistoryRequestSlot<TRequest> where TRequest : class
+	{
+		private readonly Action<TRequest> _cancel;
+		private TRequest _activeRequest;
+
+		public ContentHistoryRequestSlot(Action<TRequest> cancel)
+		{
+			_cancel = cancel;
+		}
+
+		public void Replace(TRequest request)
+		{
+			CancelActive();
+			_activeRequest = request;
+		}
+
+		public bool IsCurrent(TRequest request)
+		{
+			return ReferenceEquals(_activeRequest, request);
+		}
+
+		public void Release(TRequest request)
+		{
+			if (IsCurrent(request))
+			{
+				_activeRequest = null;
+			}
+		}
+
+		public void CancelActive()
+		{
+			if (_activeRequest == null)
+			{
+				return;
+			}
+
+			var request = _activeRequest;
+			_activeRequest = null;
+			_cancel?.Invoke(request);
 		}
 	}
 

--- a/client/Packages/com.beamable/Editor/ContentService/CliContentService.History.cs
+++ b/client/Packages/com.beamable/Editor/ContentService/CliContentService.History.cs
@@ -26,6 +26,10 @@ namespace Beamable.Editor.ContentService
 		/// </summary>
 		public bool IsContentHistoryWatching => _contentHistoryWatcher != null;
 		/// <summary>
+		/// Gets the last watcher failure so the History window can display a recoverable error state.
+		/// </summary>
+		public ContentHistoryOperationException ContentHistoryWatcherError { get; private set; }
+		/// <summary>
 		/// True after the watcher has delivered its first valid history event, including an empty history.
 		/// </summary>
 		public bool HasReceivedInitialContentHistory { get; private set; }
@@ -43,6 +47,7 @@ namespace Beamable.Editor.ContentService
 
 			_contentHistoryEntryCache.Clear();
 			HasReceivedInitialContentHistory = false;
+			ContentHistoryWatcherError = null;
 			ContentHistoryVersion++;
 			_contentHistoryWatcher = _cli.ContentHistory(new ContentHistoryArgs
 			{
@@ -51,7 +56,16 @@ namespace Beamable.Editor.ContentService
 				requireProcessId = Process.GetCurrentProcess().Id
 			});
 			_contentHistoryWatcher.Command.On(report => OnContentHistoryEvent(report.json));
-			_ = _contentHistoryWatcher.Run();
+			_ = RunContentHistoryWatcher(_contentHistoryWatcher);
+		}
+
+		/// <summary>
+		/// Stops a failed watcher, if any, and starts a new watcher with a fresh editor-side cache.
+		/// </summary>
+		public void RestartContentHistory()
+		{
+			StopContentHistory();
+			StartContentHistory();
 		}
 
 		/// <summary>
@@ -75,7 +89,6 @@ namespace Beamable.Editor.ContentService
 		/// <param name="manifestUid">The historical manifest UID to inspect.</param>
 		public async Task<BeamContentHistoryChangelistEntry[]> GetContentHistoryChanges(string manifestUid)
 		{
-			var changesWaiter = new TaskCompletionSource<BeamContentHistoryChangelistEntry[]>();
 			var wrapper = _cli.ContentHistorySyncContent(new ContentHistoryArgs
 			{
 				manifestIds = GetSelectedManifestIdsCliOption()
@@ -83,16 +96,33 @@ namespace Beamable.Editor.ContentService
 			{
 				manifestUid = manifestUid
 			});
-			wrapper.Command.On(report =>
+			BeamContentHistoryChangelistEntry[] changes = null;
+			try
 			{
-				if (ContentHistoryStreamParser.TryParseChanges(report.json, out var entries))
+				wrapper.Command.On(report =>
 				{
-					changesWaiter.TrySetResult(entries);
-				}
-			});
+					if (ContentHistoryStreamParser.TryParseChanges(report.json, out var entries))
+					{
+						changes = entries;
+					}
+				});
 
-			await wrapper.Run();
-			return await changesWaiter.Task;
+				await wrapper.Run();
+				if (changes == null)
+				{
+					throw new InvalidOperationException("The CLI completed without delivering a usable content-history changelist stream response.");
+				}
+
+				return changes;
+			}
+			catch (Exception exception)
+			{
+				throw new ContentHistoryOperationException(
+					"Load publish changes",
+					"Unable to load changes for this publish. Check your connection and try again.",
+					manifestUid,
+					exception);
+			}
 		}
 
 		/// <summary>
@@ -102,16 +132,34 @@ namespace Beamable.Editor.ContentService
 		/// <param name="contentId">The full content ID to preview.</param>
 		public async Task<string> GetContentHistoryJson(string manifestUid, string contentId)
 		{
-			var entries = await GetContentHistoryChanges(manifestUid);
-			foreach (var entry in entries)
+			try
 			{
-				if (entry.FullId == contentId && !string.IsNullOrEmpty(entry.JsonFilePath) && File.Exists(entry.JsonFilePath))
+				var entries = await GetContentHistoryChanges(manifestUid);
+				foreach (var entry in entries)
 				{
+					if (entry.FullId != contentId)
+					{
+						continue;
+					}
+
+					if (string.IsNullOrEmpty(entry.JsonFilePath) || !File.Exists(entry.JsonFilePath))
+					{
+						throw new FileNotFoundException("The CLI did not provide a readable cached historical content file.", entry.JsonFilePath);
+					}
+
 					return await File.ReadAllTextAsync(entry.JsonFilePath);
 				}
-			}
 
-			return string.Empty;
+				throw new FileNotFoundException($"The selected content entry '{contentId}' was not included in the historical changelist.");
+			}
+			catch (Exception exception)
+			{
+				throw new ContentHistoryOperationException(
+					"Preview historical content",
+					"Unable to load this historical content file. Check your connection and try again.",
+					manifestUid,
+					exception);
+			}
 		}
 
 		/// <summary>
@@ -121,29 +169,131 @@ namespace Beamable.Editor.ContentService
 		/// <param name="manifestUid">The historical manifest UID to restore.</param>
 		public async Task RestoreContentHistory(string manifestUid)
 		{
-			var wrapper = _cli.ContentHistoryRestoreContent(new ContentHistoryArgs
+			try
 			{
-				manifestIds = GetSelectedManifestIdsCliOption()
-			}, new ContentHistoryRestoreContentArgs
-			{
-				manifestUid = manifestUid
-			});
+				var wrapper = _cli.ContentHistoryRestoreContent(new ContentHistoryArgs
+				{
+					manifestIds = GetSelectedManifestIdsCliOption()
+				}, new ContentHistoryRestoreContentArgs
+				{
+					manifestUid = manifestUid
+				});
 
-			await wrapper.Run();
-			await Reload();
+				await wrapper.Run();
+				await Reload();
+			}
+			catch (ContentHistoryOperationException)
+			{
+				throw;
+			}
+			catch (Exception exception)
+			{
+				throw new ContentHistoryOperationException(
+					"Restore changed files",
+					"Unable to restore changed files. Check your connection and try again.",
+					manifestUid,
+					exception);
+			}
+		}
+
+		private async Task RunContentHistoryWatcher(ContentHistoryWrapper watcher)
+		{
+			try
+			{
+				await watcher.Run();
+				if (ReferenceEquals(_contentHistoryWatcher, watcher))
+				{
+					SetContentHistoryWatcherError(new ContentHistoryOperationException(
+						"Watch publish history",
+						HasReceivedInitialContentHistory
+							? "History updates stopped. Showing the history already loaded. Retry to resume updates."
+							: "Unable to load published history. Check your connection and try again.",
+						null,
+						new InvalidOperationException("The CLI history watcher ended unexpectedly.")));
+				}
+			}
+			catch (Exception exception)
+			{
+				if (ReferenceEquals(_contentHistoryWatcher, watcher))
+				{
+					SetContentHistoryWatcherError(new ContentHistoryOperationException(
+						"Watch publish history",
+						HasReceivedInitialContentHistory
+							? "History updates stopped. Showing the history already loaded. Retry to resume updates."
+							: "Unable to load published history. Check your connection and try again.",
+						null,
+						exception));
+				}
+			}
+		}
+
+		private void SetContentHistoryWatcherError(ContentHistoryOperationException error)
+		{
+			_contentHistoryWatcher = null;
+			ContentHistoryWatcherError = error;
+			ContentHistoryVersion++;
+			UnityEngine.Debug.LogError(error.Diagnostic);
 		}
 
 		private void OnContentHistoryEvent(string streamJson)
 		{
-			var historyUpdate = ContentHistoryStreamParser.Parse(streamJson);
-			if (historyUpdate == null)
+			try
 			{
-				return;
-			}
+				var historyUpdate = ContentHistoryStreamParser.Parse(streamJson);
+				if (historyUpdate == null)
+				{
+					return;
+				}
 
-			_contentHistoryEntryCache.Apply(historyUpdate.Entries, historyUpdate.EntriesToRemove);
-			HasReceivedInitialContentHistory = true;
-			ContentHistoryVersion++;
+				_contentHistoryEntryCache.Apply(historyUpdate.Entries, historyUpdate.EntriesToRemove);
+				HasReceivedInitialContentHistory = true;
+				ContentHistoryVersion++;
+			}
+			catch (Exception exception)
+			{
+				if (_contentHistoryWatcher == null)
+				{
+					return;
+				}
+
+				_contentHistoryWatcher.Cancel();
+				SetContentHistoryWatcherError(new ContentHistoryOperationException(
+					"Watch publish history",
+					"Unable to load published history. Check your connection and try again.",
+					null,
+					exception));
+			}
+		}
+	}
+
+	public class ContentHistoryOperationException : Exception
+	{
+		public string Operation { get; }
+		public string UserMessage { get; }
+		public string ManifestUid { get; }
+		public DateTimeOffset TimestampUtc { get; }
+
+		public string Diagnostic =>
+			$"Content History operation failed\n" +
+			$"Timestamp (UTC): {TimestampUtc:O}\n" +
+			$"Operation: {Operation}\n" +
+			$"Manifest UID: {ManifestUid ?? "(not applicable)"}\n" +
+			$"Exception:\n{InnerException}";
+
+		public ContentHistoryOperationException(string operation, string userMessage, string manifestUid, Exception innerException)
+			: base(userMessage, innerException)
+		{
+			Operation = operation;
+			UserMessage = userMessage;
+			ManifestUid = manifestUid;
+			TimestampUtc = DateTimeOffset.UtcNow;
+		}
+
+		public static ContentHistoryOperationException FromException(string operation, string userMessage, string manifestUid,
+			Exception exception)
+		{
+			return exception as ContentHistoryOperationException ??
+			       new ContentHistoryOperationException(operation, userMessage, manifestUid, exception);
 		}
 	}
 }

--- a/client/Packages/com.beamable/Editor/ContentService/CliContentService.History.cs
+++ b/client/Packages/com.beamable/Editor/ContentService/CliContentService.History.cs
@@ -1,0 +1,149 @@
+using Beamable.Editor.BeamCli.Commands;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Beamable.Editor.ContentService
+{
+	public partial class CliContentService
+	{
+		private ContentHistoryWrapper _contentHistoryWatcher;
+		private readonly ContentHistoryEntryCache _contentHistoryEntryCache = new();
+
+		/// <summary>
+		/// Gets the publish metadata received by the active history watcher, ordered newest first.
+		/// This is an in-memory view over the CLI's local history cache.
+		/// </summary>
+		public IReadOnlyList<BeamContentHistoryEntry> ContentHistoryEntries => _contentHistoryEntryCache.Entries;
+		/// <summary>
+		/// Changes whenever the history cache is cleared or updated so editor windows can repaint.
+		/// </summary>
+		public int ContentHistoryVersion { get; private set; }
+		/// <summary>
+		/// True while the long-running <c>content history --watch</c> command is active.
+		/// </summary>
+		public bool IsContentHistoryWatching => _contentHistoryWatcher != null;
+		/// <summary>
+		/// True after the watcher has delivered its first valid history event, including an empty history.
+		/// </summary>
+		public bool HasReceivedInitialContentHistory { get; private set; }
+
+		/// <summary>
+		/// Starts a process-bound CLI history watcher for the selected manifests and clears the previous in-memory entries.
+		/// The CLI maintains its own on-disk cache; this method only resets the editor-side view of that cache.
+		/// </summary>
+		public void StartContentHistory()
+		{
+			if (_contentHistoryWatcher != null)
+			{
+				return;
+			}
+
+			_contentHistoryEntryCache.Clear();
+			HasReceivedInitialContentHistory = false;
+			ContentHistoryVersion++;
+			_contentHistoryWatcher = _cli.ContentHistory(new ContentHistoryArgs
+			{
+				manifestIds = GetSelectedManifestIdsCliOption(),
+				watch = true,
+				requireProcessId = Process.GetCurrentProcess().Id
+			});
+			_contentHistoryWatcher.Command.On(report => OnContentHistoryEvent(report.json));
+			_ = _contentHistoryWatcher.Run();
+		}
+
+		/// <summary>
+		/// Cancels the active history watcher. It does not clear the CLI's on-disk history cache.
+		/// </summary>
+		public void StopContentHistory()
+		{
+			if (_contentHistoryWatcher == null)
+			{
+				return;
+			}
+
+			_contentHistoryWatcher.Cancel();
+			_contentHistoryWatcher = null;
+		}
+
+		/// <summary>
+		/// Synchronizes and returns the changelist for one historical publish.
+		/// The result is delivered by the CLI stream and parsed through the history-specific wire adapter.
+		/// </summary>
+		/// <param name="manifestUid">The historical manifest UID to inspect.</param>
+		public async Task<BeamContentHistoryChangelistEntry[]> GetContentHistoryChanges(string manifestUid)
+		{
+			var changesWaiter = new TaskCompletionSource<BeamContentHistoryChangelistEntry[]>();
+			var wrapper = _cli.ContentHistorySyncContent(new ContentHistoryArgs
+			{
+				manifestIds = GetSelectedManifestIdsCliOption()
+			}, new ContentHistorySyncContentArgs
+			{
+				manifestUid = manifestUid
+			});
+			wrapper.Command.On(report =>
+			{
+				if (ContentHistoryStreamParser.TryParseChanges(report.json, out var entries))
+				{
+					changesWaiter.TrySetResult(entries);
+				}
+			});
+
+			await wrapper.Run();
+			return await changesWaiter.Task;
+		}
+
+		/// <summary>
+		/// Returns the locally cached historical JSON for one content ID, synchronizing the selected changelist first.
+		/// </summary>
+		/// <param name="manifestUid">The historical manifest UID that owns the content version.</param>
+		/// <param name="contentId">The full content ID to preview.</param>
+		public async Task<string> GetContentHistoryJson(string manifestUid, string contentId)
+		{
+			var entries = await GetContentHistoryChanges(manifestUid);
+			foreach (var entry in entries)
+			{
+				if (entry.FullId == contentId && !string.IsNullOrEmpty(entry.JsonFilePath) && File.Exists(entry.JsonFilePath))
+				{
+					return await File.ReadAllTextAsync(entry.JsonFilePath);
+				}
+			}
+
+			return string.Empty;
+		}
+
+		/// <summary>
+		/// Restores every changed content file from a historical publish into the local workspace, then reloads Content Manager.
+		/// This does not publish the restored files to the realm.
+		/// </summary>
+		/// <param name="manifestUid">The historical manifest UID to restore.</param>
+		public async Task RestoreContentHistory(string manifestUid)
+		{
+			var wrapper = _cli.ContentHistoryRestoreContent(new ContentHistoryArgs
+			{
+				manifestIds = GetSelectedManifestIdsCliOption()
+			}, new ContentHistoryRestoreContentArgs
+			{
+				manifestUid = manifestUid
+			});
+
+			await wrapper.Run();
+			await Reload();
+		}
+
+		private void OnContentHistoryEvent(string streamJson)
+		{
+			var historyUpdate = ContentHistoryStreamParser.Parse(streamJson);
+			if (historyUpdate == null)
+			{
+				return;
+			}
+
+			_contentHistoryEntryCache.Apply(historyUpdate.Entries, historyUpdate.EntriesToRemove);
+			HasReceivedInitialContentHistory = true;
+			ContentHistoryVersion++;
+		}
+	}
+}

--- a/client/Packages/com.beamable/Editor/ContentService/CliContentService.History.cs.meta
+++ b/client/Packages/com.beamable/Editor/ContentService/CliContentService.History.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8965ade1c4ae3c14db001f4e99fcdbd8

--- a/client/Packages/com.beamable/Editor/ContentService/CliContentService.cs
+++ b/client/Packages/com.beamable/Editor/ContentService/CliContentService.cs
@@ -47,7 +47,7 @@ namespace Beamable.Editor.ContentService
 		public float Progress;
 	}
 
-	public class CliContentService : IStorageHandler<CliContentService>, ILoadWithContext
+	public partial class CliContentService : IStorageHandler<CliContentService>, ILoadWithContext
 	{
 		private const string SYNC_OPERATION_TITLE = "Sync Contents";
 		private const string SYNC_OPERATION_SUCCESS_BASE_MESSAGE = "{0} sync complete. {1}/{2} items synced.";

--- a/client/Packages/com.beamable/Editor/ContentService/ContentHistoryEntryCache.cs
+++ b/client/Packages/com.beamable/Editor/ContentService/ContentHistoryEntryCache.cs
@@ -1,0 +1,44 @@
+using Beamable.Editor.BeamCli.Commands;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Beamable.Editor.ContentService
+{
+	public class ContentHistoryEntryCache
+	{
+		private readonly Dictionary<string, BeamContentHistoryEntry> _entriesByManifestUid = new();
+
+		public IReadOnlyList<BeamContentHistoryEntry> Entries => _entriesByManifestUid.Values
+			.OrderByDescending(entry => entry.CreatedDate)
+			.ToList();
+
+		public void Apply(IEnumerable<BeamContentHistoryEntry> entries, IEnumerable<string> entriesToRemove = null)
+		{
+			if (entriesToRemove != null)
+			{
+				foreach (var manifestUid in entriesToRemove)
+				{
+					_entriesByManifestUid.Remove(manifestUid);
+				}
+			}
+
+			if (entries == null)
+			{
+				return;
+			}
+
+			foreach (var entry in entries)
+			{
+				if (!string.IsNullOrEmpty(entry?.ManifestUid))
+				{
+					_entriesByManifestUid[entry.ManifestUid] = entry;
+				}
+			}
+		}
+
+		public void Clear()
+		{
+			_entriesByManifestUid.Clear();
+		}
+	}
+}

--- a/client/Packages/com.beamable/Editor/ContentService/ContentHistoryEntryCache.cs
+++ b/client/Packages/com.beamable/Editor/ContentService/ContentHistoryEntryCache.cs
@@ -7,23 +7,43 @@ namespace Beamable.Editor.ContentService
 	public class ContentHistoryEntryCache
 	{
 		private readonly Dictionary<string, BeamContentHistoryEntry> _entriesByManifestUid = new();
+		private IReadOnlyList<BeamContentHistoryEntry> _sortedEntries = new List<BeamContentHistoryEntry>();
+		private bool _isSortedEntriesDirty = true;
 
-		public IReadOnlyList<BeamContentHistoryEntry> Entries => _entriesByManifestUid.Values
-			.OrderByDescending(entry => entry.CreatedDate)
-			.ToList();
+		public IReadOnlyList<BeamContentHistoryEntry> Entries
+		{
+			get
+			{
+				if (_isSortedEntriesDirty)
+				{
+					_sortedEntries = _entriesByManifestUid.Values
+						.OrderByDescending(entry => entry.CreatedDate)
+						.ToList();
+					_isSortedEntriesDirty = false;
+				}
+
+				return _sortedEntries;
+			}
+		}
 
 		public void Apply(IEnumerable<BeamContentHistoryEntry> entries, IEnumerable<string> entriesToRemove = null)
 		{
+			var hasChanges = false;
 			if (entriesToRemove != null)
 			{
 				foreach (var manifestUid in entriesToRemove)
 				{
-					_entriesByManifestUid.Remove(manifestUid);
+					hasChanges |= _entriesByManifestUid.Remove(manifestUid);
 				}
 			}
 
 			if (entries == null)
 			{
+				if (hasChanges)
+				{
+					_isSortedEntriesDirty = true;
+				}
+
 				return;
 			}
 
@@ -32,13 +52,25 @@ namespace Beamable.Editor.ContentService
 				if (!string.IsNullOrEmpty(entry?.ManifestUid))
 				{
 					_entriesByManifestUid[entry.ManifestUid] = entry;
+					hasChanges = true;
 				}
+			}
+
+			if (hasChanges)
+			{
+				_isSortedEntriesDirty = true;
 			}
 		}
 
 		public void Clear()
 		{
+			if (_entriesByManifestUid.Count == 0)
+			{
+				return;
+			}
+
 			_entriesByManifestUid.Clear();
+			_isSortedEntriesDirty = true;
 		}
 	}
 }

--- a/client/Packages/com.beamable/Editor/ContentService/ContentHistoryEntryCache.cs.meta
+++ b/client/Packages/com.beamable/Editor/ContentService/ContentHistoryEntryCache.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4b9b3254302b8ac4eadbd88b00108b8d

--- a/client/Packages/com.beamable/Editor/ContentService/ContentHistoryStreamParser.cs
+++ b/client/Packages/com.beamable/Editor/ContentService/ContentHistoryStreamParser.cs
@@ -1,0 +1,155 @@
+using Beamable.Editor.BeamCli.Commands;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace Beamable.Editor.ContentService
+{
+	/// <summary>
+	/// Adapts the CLI's content-history stream payloads to the generated Unity DTOs.
+	/// The generated DTOs use Pascal-case members, while the CLI emits camel-case fields inside history entries and changelists;
+	/// keeping this mapping here avoids changing generated command code or the CLI wire contract.
+	/// </summary>
+	public static class ContentHistoryStreamParser
+	{
+		public static IReadOnlyList<BeamContentHistoryEntry> ParseEntries(string streamJson)
+		{
+			var update = Parse(streamJson);
+			return update?.Entries ?? Array.Empty<BeamContentHistoryEntry>();
+		}
+
+		public static BeamContentHistoryChangelistEntry[] ParseChanges(string streamJson)
+		{
+			return TryParseChanges(streamJson, out var entries)
+				? entries
+				: Array.Empty<BeamContentHistoryChangelistEntry>();
+		}
+
+		public static bool TryParseChanges(string streamJson, out BeamContentHistoryChangelistEntry[] entries)
+		{
+			var report = JsonUtility.FromJson<ContentHistoryChangeStreamReport>(streamJson);
+			if (report == null || report.type != "stream" || report.data?.ContentEntries == null)
+			{
+				entries = Array.Empty<BeamContentHistoryChangelistEntry>();
+				return false;
+			}
+
+			entries = report.data.ContentEntries
+				.Where(entry => !string.IsNullOrEmpty(entry.fullId))
+				.Select(entry => new BeamContentHistoryChangelistEntry
+				{
+					OldVersion = entry.oldVersion,
+					OldChecksum = entry.oldChecksum,
+					OldTags = entry.oldTags,
+					NewVersion = entry.newVersion,
+					NewChecksum = entry.newChecksum,
+					NewTags = entry.newTags,
+					JsonFilePath = entry.jsonFilePath,
+					FullId = entry.fullId,
+					TypeName = entry.typeName,
+					Name = entry.name,
+					ChangeStatus = entry.changeStatus,
+					ChangeDate = entry.changeDate
+				})
+				.ToArray();
+			return true;
+		}
+
+		public static ContentHistoryStreamUpdate Parse(string streamJson)
+		{
+			var report = JsonUtility.FromJson<ContentHistoryStreamReport>(streamJson);
+			if (report == null || report.type != "stream" || report.data == null || report.data.EventType != 0)
+			{
+				return null;
+			}
+
+			var entries = report.data.EntriesPage?.Entries?
+				.Where(entry => !string.IsNullOrEmpty(entry.manifestUid))
+				.Select(entry => new BeamContentHistoryEntry
+				{
+					ManifestUid = entry.manifestUid,
+					CreatedDate = entry.createdDate,
+					PublishedBy = entry.publishedBy,
+					PublishedByName = entry.publishedByName,
+					AffectedContentIds = entry.affectedContentIds
+				})
+				.ToArray() ?? Array.Empty<BeamContentHistoryEntry>();
+
+			return new ContentHistoryStreamUpdate(entries, report.data.EntriesToRemove);
+		}
+
+		[Serializable]
+		private class ContentHistoryStreamReport
+		{
+			public string type;
+			public ContentHistoryStreamData data;
+		}
+
+		[Serializable]
+		private class ContentHistoryStreamData
+		{
+			public int EventType;
+			public ContentHistoryStreamEntriesPage EntriesPage;
+			public string[] EntriesToRemove;
+		}
+
+		[Serializable]
+		private class ContentHistoryStreamEntriesPage
+		{
+			public ContentHistoryStreamEntry[] Entries;
+		}
+
+		[Serializable]
+		private class ContentHistoryStreamEntry
+		{
+			public string manifestUid;
+			public long createdDate;
+			public string publishedBy;
+			public string publishedByName;
+			public string[] affectedContentIds;
+		}
+
+		[Serializable]
+		private class ContentHistoryChangeStreamReport
+		{
+			public string type;
+			public ContentHistoryChangeStreamData data;
+		}
+
+		[Serializable]
+		private class ContentHistoryChangeStreamData
+		{
+			public ContentHistoryChangeStreamEntry[] ContentEntries;
+		}
+
+		[Serializable]
+		private class ContentHistoryChangeStreamEntry
+		{
+			public string oldVersion;
+			public string oldChecksum;
+			public string[] oldTags;
+			public string newVersion;
+			public string newChecksum;
+			public string[] newTags;
+			public string jsonFilePath;
+			public string fullId;
+			public string typeName;
+			public string name;
+			public int changeStatus;
+			public long changeDate;
+		}
+	}
+
+	public class ContentHistoryStreamUpdate
+	{
+		public readonly IReadOnlyList<BeamContentHistoryEntry> Entries;
+		public readonly IReadOnlyList<string> EntriesToRemove;
+
+		public ContentHistoryStreamUpdate(IReadOnlyList<BeamContentHistoryEntry> entries, IReadOnlyList<string> entriesToRemove)
+		{
+			Entries = entries;
+			EntriesToRemove = entriesToRemove;
+		}
+	}
+}

--- a/client/Packages/com.beamable/Editor/ContentService/ContentHistoryStreamParser.cs
+++ b/client/Packages/com.beamable/Editor/ContentService/ContentHistoryStreamParser.cs
@@ -1,4 +1,6 @@
 using Beamable.Editor.BeamCli.Commands;
+using Beamable.Common.BeamCli.Contracts;
+using Beamable.Serialization.SmallerJSON;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -56,6 +58,34 @@ namespace Beamable.Editor.ContentService
 			return true;
 		}
 
+		public static bool TryParseChangelist(string streamJson, out BeamContentHistoryChangelistEntry[] entries)
+		{
+			entries = Array.Empty<BeamContentHistoryChangelistEntry>();
+			try
+			{
+				if (Json.Deserialize(streamJson) is not ArrayDict report ||
+					!TryGetString(report, "type", out var reportType) || reportType != "stream" ||
+					!TryGetObject(report, "data", out var data) ||
+					!TryGetObject(data, "Changelist", out var changelist))
+				{
+					return false;
+				}
+
+				var publishedAt = TryGetLong(changelist, "publishedAt", out var timestamp) ? timestamp : 0;
+				var parsedEntries = new List<BeamContentHistoryChangelistEntry>();
+				AddChangelistEntries(changelist, "added", ContentStatus.Created, publishedAt, parsedEntries);
+				AddChangelistEntries(changelist, "modified", ContentStatus.Modified, publishedAt, parsedEntries);
+				AddChangelistEntries(changelist, "removed", ContentStatus.Deleted, publishedAt, parsedEntries);
+				entries = parsedEntries.ToArray();
+				return true;
+			}
+			catch (Exception)
+			{
+				entries = Array.Empty<BeamContentHistoryChangelistEntry>();
+				return false;
+			}
+		}
+
 		public static ContentHistoryStreamUpdate Parse(string streamJson)
 		{
 			var report = JsonUtility.FromJson<ContentHistoryStreamReport>(streamJson);
@@ -77,6 +107,83 @@ namespace Beamable.Editor.ContentService
 				.ToArray() ?? Array.Empty<BeamContentHistoryEntry>();
 
 			return new ContentHistoryStreamUpdate(entries, report.data.EntriesToRemove);
+		}
+
+		private static void AddChangelistEntries(ArrayDict changelist, string key, ContentStatus status, long publishedAt,
+			ICollection<BeamContentHistoryChangelistEntry> entries)
+		{
+			if (!TryGetObject(changelist, key, out var category))
+			{
+				return;
+			}
+
+			foreach (var pair in category)
+			{
+				if (string.IsNullOrEmpty(pair.Key) || pair.Value is not ArrayDict entry)
+				{
+					continue;
+				}
+
+				var separatorIndex = pair.Key.IndexOf('.', StringComparison.Ordinal);
+				var typeName = separatorIndex > 0 ? pair.Key.Substring(0, separatorIndex) : string.Empty;
+				var name = separatorIndex >= 0 && separatorIndex < pair.Key.Length - 1
+					? pair.Key.Substring(separatorIndex + 1)
+					: pair.Key;
+				entries.Add(new BeamContentHistoryChangelistEntry
+				{
+					OldVersion = GetString(entry, "oldVersion"),
+					OldChecksum = GetString(entry, "oldChecksum"),
+					OldTags = GetStringArray(entry, "oldTags"),
+					NewVersion = GetString(entry, "newVersion"),
+					NewChecksum = GetString(entry, "newChecksum"),
+					NewTags = GetStringArray(entry, "newTags"),
+					FullId = pair.Key,
+					TypeName = typeName,
+					Name = name,
+					ChangeStatus = (int)status,
+					ChangeDate = publishedAt
+				});
+			}
+		}
+
+		private static bool TryGetObject(ArrayDict source, string key, out ArrayDict value)
+		{
+			if (source != null && source.TryGetValue(key, out var rawValue) && rawValue is ArrayDict dictionary)
+			{
+				value = dictionary;
+				return true;
+			}
+
+			value = null;
+			return false;
+		}
+
+		private static bool TryGetString(ArrayDict source, string key, out string value)
+		{
+			value = GetString(source, key);
+			return value != null;
+		}
+
+		private static string GetString(ArrayDict source, string key)
+		{
+			return source != null && source.TryGetValue(key, out var value) ? value?.ToString() : null;
+		}
+
+		private static string[] GetStringArray(ArrayDict source, string key)
+		{
+			if (source == null || !source.TryGetValue(key, out var value) || value is not List<object> values)
+			{
+				return null;
+			}
+
+			return values.Select(item => item?.ToString()).ToArray();
+		}
+
+		private static bool TryGetLong(ArrayDict source, string key, out long value)
+		{
+			value = 0;
+			return source != null && source.TryGetValue(key, out var rawValue) &&
+				long.TryParse(rawValue?.ToString(), out value);
 		}
 
 		[Serializable]

--- a/client/Packages/com.beamable/Editor/ContentService/ContentHistoryStreamParser.cs.meta
+++ b/client/Packages/com.beamable/Editor/ContentService/ContentHistoryStreamParser.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f7dbcdd978715fc48801c110e6e1216d

--- a/client/Packages/com.beamable/Editor/Modules/Content/UI/ContentObjectEditor.cs
+++ b/client/Packages/com.beamable/Editor/Modules/Content/UI/ContentObjectEditor.cs
@@ -31,6 +31,8 @@ namespace Beamable.Editor.Content.UI
 		{
 			var contentObject = target as ContentObject;
 			if (contentObject == null) return;
+			using (new EditorGUI.DisabledScope(ContentHistoryInspectorPreview.IsReadOnly(contentObject)))
+			{
 			var isEditingMultiple = targets.Length > 1;
 
 			var contentService = BeamEditorContext.Default.ServiceScope.GetService<CliContentService>();
@@ -119,7 +121,8 @@ namespace Beamable.Editor.Content.UI
 					DrawContentButtons(contentObject, buttonsRect, contentService);
 				}
 			}
-		GUILayout.EndVertical();
+			GUILayout.EndVertical();
+			}
 		}
 
 		private void DrawContentButtons(ContentObject content, Rect buttonsRect, CliContentService contentService)
@@ -345,6 +348,8 @@ namespace Beamable.Editor.Content.UI
 		{
 			var contentObject = target as ContentObject;
 			if (contentObject == null) return;
+			using (new EditorGUI.DisabledScope(ContentHistoryInspectorPreview.IsReadOnly(contentObject)))
+			{
 
 			if (contentObject.ContentStatus is Common.BeamCli.Contracts.ContentStatus.Deleted)
 			{
@@ -379,6 +384,7 @@ namespace Beamable.Editor.Content.UI
 			
 			base.OnInspectorGUI();
 			contentObject.CheckForNonDetectedChanges();
+			}
 		}
 
 		public string GetTagString(string[] tags)

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentHistoryPagination.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentHistoryPagination.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Beamable.Editor.UI.ContentWindow
+{
+	public static class ContentHistoryPagination
+	{
+		public const int MinimumPageSize = 10;
+		public const int MaximumPageSize = 50;
+
+		public static int ClampPageSize(int pageSize)
+		{
+			return Math.Clamp(pageSize, MinimumPageSize, MaximumPageSize);
+		}
+
+		public static int GetPageCount(int entryCount, int pageSize)
+		{
+			if (entryCount <= 0)
+			{
+				return 0;
+			}
+
+			return (entryCount + ClampPageSize(pageSize) - 1) / ClampPageSize(pageSize);
+		}
+
+		public static int ClampPageIndex(int pageIndex, int pageCount)
+		{
+			return pageCount <= 0 ? 0 : Math.Clamp(pageIndex, 0, pageCount - 1);
+		}
+	}
+}

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentHistoryPagination.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentHistoryPagination.cs
@@ -26,5 +26,30 @@ namespace Beamable.Editor.UI.ContentWindow
 		{
 			return pageCount <= 0 ? 0 : Math.Clamp(pageIndex, 0, pageCount - 1);
 		}
+
+		public static ContentHistoryVisibleRange GetVisibleRange(int itemCount, float scrollPosition, float viewportHeight, float rowHeight)
+		{
+			if (itemCount <= 0 || viewportHeight <= 0 || rowHeight <= 0)
+			{
+				return new ContentHistoryVisibleRange(0, 0);
+			}
+
+			var firstIndex = Math.Clamp((int)Math.Floor(Math.Max(0, scrollPosition) / rowHeight), 0, itemCount);
+			var visibleRowCount = (int)Math.Ceiling(viewportHeight / rowHeight) + 1;
+			var lastExclusive = Math.Min(itemCount, firstIndex + visibleRowCount);
+			return new ContentHistoryVisibleRange(firstIndex, lastExclusive);
+		}
+	}
+
+	public struct ContentHistoryVisibleRange
+	{
+		public readonly int FirstIndex;
+		public readonly int LastExclusive;
+
+		public ContentHistoryVisibleRange(int firstIndex, int lastExclusive)
+		{
+			FirstIndex = firstIndex;
+			LastExclusive = lastExclusive;
+		}
 	}
 }

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentHistoryPagination.cs.meta
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentHistoryPagination.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1113a4e4e199e214e97808dee9fa0e29

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentHistoryTimeBuckets.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentHistoryTimeBuckets.cs
@@ -1,0 +1,263 @@
+using Beamable.Editor.BeamCli.Commands;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Beamable.Editor.UI.ContentWindow
+{
+	/// <summary>
+	/// Builds the local-time, progressively grouped publish-history hierarchy used by the Content Window.
+	/// Keeping the date rules here makes the IMGUI view a renderer instead of a second source of grouping logic.
+	/// </summary>
+	public static class ContentHistoryTimeBuckets
+	{
+		public static IReadOnlyList<ContentHistoryTimeBucket> Create(IReadOnlyList<BeamContentHistoryEntry> entries, DateTime localNow)
+		{
+			var todayEntries = new List<BeamContentHistoryEntry>();
+			var thisWeekEntries = new List<BeamContentHistoryEntry>();
+			var earlierThisMonthEntries = new List<BeamContentHistoryEntry>();
+			var olderMonths = new Dictionary<DateTime, List<BeamContentHistoryEntry>>();
+			var startOfToday = localNow.Date;
+			var startOfThisWeek = startOfToday.AddDays(-((7 + (int)startOfToday.DayOfWeek - (int)DayOfWeek.Monday) % 7));
+
+			foreach (var entry in entries ?? Array.Empty<BeamContentHistoryEntry>())
+			{
+				if (entry == null)
+				{
+					continue;
+				}
+
+				var localDate = DateTimeOffset.FromUnixTimeMilliseconds(entry.CreatedDate).LocalDateTime.Date;
+				if (localDate == startOfToday)
+				{
+					todayEntries.Add(entry);
+				}
+				else if (localDate >= startOfThisWeek && localDate < startOfToday)
+				{
+					thisWeekEntries.Add(entry);
+				}
+				else if (localDate.Year == localNow.Year && localDate.Month == localNow.Month)
+				{
+					earlierThisMonthEntries.Add(entry);
+				}
+				else
+				{
+					var month = new DateTime(localDate.Year, localDate.Month, 1);
+					if (!olderMonths.TryGetValue(month, out var monthEntries))
+					{
+						monthEntries = new List<BeamContentHistoryEntry>();
+						olderMonths.Add(month, monthEntries);
+					}
+					monthEntries.Add(entry);
+				}
+			}
+
+			var buckets = new List<ContentHistoryTimeBucket>();
+			AddBucketIfNotEmpty(buckets, "today", "Today", true, todayEntries);
+			AddBucketIfNotEmpty(buckets, "this-week", "This week", true, thisWeekEntries);
+			AddBucketIfNotEmpty(buckets, "earlier-this-month", "Earlier this month", true, earlierThisMonthEntries);
+
+			var previousMonth = new DateTime(localNow.Year, localNow.Month, 1).AddMonths(-1);
+			var secondPreviousMonth = previousMonth.AddMonths(-1);
+			AddMonthIfPresent(buckets, olderMonths, previousMonth);
+			AddMonthIfPresent(buckets, olderMonths, secondPreviousMonth);
+
+			foreach (var yearGroup in olderMonths
+				.Where(pair => pair.Key != previousMonth && pair.Key != secondPreviousMonth)
+				.GroupBy(pair => pair.Key.Year)
+				.OrderByDescending(group => group.Key))
+			{
+				var yearBucket = new ContentHistoryTimeBucket($"year:{yearGroup.Key}", yearGroup.Key.ToString(), false);
+				foreach (var monthGroup in yearGroup.OrderByDescending(pair => pair.Key))
+				{
+					yearBucket.AddChild(CreateMonthBucket(monthGroup.Key, monthGroup.Value));
+				}
+				buckets.Add(yearBucket);
+			}
+
+			return buckets;
+		}
+
+		public static IReadOnlyList<string> GetAncestorKeys(IReadOnlyList<ContentHistoryTimeBucket> buckets, string manifestUid)
+		{
+			if (string.IsNullOrEmpty(manifestUid))
+			{
+				return Array.Empty<string>();
+			}
+
+			foreach (var bucket in buckets ?? Array.Empty<ContentHistoryTimeBucket>())
+			{
+				var keys = new List<string>();
+				if (TryGetAncestorKeys(bucket, manifestUid, keys))
+				{
+					return keys;
+				}
+			}
+
+			return Array.Empty<string>();
+		}
+
+		public static IReadOnlyList<ContentHistoryTimeBucketRow> BuildVisibleRows(
+			IReadOnlyList<ContentHistoryTimeBucket> buckets, ISet<string> expandedBucketKeys)
+		{
+			var rows = new List<ContentHistoryTimeBucketRow>();
+			foreach (var bucket in buckets ?? Array.Empty<ContentHistoryTimeBucket>())
+			{
+				AddVisibleRows(rows, bucket, expandedBucketKeys);
+			}
+			return rows;
+		}
+
+		public static IReadOnlyCollection<string> GetDefaultExpandedKeys(IReadOnlyList<ContentHistoryTimeBucket> buckets)
+		{
+			var keys = new HashSet<string>();
+			foreach (var bucket in buckets ?? Array.Empty<ContentHistoryTimeBucket>())
+			{
+				AddDefaultExpandedKeys(bucket, keys);
+			}
+			return keys;
+		}
+
+		public static string GetFirstManifestUid(ContentHistoryTimeBucket bucket)
+		{
+			if (bucket == null)
+			{
+				return string.Empty;
+			}
+
+			if (bucket.Entries.Count > 0)
+			{
+				return bucket.Entries[0].ManifestUid;
+			}
+
+			foreach (var child in bucket.Children)
+			{
+				var manifestUid = GetFirstManifestUid(child);
+				if (!string.IsNullOrEmpty(manifestUid))
+				{
+					return manifestUid;
+				}
+			}
+
+			return string.Empty;
+		}
+
+		private static void AddBucketIfNotEmpty(ICollection<ContentHistoryTimeBucket> buckets, string key, string label,
+			bool isExpandedByDefault, IReadOnlyList<BeamContentHistoryEntry> entries)
+		{
+			if (entries.Count > 0)
+			{
+				buckets.Add(new ContentHistoryTimeBucket(key, label, isExpandedByDefault, entries));
+			}
+		}
+
+		private static void AddMonthIfPresent(ICollection<ContentHistoryTimeBucket> buckets,
+			IReadOnlyDictionary<DateTime, List<BeamContentHistoryEntry>> olderMonths, DateTime month)
+		{
+			if (olderMonths.TryGetValue(month, out var entries))
+			{
+				buckets.Add(CreateMonthBucket(month, entries));
+			}
+		}
+
+		private static ContentHistoryTimeBucket CreateMonthBucket(DateTime month, IReadOnlyList<BeamContentHistoryEntry> entries)
+		{
+			return new ContentHistoryTimeBucket($"month:{month:yyyy-MM}", month.ToString("MMMM yyyy"), false, entries);
+		}
+
+		private static void AddVisibleRows(ICollection<ContentHistoryTimeBucketRow> rows, ContentHistoryTimeBucket bucket,
+			ISet<string> expandedBucketKeys)
+		{
+			rows.Add(new ContentHistoryTimeBucketRow(bucket, null));
+			if (expandedBucketKeys == null || !expandedBucketKeys.Contains(bucket.Key))
+			{
+				return;
+			}
+
+			foreach (var child in bucket.Children)
+			{
+				AddVisibleRows(rows, child, expandedBucketKeys);
+			}
+
+			foreach (var entry in bucket.Entries)
+			{
+				rows.Add(new ContentHistoryTimeBucketRow(null, entry));
+			}
+		}
+
+		private static void AddDefaultExpandedKeys(ContentHistoryTimeBucket bucket, ISet<string> keys)
+		{
+			if (bucket.IsExpandedByDefault)
+			{
+				keys.Add(bucket.Key);
+			}
+
+			foreach (var child in bucket.Children)
+			{
+				AddDefaultExpandedKeys(child, keys);
+			}
+		}
+
+		private static bool TryGetAncestorKeys(ContentHistoryTimeBucket bucket, string manifestUid, ICollection<string> keys)
+		{
+			keys.Add(bucket.Key);
+			if (bucket.Entries.Any(entry => entry.ManifestUid == manifestUid))
+			{
+				return true;
+			}
+
+			foreach (var child in bucket.Children)
+			{
+				if (TryGetAncestorKeys(child, manifestUid, keys))
+				{
+					return true;
+				}
+			}
+
+			keys.Remove(bucket.Key);
+			return false;
+		}
+	}
+
+	public readonly struct ContentHistoryTimeBucketRow
+	{
+		public ContentHistoryTimeBucket Bucket { get; }
+		public BeamContentHistoryEntry Entry { get; }
+
+		public ContentHistoryTimeBucketRow(ContentHistoryTimeBucket bucket, BeamContentHistoryEntry entry)
+		{
+			Bucket = bucket;
+			Entry = entry;
+		}
+	}
+
+	public class ContentHistoryTimeBucket
+	{
+		private readonly List<BeamContentHistoryEntry> _entries;
+		private readonly List<ContentHistoryTimeBucket> _children = new();
+
+		public string Key { get; }
+		public string Label { get; }
+		public bool IsExpandedByDefault { get; }
+		public IReadOnlyList<BeamContentHistoryEntry> Entries => _entries;
+		public IReadOnlyList<ContentHistoryTimeBucket> Children => _children;
+		public int EntryCount => _entries.Count + _children.Sum(child => child.EntryCount);
+
+		public ContentHistoryTimeBucket(string key, string label, bool isExpandedByDefault,
+			IReadOnlyList<BeamContentHistoryEntry> entries = null)
+		{
+			Key = key;
+			Label = label;
+			IsExpandedByDefault = isExpandedByDefault;
+			_entries = entries?.ToList() ?? new List<BeamContentHistoryEntry>();
+		}
+
+		public void AddChild(ContentHistoryTimeBucket child)
+		{
+			if (child != null)
+			{
+				_children.Add(child);
+			}
+		}
+	}
+}

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentHistoryTimeBuckets.cs.meta
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentHistoryTimeBuckets.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f8c241c847ad498aaac14e7c27579ba2

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow.cs
@@ -95,6 +95,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		public override void OnEnable()
 		{
 			base.OnEnable();
+			EnsureHistoryCopyManifestContent();
 			EditorApplication.update += OnEditorUpdate;
 		}
 

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow.cs
@@ -101,6 +101,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		private void OnDisable()
 		{
 			EditorApplication.update -= OnEditorUpdate;
+			ResetHistorySelection();
 			_contentService?.StopContentHistory();
 		}
 

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow.cs
@@ -32,6 +32,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		private Vector2 _horizontalScrollPosition;
 		private int _lastManifestChangedCount;
 		private int _lastProgressUpdateVersion;
+		private int _lastContentHistoryVersion;
 		private EditorGUISplitView _mainSplitter;
 		private bool _importingDefaultContent;
 
@@ -100,6 +101,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		private void OnDisable()
 		{
 			EditorApplication.update -= OnEditorUpdate;
+			_contentService?.StopContentHistory();
 		}
 
 		private void OnEditorUpdate()
@@ -117,6 +119,12 @@ namespace Beamable.Editor.UI.ContentWindow
 				_lastProgressUpdateVersion = _contentService.ProgressUpdateVersion;
 				Repaint();
 			}
+
+			if (_contentService != null && _contentService.ContentHistoryVersion != _lastContentHistoryVersion)
+			{
+				_lastContentHistoryVersion = _contentService.ContentHistoryVersion;
+				Repaint();
+			}
 		}
 
 		private void ReloadData()
@@ -125,7 +133,7 @@ namespace Beamable.Editor.UI.ContentWindow
 			_allTags = _contentService.TagsCache;
 			SetEditorSelection();
 			
-			if(!_contentService.HasChangedContents && _windowStatus != ContentWindowStatus.SnapshotManager)
+			if(!_contentService.HasChangedContents && _windowStatus != ContentWindowStatus.SnapshotManager && _windowStatus != ContentWindowStatus.History)
 			{
 				ChangeWindowStatusDelayed(ContentWindowStatus.Normal);
 			}
@@ -202,6 +210,9 @@ namespace Beamable.Editor.UI.ContentWindow
 					break;
 				case ContentWindowStatus.SnapshotManager:
 					DrawSnapshotManager();
+					break;
+				case ContentWindowStatus.History:
+					DrawContentHistory();
 					break;
 			}
 			
@@ -482,8 +493,9 @@ namespace Beamable.Editor.UI.ContentWindow
 		Publish,
 		Building,
 		Revert,
-		Validate,
-		SnapshotManager,
-	}
+			Validate,
+			SnapshotManager,
+			History,
+		}
 	
 }

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_Header.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_Header.cs
@@ -180,6 +180,12 @@ namespace Beamable.Editor.UI.ContentWindow
 					ChangeToSnapshotManager();
 				}
 
+				if (BeamGUI.HeaderButton("History", BeamGUI.iconRefresh, width: HEADER_BUTTON_WIDTH, iconPadding: 2,
+				                         tooltip: "View published content history"))
+				{
+					ChangeToHistory();
+				}
+
 				if (_windowStatus != ContentWindowStatus.Validate)
 				{
 					EditorGUILayout.Space(5, false);
@@ -225,12 +231,26 @@ namespace Beamable.Editor.UI.ContentWindow
 			});
 		}
 
+		private void ChangeToHistory()
+		{
+			AddDelayedAction(() => ChangeWindowStatus(ContentWindowStatus.History));
+		}
+
 		private void ChangeWindowStatus(ContentWindowStatus windowStatus, bool shouldRepaint = true)
 		{
 			if(_windowStatus == windowStatus)
 				return;
 			
 			_windowStatus = windowStatus;
+			if (_windowStatus == ContentWindowStatus.History)
+			{
+				ResetHistorySelection();
+				_contentService?.StartContentHistory();
+			}
+			else
+			{
+				_contentService?.StopContentHistory();
+			}
 			if (_windowStatus is ContentWindowStatus.Normal)
 			{
 				var selection = new List<Object> { };

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_Header.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_Header.cs
@@ -241,7 +241,12 @@ namespace Beamable.Editor.UI.ContentWindow
 			if(_windowStatus == windowStatus)
 				return;
 			
+			var previousWindowStatus = _windowStatus;
 			_windowStatus = windowStatus;
+			if (previousWindowStatus == ContentWindowStatus.History && _windowStatus != ContentWindowStatus.History)
+			{
+				ResetHistorySelection();
+			}
 			if (_windowStatus == ContentWindowStatus.History)
 			{
 				ResetHistorySelection();

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
@@ -1,6 +1,7 @@
 using Beamable.Common.BeamCli.Contracts;
 using Beamable.Editor.BeamCli.Commands;
 using Beamable.Editor.BeamCli.UI.LogHelpers;
+using Beamable.Editor.ContentService;
 using Beamable.Editor.ThirdParty.Splitter;
 using Beamable.Editor.Util;
 using System;
@@ -16,6 +17,8 @@ namespace Beamable.Editor.UI.ContentWindow
 	{
 		private static readonly int[] HistoryPageSizes = { 10, 20, 30, 40, 50 };
 		private const int HistoryChangesPageSize = 25;
+		private const float HistoryEntryRowHeight = 42f;
+		private const float HistoryChangeRowHeight = 22f;
 		private EditorGUISplitView _historySplitter;
 		private SearchData _historySearchData;
 		private Vector2 _historyEntriesScroll;
@@ -27,14 +30,27 @@ namespace Beamable.Editor.UI.ContentWindow
 		private int _historyPageIndex;
 		private int _historyChangesPageIndex;
 		private int _historySelectionRequestVersion;
+		private int _historyPreviewRequestVersion;
+		private int _filteredHistoryVersion = -1;
+		private string _historyFilterKey;
+		private IReadOnlyList<BeamContentHistoryEntry> _filteredHistoryEntries = Array.Empty<BeamContentHistoryEntry>();
 		private bool _isLoadingHistoryChanges;
 		private bool _isLoadingHistoryPreview;
 		private bool _isRestoringHistory;
-		private string _historyRestoreError;
+		private string _historyPreviewContentId;
+		private ContentHistoryOperationException _historyChangesError;
+		private ContentHistoryOperationException _historyPreviewError;
+		private ContentHistoryOperationException _historyRestoreError;
+		private GUIStyle _historyAddedChangeStyle;
+		private GUIStyle _historyModifiedChangeStyle;
+		private GUIStyle _historyRemovedChangeStyle;
+		private GUIStyle _historyDefaultChangeStyle;
+		private GUIStyle _historyRestoreButtonStyle;
 
 		private void DrawContentHistory()
 		{
 			EnsureHistorySearchData();
+			EnsureHistoryStyles();
 			if (IsContentHistoryLoading() || _isRestoringHistory)
 			{
 				Repaint();
@@ -61,7 +77,15 @@ namespace Beamable.Editor.UI.ContentWindow
 				return;
 			}
 
-			_historySearchData = new SearchData { onEndCheck = () => _historyPageIndex = 0 };
+			_historySearchData = new SearchData
+			{
+				onEndCheck = () =>
+				{
+					_historyPageIndex = 0;
+					_historyEntriesScroll = Vector2.zero;
+					_historyFilterKey = null;
+				}
+			};
 		}
 
 		private void DrawHistoryEntries()
@@ -80,21 +104,25 @@ namespace Beamable.Editor.UI.ContentWindow
 			var pageSize = ContentHistoryPagination.ClampPageSize(_contentConfiguration.HistoryEntriesPerPage);
 			var pageCount = ContentHistoryPagination.GetPageCount(filteredEntries.Count, pageSize);
 			_historyPageIndex = ContentHistoryPagination.ClampPageIndex(_historyPageIndex, pageCount);
-			var currentEntries = filteredEntries.Skip(_historyPageIndex * pageSize).Take(pageSize).ToList();
+			var firstEntryIndex = _historyPageIndex * pageSize;
+			var currentEntryCount = Math.Min(pageSize, Math.Max(0, filteredEntries.Count - firstEntryIndex));
 
-			_historyEntriesScroll = EditorGUILayout.BeginScrollView(_historyEntriesScroll, GUILayout.ExpandHeight(true));
-			if (currentEntries.Count == 0)
+			if (_contentService.ContentHistoryWatcherError != null)
 			{
-				EditorGUILayout.HelpBox("No published content history matches this search.", MessageType.Info);
+				DrawHistoryOperationError(_contentService.ContentHistoryWatcherError, RetryContentHistory);
+			}
+
+			if (currentEntryCount == 0)
+			{
+				if (_contentService.ContentHistoryWatcherError == null)
+				{
+					EditorGUILayout.HelpBox("No published content history matches this search.", MessageType.Info);
+				}
 			}
 			else
 			{
-				foreach (var entry in currentEntries)
-				{
-					DrawHistoryEntry(entry);
-				}
+				DrawVirtualHistoryEntries(filteredEntries, firstEntryIndex, currentEntryCount);
 			}
-			EditorGUILayout.EndScrollView();
 
 			DrawHistoryPagination(filteredEntries.Count, pageSize, pageCount);
 			EditorGUILayout.EndVertical();
@@ -121,26 +149,44 @@ namespace Beamable.Editor.UI.ContentWindow
 			EditorGUILayout.EndVertical();
 		}
 
-		private List<BeamContentHistoryEntry> GetFilteredHistoryEntries()
+		private IReadOnlyList<BeamContentHistoryEntry> GetFilteredHistoryEntries()
 		{
 			var search = _historySearchData?.searchText?.Trim();
-			var entries = _contentService.ContentHistoryEntries;
-			if (string.IsNullOrEmpty(search))
+			var historyVersion = _contentService.ContentHistoryVersion;
+			if (_filteredHistoryVersion == historyVersion && string.Equals(_historyFilterKey, search, StringComparison.Ordinal))
 			{
-				return entries.ToList();
+				return _filteredHistoryEntries;
 			}
 
-			return entries.Where(entry =>
-				(entry.ManifestUid?.IndexOf(search, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0 ||
-				(entry.PublishedBy?.IndexOf(search, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0 ||
-				(entry.PublishedByName?.IndexOf(search, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0)
-				.ToList();
+			var entries = _contentService.ContentHistoryEntries;
+			_filteredHistoryEntries = string.IsNullOrEmpty(search)
+				? entries
+				: entries.Where(entry =>
+					(entry.ManifestUid?.IndexOf(search, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0 ||
+					(entry.PublishedBy?.IndexOf(search, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0 ||
+					(entry.PublishedByName?.IndexOf(search, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0)
+					.ToList();
+			_filteredHistoryVersion = historyVersion;
+			_historyFilterKey = search;
+			return _filteredHistoryEntries;
 		}
 
-		private void DrawHistoryEntry(BeamContentHistoryEntry entry)
+		private void DrawVirtualHistoryEntries(IReadOnlyList<BeamContentHistoryEntry> entries, int firstEntryIndex, int entryCount)
 		{
+			var areaRect = GUILayoutUtility.GetRect(GUIContent.none, GUIStyle.none, GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true));
+			var contentRect = new Rect(0, 0, Math.Max(0, areaRect.width - 16), entryCount * HistoryEntryRowHeight);
+			_historyEntriesScroll = GUI.BeginScrollView(areaRect, _historyEntriesScroll, contentRect, false, true);
+			var visibleRange = ContentHistoryPagination.GetVisibleRange(entryCount, _historyEntriesScroll.y, areaRect.height, HistoryEntryRowHeight);
+			for (var index = visibleRange.FirstIndex; index < visibleRange.LastExclusive; index++)
+			{
+				DrawHistoryEntry(entries[firstEntryIndex + index], new Rect(0, index * HistoryEntryRowHeight, contentRect.width, HistoryEntryRowHeight));
+			}
+			GUI.EndScrollView();
+		}
+
+		private void DrawHistoryEntry(BeamContentHistoryEntry entry, Rect rowRect)
+			{
 			var isSelected = entry.ManifestUid == _selectedHistoryManifestUid;
-			var rowRect = EditorGUILayout.GetControlRect(false, 42);
 			if (isSelected)
 			{
 				GUI.Box(rowRect, GUIContent.none, EditorStyles.selectionRect);
@@ -219,6 +265,10 @@ namespace Beamable.Editor.UI.ContentWindow
 			{
 				EditorGUILayout.HelpBox("Loading historical content changes...", MessageType.Info);
 			}
+			else if (_historyChangesError != null)
+			{
+				DrawHistoryOperationError(_historyChangesError, RetryHistoryChanges);
+			}
 			else
 			{
 				DrawHistoryChangesTable();
@@ -231,7 +281,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		private void DrawHistoryChangesTable()
 		{
 			EditorGUILayout.BeginHorizontal(EditorStyles.toolbar);
-			EditorGUILayout.LabelField("Change", GUILayout.Width(88));
+			EditorGUILayout.LabelField("Change", GUILayout.Width(110));
 			EditorGUILayout.LabelField("Content", GUILayout.ExpandWidth(true));
 			EditorGUILayout.LabelField("Type", GUILayout.Width(110));
 			EditorGUILayout.LabelField("Preview", GUILayout.Width(55));
@@ -239,27 +289,25 @@ namespace Beamable.Editor.UI.ContentWindow
 
 			var pageCount = ContentHistoryPagination.GetPageCount(_selectedHistoryChanges.Length, HistoryChangesPageSize);
 			_historyChangesPageIndex = ContentHistoryPagination.ClampPageIndex(_historyChangesPageIndex, pageCount);
-			var currentChanges = _selectedHistoryChanges
-				.Skip(_historyChangesPageIndex * HistoryChangesPageSize)
-				.Take(HistoryChangesPageSize);
+			var firstChangeIndex = _historyChangesPageIndex * HistoryChangesPageSize;
+			var currentChangeCount = Math.Min(HistoryChangesPageSize, Math.Max(0, _selectedHistoryChanges.Length - firstChangeIndex));
 
 			using (new EditorGUI.DisabledScope(IsHistoryRightPaneLocked()))
 			{
-				_historyChangesScroll = EditorGUILayout.BeginScrollView(_historyChangesScroll, GUILayout.ExpandHeight(true));
-				foreach (var entry in currentChanges)
+				if (currentChangeCount == 0)
 				{
-					EditorGUILayout.BeginHorizontal(EditorStyles.helpBox);
-					DrawHistoryChangeStatus(entry.ChangeStatus);
-					EditorGUILayout.LabelField(entry.FullId, GUILayout.ExpandWidth(true));
-					EditorGUILayout.LabelField(entry.TypeName, GUILayout.Width(110));
-					using (new EditorGUI.DisabledScope(_isLoadingHistoryPreview || string.IsNullOrEmpty(entry.JsonFilePath)))
-					{
-						if (GUILayout.Button("View", GUILayout.Width(55))) _ = LoadHistoryPreview(entry.FullId);
-					}
-					EditorGUILayout.EndHorizontal();
+					EditorGUILayout.HelpBox("This publish has no changed content items.", MessageType.Info);
 				}
-				EditorGUILayout.EndScrollView();
+				else
+				{
+					DrawVirtualHistoryChanges(firstChangeIndex, currentChangeCount);
+				}
 				DrawHistoryChangesPagination(_selectedHistoryChanges.Length, pageCount);
+			}
+
+			if (_historyPreviewError != null)
+			{
+				DrawHistoryOperationError(_historyPreviewError, RetryHistoryPreview);
 			}
 
 			if (!string.IsNullOrEmpty(_selectedHistoryJson))
@@ -268,6 +316,36 @@ namespace Beamable.Editor.UI.ContentWindow
 				_historyPreviewScroll = EditorGUILayout.BeginScrollView(_historyPreviewScroll, GUILayout.Height(120));
 				EditorGUILayout.TextArea(_selectedHistoryJson, GUILayout.ExpandHeight(true));
 				EditorGUILayout.EndScrollView();
+			}
+		}
+
+		private void DrawVirtualHistoryChanges(int firstChangeIndex, int changeCount)
+		{
+			var areaRect = GUILayoutUtility.GetRect(GUIContent.none, GUIStyle.none, GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true));
+			var contentRect = new Rect(0, 0, Math.Max(0, areaRect.width - 16), changeCount * HistoryChangeRowHeight);
+			_historyChangesScroll = GUI.BeginScrollView(areaRect, _historyChangesScroll, contentRect, false, true);
+			var visibleRange = ContentHistoryPagination.GetVisibleRange(changeCount, _historyChangesScroll.y, areaRect.height, HistoryChangeRowHeight);
+			for (var index = visibleRange.FirstIndex; index < visibleRange.LastExclusive; index++)
+			{
+				DrawHistoryChange(_selectedHistoryChanges[firstChangeIndex + index],
+					new Rect(0, index * HistoryChangeRowHeight, contentRect.width, HistoryChangeRowHeight));
+			}
+			GUI.EndScrollView();
+		}
+
+		private void DrawHistoryChange(BeamContentHistoryChangelistEntry entry, Rect rowRect)
+		{
+			GUI.Box(rowRect, GUIContent.none, EditorStyles.helpBox);
+			var statusRect = new Rect(rowRect.x, rowRect.y, 110, rowRect.height);
+			var previewRect = new Rect(rowRect.xMax - 55, rowRect.y + 1, 55, rowRect.height - 2);
+			var typeRect = new Rect(previewRect.x - 110, rowRect.y, 110, rowRect.height);
+			var contentRect = new Rect(statusRect.xMax, rowRect.y, Math.Max(0, typeRect.x - statusRect.xMax), rowRect.height);
+			DrawHistoryChangeStatus(entry.ChangeStatus, statusRect);
+			GUI.Label(contentRect, entry.FullId);
+			GUI.Label(typeRect, entry.TypeName);
+			using (new EditorGUI.DisabledScope(_isLoadingHistoryPreview || string.IsNullOrEmpty(entry.JsonFilePath)))
+			{
+				if (GUI.Button(previewRect, "View")) _ = LoadHistoryPreview(entry.FullId);
 			}
 		}
 
@@ -295,22 +373,19 @@ namespace Beamable.Editor.UI.ContentWindow
 			EditorGUILayout.EndHorizontal();
 		}
 
-		private static void DrawHistoryChangeStatus(int changeStatus)
+		private void DrawHistoryChangeStatus(int changeStatus, Rect rect)
 		{
-			var (label, icon, color) = ((ContentStatus)changeStatus) switch
+			var (label, icon, style) = ((ContentStatus)changeStatus) switch
 			{
-				ContentStatus.Created => ("Added", BeamGUI.iconStatusAdded, new Color(.45f, .8f, .3f)),
-				ContentStatus.Modified => ("Modified", BeamGUI.iconStatusModified, new Color(1f, .65f, .15f)),
-				ContentStatus.Deleted => ("Removed", BeamGUI.iconStatusDeleted, new Color(1f, .35f, .3f)),
-				_ => ("Changed", BeamGUI.iconStatusModified, EditorStyles.label.normal.textColor)
+				ContentStatus.Created => ("Added", BeamGUI.iconStatusAdded, _historyAddedChangeStyle),
+				ContentStatus.Modified => ("Modified", BeamGUI.iconStatusModified, _historyModifiedChangeStyle),
+				ContentStatus.Deleted => ("Removed", BeamGUI.iconStatusDeleted, _historyRemovedChangeStyle),
+				_ => ("Changed", BeamGUI.iconStatusModified, _historyDefaultChangeStyle)
 			};
 
-			var rect = GUILayoutUtility.GetRect(110, EditorGUIUtility.singleLineHeight, GUILayout.Width(110));
 			var iconRect = new Rect(rect.x + 2, rect.y + 1, 16, 16);
 			GUI.DrawTexture(iconRect, icon, ScaleMode.ScaleToFit);
-			var labelStyle = new GUIStyle(EditorStyles.label);
-			labelStyle.normal.textColor = color;
-			GUI.Label(new Rect(iconRect.xMax + 5, rect.y, rect.width - 23, rect.height), label, labelStyle);
+			GUI.Label(new Rect(iconRect.xMax + 5, rect.y, rect.width - 23, rect.height), label, style);
 		}
 
 		private void DrawHistoryActions()
@@ -331,14 +406,13 @@ namespace Beamable.Editor.UI.ContentWindow
 			}
 			EditorGUILayout.EndHorizontal();
 			EditorGUILayout.LabelField("Restores local files only — review and publish to update the realm.", EditorStyles.miniLabel);
-			if (!string.IsNullOrEmpty(_historyRestoreError))
+			if (_historyRestoreError != null)
 			{
-				EditorGUILayout.HelpBox(_historyRestoreError, MessageType.Error);
-				if (GUILayout.Button("Dismiss error")) _historyRestoreError = string.Empty;
+				DrawHistoryOperationError(_historyRestoreError, RestoreSelectedHistory, () => _historyRestoreError = null);
 			}
 		}
 
-		private static bool DrawHistoryRestoreButton(bool isEnabled)
+		private bool DrawHistoryRestoreButton(bool isEnabled)
 		{
 			var content = new GUIContent("Restore changed files...");
 			var rect = GUILayoutUtility.GetRect(content, GUI.skin.button, GUILayout.Width(172));
@@ -353,12 +427,68 @@ namespace Beamable.Editor.UI.ContentWindow
 				EditorGUI.DrawRect(new Rect(rect.x, rect.y, rect.width, 1), new Color(1f, 1f, 1f, .45f));
 			}
 			if (isEnabled) EditorGUIUtility.AddCursorRect(rect, MouseCursor.Link);
-			GUI.Label(rect, content, new GUIStyle(EditorStyles.label)
+			GUI.Label(rect, content, _historyRestoreButtonStyle);
+			return isEnabled && GUI.Button(rect, GUIContent.none, GUIStyle.none);
+		}
+
+		private void DrawHistoryOperationError(ContentHistoryOperationException error, Action retry, Action dismiss = null)
+		{
+			EditorGUILayout.HelpBox(error.UserMessage, MessageType.Error);
+			EditorGUILayout.BeginHorizontal();
+			if (GUILayout.Button("Retry")) retry?.Invoke();
+			if (GUILayout.Button("Copy details")) EditorGUIUtility.systemCopyBuffer = error.Diagnostic;
+			if (dismiss != null && GUILayout.Button("Dismiss")) dismiss();
+			EditorGUILayout.EndHorizontal();
+		}
+
+		private void RetryContentHistory()
+		{
+			_contentService.RestartContentHistory();
+			Repaint();
+		}
+
+		private void RetryHistoryChanges()
+		{
+			if (string.IsNullOrEmpty(_selectedHistoryManifestUid))
+			{
+				return;
+			}
+
+			var requestVersion = ++_historySelectionRequestVersion;
+			_ = LoadHistoryChanges(_selectedHistoryManifestUid, requestVersion);
+		}
+
+		private void RetryHistoryPreview()
+		{
+			if (!string.IsNullOrEmpty(_historyPreviewContentId))
+			{
+				_ = LoadHistoryPreview(_historyPreviewContentId);
+			}
+		}
+
+		private void EnsureHistoryStyles()
+		{
+			if (_historyAddedChangeStyle != null)
+			{
+				return;
+			}
+
+			_historyAddedChangeStyle = CreateHistoryChangeStyle(new Color(.45f, .8f, .3f));
+			_historyModifiedChangeStyle = CreateHistoryChangeStyle(new Color(1f, .65f, .15f));
+			_historyRemovedChangeStyle = CreateHistoryChangeStyle(new Color(1f, .35f, .3f));
+			_historyDefaultChangeStyle = new GUIStyle(EditorStyles.label);
+			_historyRestoreButtonStyle = new GUIStyle(EditorStyles.label)
 			{
 				alignment = TextAnchor.MiddleCenter,
 				normal = { textColor = Color.white }
-			});
-			return isEnabled && GUI.Button(rect, GUIContent.none, GUIStyle.none);
+			};
+		}
+
+		private static GUIStyle CreateHistoryChangeStyle(Color color)
+		{
+			var style = new GUIStyle(EditorStyles.label);
+			style.normal.textColor = color;
+			return style;
 		}
 
 		private static void DrawHistoryRestoreProgress()
@@ -380,6 +510,12 @@ namespace Beamable.Editor.UI.ContentWindow
 			_selectedHistoryChanges = Array.Empty<BeamContentHistoryChangelistEntry>();
 			_selectedHistoryJson = string.Empty;
 			_historyChangesPageIndex = 0;
+			_historyChangesError = null;
+			_historyPreviewError = null;
+			_historyPreviewContentId = string.Empty;
+			_historyPreviewRequestVersion++;
+			_isLoadingHistoryPreview = false;
+			_historyPreviewScroll = Vector2.zero;
 			var requestVersion = ++_historySelectionRequestVersion;
 			_ = LoadHistoryChanges(manifestUid, requestVersion);
 		}
@@ -387,6 +523,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		private void ResetHistorySelection()
 		{
 			_historySelectionRequestVersion++;
+			_historyPreviewRequestVersion++;
 			_selectedHistoryManifestUid = string.Empty;
 			_selectedHistoryChanges = Array.Empty<BeamContentHistoryChangelistEntry>();
 			_selectedHistoryJson = string.Empty;
@@ -396,12 +533,16 @@ namespace Beamable.Editor.UI.ContentWindow
 			_isLoadingHistoryChanges = false;
 			_isLoadingHistoryPreview = false;
 			_isRestoringHistory = false;
-			_historyRestoreError = string.Empty;
+			_historyPreviewContentId = string.Empty;
+			_historyChangesError = null;
+			_historyPreviewError = null;
+			_historyRestoreError = null;
 		}
 
 		private async Task LoadHistoryChanges(string manifestUid, int requestVersion)
 		{
 			_isLoadingHistoryChanges = true;
+			_historyChangesError = null;
 			Repaint();
 			try
 			{
@@ -409,6 +550,18 @@ namespace Beamable.Editor.UI.ContentWindow
 				if (requestVersion == _historySelectionRequestVersion)
 				{
 					_selectedHistoryChanges = changes;
+				}
+			}
+			catch (Exception exception)
+			{
+				if (requestVersion == _historySelectionRequestVersion)
+				{
+					_historyChangesError = ContentHistoryOperationException.FromException(
+						"Load publish changes",
+						"Unable to load changes for this publish. Check your connection and try again.",
+						manifestUid,
+						exception);
+					Debug.LogError(_historyChangesError.Diagnostic);
 				}
 			}
 			finally
@@ -423,15 +576,39 @@ namespace Beamable.Editor.UI.ContentWindow
 
 		private async Task LoadHistoryPreview(string contentId)
 		{
+			var manifestUid = _selectedHistoryManifestUid;
+			var selectionRequestVersion = _historySelectionRequestVersion;
+			var previewRequestVersion = ++_historyPreviewRequestVersion;
 			_isLoadingHistoryPreview = true;
+			_historyPreviewError = null;
+			_historyPreviewContentId = contentId;
 			Repaint();
 			try
 			{
-				_selectedHistoryJson = await _contentService.GetContentHistoryJson(_selectedHistoryManifestUid, contentId);
+				var historyJson = await _contentService.GetContentHistoryJson(manifestUid, contentId);
+				if (selectionRequestVersion == _historySelectionRequestVersion && previewRequestVersion == _historyPreviewRequestVersion)
+				{
+					_selectedHistoryJson = historyJson;
+				}
+			}
+			catch (Exception exception)
+			{
+				if (selectionRequestVersion == _historySelectionRequestVersion && previewRequestVersion == _historyPreviewRequestVersion)
+				{
+					_historyPreviewError = ContentHistoryOperationException.FromException(
+						"Preview historical content",
+						"Unable to load this historical content file. Check your connection and try again.",
+						manifestUid,
+						exception);
+					Debug.LogError(_historyPreviewError.Diagnostic);
+				}
 			}
 			finally
 			{
-				_isLoadingHistoryPreview = false;
+				if (previewRequestVersion == _historyPreviewRequestVersion)
+				{
+					_isLoadingHistoryPreview = false;
+				}
 				Repaint();
 			}
 		}
@@ -456,7 +633,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		private async Task RestoreSelectedHistoryAsync()
 		{
 			_isRestoringHistory = true;
-			_historyRestoreError = string.Empty;
+			_historyRestoreError = null;
 			Repaint();
 			try
 			{
@@ -465,8 +642,12 @@ namespace Beamable.Editor.UI.ContentWindow
 			}
 			catch (Exception exception)
 			{
-				Debug.LogException(exception);
-				_historyRestoreError = $"Restore failed. Check your connection and try again. {exception.Message}";
+				_historyRestoreError = ContentHistoryOperationException.FromException(
+					"Restore changed files",
+					"Unable to restore changed files. Check your connection and try again.",
+					_selectedHistoryManifestUid,
+					exception);
+				Debug.LogError(_historyRestoreError.Diagnostic);
 			}
 			finally
 			{
@@ -475,15 +656,5 @@ namespace Beamable.Editor.UI.ContentWindow
 			}
 		}
 
-		private static string GetChangeLabel(int changeStatus)
-		{
-			return ((ContentStatus)changeStatus) switch
-			{
-				ContentStatus.Created => "Added",
-				ContentStatus.Modified => "Modified",
-				ContentStatus.Deleted => "Removed",
-				_ => "Changed"
-			};
-		}
 	}
 }

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
@@ -27,6 +27,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		private const float HistoryTimeColumnWidth = 74f;
 		private const float HistoryChangesColumnWidth = 82f;
 		private const float HistoryAuthorColumnWidth = 112f;
+		private const float HistoryManifestCopyButtonWidth = 20f;
 		private static readonly Color HistoryEntryColor = new(.18f, .18f, .18f, 1f);
 		private static readonly Color HistoryEntryHoverColor = new(.25f, .28f, .31f, 1f);
 		private static readonly Color HistoryExpandedBucketColor = new(.20f, .21f, .23f, 1f);
@@ -35,6 +36,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		private static readonly Color HistoryCollapsedBucketHoverColor = new(.20f, .23f, .27f, 1f);
 		private EditorGUISplitView _historySplitter;
 		private SearchData _historySearchData;
+		private SearchData _historyChangesSearchData;
 		private Vector2 _historyEntriesScroll;
 		private Vector2 _historyChangesScroll;
 		private Vector2 _historyPreviewScroll;
@@ -43,6 +45,9 @@ namespace Beamable.Editor.UI.ContentWindow
 		private string _selectedHistoryJson = string.Empty;
 		private int _historyPageIndex;
 		private int _historyChangesPageIndex;
+		private string _historyChangesFilterKey;
+		private IReadOnlyList<BeamContentHistoryChangelistEntry> _historyChangesFilterSource;
+		private IReadOnlyList<BeamContentHistoryChangelistEntry> _filteredHistoryChanges = Array.Empty<BeamContentHistoryChangelistEntry>();
 		private int _historySelectionRequestVersion;
 		private int _historyPreviewRequestVersion;
 		private int _filteredHistoryVersion = -1;
@@ -74,6 +79,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		private GUIStyle _historyRestoreButtonStyle;
 		private GUIStyle _historyEllipsisLabelStyle;
 		private readonly GUIContent _historyEllipsisMeasureContent = new();
+		private static readonly GUIContent HistoryCopyManifestContent = new(EditorGUIUtility.FindTexture("Clipboard"), "Copy manifest ID");
 
 		private void DrawContentHistory()
 		{
@@ -114,6 +120,24 @@ namespace Beamable.Editor.UI.ContentWindow
 					_historyFilterKey = null;
 					_historyBucketAutoExpandKey = null;
 					_historyDisplayRowsDirty = true;
+				}
+			};
+		}
+
+		private void EnsureHistoryChangesSearchData()
+		{
+			if (_historyChangesSearchData != null)
+			{
+				return;
+			}
+
+			_historyChangesSearchData = new SearchData
+			{
+				onEndCheck = () =>
+				{
+					_historyChangesPageIndex = 0;
+					_historyChangesScroll = Vector2.zero;
+					_historyChangesFilterKey = null;
 				}
 			};
 		}
@@ -404,11 +428,18 @@ namespace Beamable.Editor.UI.ContentWindow
 			var timeRect = new Rect(rowRect.x + 6, rowRect.y + 3, HistoryTimeColumnWidth - 6, EditorGUIUtility.singleLineHeight);
 			var changesRect = new Rect(timeRect.xMax, rowRect.y + 3, HistoryChangesColumnWidth, EditorGUIUtility.singleLineHeight);
 			var authorRect = new Rect(rowRect.xMax - HistoryAuthorColumnWidth, rowRect.y + 3, HistoryAuthorColumnWidth - 6, EditorGUIUtility.singleLineHeight);
-			var manifestRect = new Rect(changesRect.xMax, rowRect.y + 3, Math.Max(0, authorRect.x - changesRect.xMax), EditorGUIUtility.singleLineHeight);
+			var copyManifestRect = new Rect(authorRect.x - HistoryManifestCopyButtonWidth, rowRect.y + 2,
+				HistoryManifestCopyButtonWidth, EditorGUIUtility.singleLineHeight + 2);
+			var manifestRect = new Rect(changesRect.xMax, rowRect.y + 3,
+				Math.Max(0, copyManifestRect.x - changesRect.xMax), EditorGUIUtility.singleLineHeight);
 
 			using (new EditorGUI.DisabledScope(_isRestoringHistory))
 			{
-				if (GUI.Button(rowRect, GUIContent.none, GUIStyle.none))
+				var selectLeftRect = new Rect(rowRect.x, rowRect.y, Math.Max(0, copyManifestRect.x - rowRect.x), rowRect.height);
+				var selectRightRect = new Rect(copyManifestRect.xMax, rowRect.y,
+					Math.Max(0, rowRect.xMax - copyManifestRect.xMax), rowRect.height);
+				if ((selectLeftRect.width > 0 && GUI.Button(selectLeftRect, GUIContent.none, GUIStyle.none)) ||
+					(selectRightRect.width > 0 && GUI.Button(selectRightRect, GUIContent.none, GUIStyle.none)))
 				{
 					SelectHistoryEntry(entry.ManifestUid);
 				}
@@ -418,6 +449,10 @@ namespace Beamable.Editor.UI.ContentWindow
 			GUI.Label(changesRect, $"{entry.AffectedContentIds?.Length ?? 0} changed", EditorStyles.miniLabel);
 			DrawHistoryTruncatedLabel(manifestRect, entry.ManifestUid);
 			DrawHistoryTruncatedLabel(authorRect, string.IsNullOrEmpty(entry.PublishedByName) ? entry.PublishedBy : entry.PublishedByName);
+			if (GUI.Button(copyManifestRect, HistoryCopyManifestContent, EditorStyles.iconButton))
+			{
+				EditorGUIUtility.systemCopyBuffer = entry.ManifestUid;
+			}
 		}
 
 		private void DrawHistoryPagination(int entryCount, int pageSize, int pageCount)
@@ -481,6 +516,8 @@ namespace Beamable.Editor.UI.ContentWindow
 			}
 
 			EditorGUILayout.LabelField($"Manifest UID: {_selectedHistoryManifestUid}", EditorStyles.miniLabel);
+			EnsureHistoryChangesSearchData();
+			this.DrawSearchBar(_historyChangesSearchData);
 			if (_isLoadingHistoryChanges)
 			{
 				EditorGUILayout.HelpBox("Loading historical content changes...", MessageType.Info);
@@ -500,6 +537,7 @@ namespace Beamable.Editor.UI.ContentWindow
 
 		private void DrawHistoryChangesTable()
 		{
+			var filteredChanges = GetFilteredHistoryChanges();
 			EditorGUILayout.BeginHorizontal(EditorStyles.toolbar);
 			EditorGUILayout.LabelField("Change", GUILayout.Width(110));
 			EditorGUILayout.LabelField("Content", GUILayout.ExpandWidth(true));
@@ -507,22 +545,24 @@ namespace Beamable.Editor.UI.ContentWindow
 			EditorGUILayout.LabelField("Preview", GUILayout.Width(55));
 			EditorGUILayout.EndHorizontal();
 
-			var pageCount = ContentHistoryPagination.GetPageCount(_selectedHistoryChanges.Length, HistoryChangesPageSize);
+			var pageCount = ContentHistoryPagination.GetPageCount(filteredChanges.Count, HistoryChangesPageSize);
 			_historyChangesPageIndex = ContentHistoryPagination.ClampPageIndex(_historyChangesPageIndex, pageCount);
 			var firstChangeIndex = _historyChangesPageIndex * HistoryChangesPageSize;
-			var currentChangeCount = Math.Min(HistoryChangesPageSize, Math.Max(0, _selectedHistoryChanges.Length - firstChangeIndex));
+			var currentChangeCount = Math.Min(HistoryChangesPageSize, Math.Max(0, filteredChanges.Count - firstChangeIndex));
 
 			using (new EditorGUI.DisabledScope(IsHistoryRightPaneLocked()))
 			{
 				if (currentChangeCount == 0)
 				{
-					EditorGUILayout.HelpBox("This publish has no changed content items.", MessageType.Info);
+					EditorGUILayout.HelpBox(HasHistoryChangesSearch()
+						? "No changed content items match this search."
+						: "This publish has no changed content items.", MessageType.Info);
 				}
 				else
 				{
-					DrawVirtualHistoryChanges(firstChangeIndex, currentChangeCount);
+					DrawVirtualHistoryChanges(filteredChanges, firstChangeIndex, currentChangeCount);
 				}
-				DrawHistoryChangesPagination(_selectedHistoryChanges.Length, pageCount);
+				DrawHistoryChangesPagination(filteredChanges.Count, pageCount);
 			}
 
 			if (_historyPreviewError != null)
@@ -557,7 +597,41 @@ namespace Beamable.Editor.UI.ContentWindow
 			GUI.Label(rect, new GUIContent(string.Empty, value), GUIStyle.none);
 		}
 
-		private void DrawVirtualHistoryChanges(int firstChangeIndex, int changeCount)
+		private IReadOnlyList<BeamContentHistoryChangelistEntry> GetFilteredHistoryChanges()
+		{
+			var search = _historyChangesSearchData?.searchText?.Trim();
+			if (ReferenceEquals(_historyChangesFilterSource, _selectedHistoryChanges) &&
+				string.Equals(_historyChangesFilterKey, search, StringComparison.Ordinal))
+			{
+				return _filteredHistoryChanges;
+			}
+
+			_historyChangesFilterSource = _selectedHistoryChanges;
+			_historyChangesFilterKey = search;
+			_filteredHistoryChanges = ContentHistoryChangesSearch.Filter(_selectedHistoryChanges, search);
+			return _filteredHistoryChanges;
+		}
+
+		private bool HasHistoryChangesSearch()
+		{
+			return !string.IsNullOrWhiteSpace(_historyChangesSearchData?.searchText);
+		}
+
+		private void ClearHistoryChangesSearch()
+		{
+			if (_historyChangesSearchData != null)
+			{
+				_historyChangesSearchData.searchText = null;
+			}
+			_historyChangesPageIndex = 0;
+			_historyChangesScroll = Vector2.zero;
+			_historyChangesFilterKey = null;
+			_historyChangesFilterSource = null;
+			_filteredHistoryChanges = Array.Empty<BeamContentHistoryChangelistEntry>();
+		}
+
+		private void DrawVirtualHistoryChanges(IReadOnlyList<BeamContentHistoryChangelistEntry> changes, int firstChangeIndex,
+			int changeCount)
 		{
 			var areaRect = GUILayoutUtility.GetRect(GUIContent.none, GUIStyle.none, GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true));
 			var contentRect = new Rect(0, 0, Math.Max(0, areaRect.width - 16), changeCount * HistoryChangeRowHeight);
@@ -565,7 +639,7 @@ namespace Beamable.Editor.UI.ContentWindow
 			var visibleRange = ContentHistoryPagination.GetVisibleRange(changeCount, _historyChangesScroll.y, areaRect.height, HistoryChangeRowHeight);
 			for (var index = visibleRange.FirstIndex; index < visibleRange.LastExclusive; index++)
 			{
-				DrawHistoryChange(_selectedHistoryChanges[firstChangeIndex + index],
+				DrawHistoryChange(changes[firstChangeIndex + index],
 					new Rect(0, index * HistoryChangeRowHeight, contentRect.width, HistoryChangeRowHeight));
 			}
 			GUI.EndScrollView();
@@ -581,7 +655,7 @@ namespace Beamable.Editor.UI.ContentWindow
 			DrawHistoryChangeStatus(entry.ChangeStatus, statusRect);
 			GUI.Label(contentRect, entry.FullId);
 			GUI.Label(typeRect, entry.TypeName);
-			using (new EditorGUI.DisabledScope(_isLoadingHistoryPreview || string.IsNullOrEmpty(entry.JsonFilePath)))
+			using (new EditorGUI.DisabledScope(_isLoadingHistoryPreview || string.IsNullOrEmpty(entry.FullId)))
 			{
 				if (GUI.Button(previewRect, "View")) _ = LoadHistoryPreview(entry.FullId, entry.TypeName);
 			}
@@ -749,7 +823,9 @@ namespace Beamable.Editor.UI.ContentWindow
 			}
 
 			_selectedHistoryManifestUid = manifestUid;
+			_contentService.CancelContentHistoryRequests();
 			ClearHistoryInspectorPreview();
+			ClearHistoryChangesSearch();
 			_selectedHistoryChanges = Array.Empty<BeamContentHistoryChangelistEntry>();
 			_selectedHistoryJson = string.Empty;
 			_historyChangesPageIndex = 0;
@@ -767,7 +843,9 @@ namespace Beamable.Editor.UI.ContentWindow
 
 		private void ResetHistorySelection()
 		{
+			_contentService?.CancelContentHistoryRequests();
 			ClearHistoryInspectorPreview();
+			ClearHistoryChangesSearch();
 			_historySelectionRequestVersion++;
 			_historyPreviewRequestVersion++;
 			_selectedHistoryManifestUid = string.Empty;
@@ -984,6 +1062,33 @@ namespace Beamable.Editor.UI.ContentWindow
 		public static bool ShouldRepaint(string currentHoveredRowKey, string nextHoveredRowKey)
 		{
 			return !string.Equals(currentHoveredRowKey, nextHoveredRowKey, StringComparison.Ordinal);
+		}
+	}
+
+	internal static class ContentHistoryChangesSearch
+	{
+		public static IReadOnlyList<BeamContentHistoryChangelistEntry> Filter(
+			IReadOnlyList<BeamContentHistoryChangelistEntry> changes, string search)
+		{
+			if (changes == null || changes.Count == 0)
+			{
+				return Array.Empty<BeamContentHistoryChangelistEntry>();
+			}
+
+			var normalizedSearch = search?.Trim();
+			if (string.IsNullOrEmpty(normalizedSearch))
+			{
+				return changes;
+			}
+
+			return changes.Where(change => change != null &&
+				(Matches(change.FullId, normalizedSearch) || Matches(change.Name, normalizedSearch) ||
+				 Matches(change.TypeName, normalizedSearch))).ToArray();
+		}
+
+		private static bool Matches(string value, string search)
+		{
+			return !string.IsNullOrEmpty(value) && value.IndexOf(search, StringComparison.OrdinalIgnoreCase) >= 0;
 		}
 	}
 

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
@@ -55,6 +55,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		private string _historyFilterKey;
 		private IReadOnlyList<BeamContentHistoryEntry> _filteredHistoryEntries = Array.Empty<BeamContentHistoryEntry>();
 		private bool _hasFilteredHistoryEntries;
+		private bool _showHistoryNoExactIdHint;
 		private IReadOnlyList<ContentHistoryTimeBucket> _historyBuckets = Array.Empty<ContentHistoryTimeBucket>();
 		private bool _hasHistoryBuckets;
 		private readonly HashSet<string> _expandedHistoryBucketKeys = new();
@@ -132,6 +133,7 @@ namespace Beamable.Editor.UI.ContentWindow
 					_historyEntriesScroll = Vector2.zero;
 					_hasFilteredHistoryEntries = false;
 					_hasHistoryBuckets = false;
+					_showHistoryNoExactIdHint = false;
 					_historyBucketAutoExpandKey = null;
 					_historyDisplayRowsDirty = true;
 				}
@@ -169,6 +171,10 @@ namespace Beamable.Editor.UI.ContentWindow
 			}
 
 			var filteredEntries = GetFilteredHistoryEntries();
+			if (_showHistoryNoExactIdHint)
+			{
+				EditorGUILayout.HelpBox("No Manifest ID or Content Id found.", MessageType.Info);
+			}
 			var historyBuckets = GetHistoryBuckets(filteredEntries);
 			AutoExpandHistoryBucketsForSearch(historyBuckets, _historySearchData?.searchText?.Trim());
 
@@ -241,14 +247,9 @@ namespace Beamable.Editor.UI.ContentWindow
 				return _filteredHistoryEntries;
 			}
 
-			var entries = _contentService.ContentHistoryEntries;
-			_filteredHistoryEntries = string.IsNullOrEmpty(search)
-				? entries
-				: entries.Where(entry =>
-					(entry.ManifestUid?.IndexOf(search, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0 ||
-					(entry.PublishedBy?.IndexOf(search, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0 ||
-					(entry.PublishedByName?.IndexOf(search, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0)
-					.ToList();
+			var searchResult = ContentHistoryPublishSearch.Filter(_contentService.ContentHistoryEntries, search);
+			_filteredHistoryEntries = searchResult.Entries;
+			_showHistoryNoExactIdHint = searchResult.ShowNoExactIdHint;
 			_filteredHistoryVersion = historyVersion;
 			_historyFilterKey = search;
 			_hasFilteredHistoryEntries = true;
@@ -895,6 +896,10 @@ namespace Beamable.Editor.UI.ContentWindow
 			_historyPreviewError = null;
 			_historyPreviewRenderError = null;
 			_historyRestoreError = null;
+			_showHistoryNoExactIdHint = false;
+			_hasFilteredHistoryEntries = false;
+			_hasHistoryBuckets = false;
+			_historyDisplayRowsDirty = true;
 		}
 
 		private async Task LoadHistoryChanges(string manifestUid, int requestVersion)
@@ -1121,6 +1126,54 @@ namespace Beamable.Editor.UI.ContentWindow
 		private static bool Matches(string value, string search)
 		{
 			return !string.IsNullOrEmpty(value) && value.IndexOf(search, StringComparison.OrdinalIgnoreCase) >= 0;
+		}
+	}
+
+	internal readonly struct ContentHistoryPublishSearchResult
+	{
+		public IReadOnlyList<BeamContentHistoryEntry> Entries { get; }
+		public bool ShowNoExactIdHint { get; }
+
+		public ContentHistoryPublishSearchResult(IReadOnlyList<BeamContentHistoryEntry> entries, bool showNoExactIdHint)
+		{
+			Entries = entries;
+			ShowNoExactIdHint = showNoExactIdHint;
+		}
+	}
+
+	internal static class ContentHistoryPublishSearch
+	{
+		public static ContentHistoryPublishSearchResult Filter(IReadOnlyList<BeamContentHistoryEntry> entries, string search)
+		{
+			var normalizedSearch = search?.Trim();
+			if (string.IsNullOrEmpty(normalizedSearch))
+			{
+				return new ContentHistoryPublishSearchResult(entries ?? Array.Empty<BeamContentHistoryEntry>(), false);
+			}
+
+			var sourceEntries = entries ?? Array.Empty<BeamContentHistoryEntry>();
+			var exactContentIdMatches = sourceEntries.Where(entry => entry?.AffectedContentIds?.Any(contentId =>
+				string.Equals(contentId, normalizedSearch, StringComparison.OrdinalIgnoreCase)) == true).ToArray();
+			if (exactContentIdMatches.Length > 0)
+			{
+				return new ContentHistoryPublishSearchResult(exactContentIdMatches, false);
+			}
+
+			var normalMatches = sourceEntries.Where(entry => entry != null &&
+				(Matches(entry.ManifestUid, normalizedSearch) ||
+				 Matches(entry.PublishedBy, normalizedSearch) ||
+				 Matches(entry.PublishedByName, normalizedSearch))).ToArray();
+			return new ContentHistoryPublishSearchResult(normalMatches, IsContentIdShaped(normalizedSearch));
+		}
+
+		private static bool Matches(string value, string search)
+		{
+			return !string.IsNullOrEmpty(value) && value.IndexOf(search, StringComparison.OrdinalIgnoreCase) >= 0;
+		}
+
+		private static bool IsContentIdShaped(string search)
+		{
+			return search.IndexOf('.') >= 0 && search.IndexOf('@') < 0 && !search.Any(char.IsWhiteSpace);
 		}
 	}
 

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
@@ -17,8 +17,17 @@ namespace Beamable.Editor.UI.ContentWindow
 	{
 		private static readonly int[] HistoryPageSizes = { 10, 20, 30, 40, 50 };
 		private const int HistoryChangesPageSize = 25;
-		private const float HistoryEntryRowHeight = 42f;
+		private const float HistoryEntryRowHeight = 24f;
 		private const float HistoryChangeRowHeight = 22f;
+		private const float HistoryTimeColumnWidth = 74f;
+		private const float HistoryChangesColumnWidth = 82f;
+		private const float HistoryAuthorColumnWidth = 112f;
+		private static readonly Color HistoryEntryColor = new(.18f, .18f, .18f, 1f);
+		private static readonly Color HistoryEntryHoverColor = new(.25f, .28f, .31f, 1f);
+		private static readonly Color HistoryExpandedBucketColor = new(.20f, .21f, .23f, 1f);
+		private static readonly Color HistoryCollapsedBucketColor = new(.12f, .13f, .15f, 1f);
+		private static readonly Color HistoryExpandedBucketHoverColor = new(.27f, .30f, .34f, 1f);
+		private static readonly Color HistoryCollapsedBucketHoverColor = new(.20f, .23f, .27f, 1f);
 		private EditorGUISplitView _historySplitter;
 		private SearchData _historySearchData;
 		private Vector2 _historyEntriesScroll;
@@ -34,6 +43,15 @@ namespace Beamable.Editor.UI.ContentWindow
 		private int _filteredHistoryVersion = -1;
 		private string _historyFilterKey;
 		private IReadOnlyList<BeamContentHistoryEntry> _filteredHistoryEntries = Array.Empty<BeamContentHistoryEntry>();
+		private IReadOnlyList<ContentHistoryTimeBucket> _historyBuckets = Array.Empty<ContentHistoryTimeBucket>();
+		private readonly HashSet<string> _expandedHistoryBucketKeys = new();
+		private int _historyBucketVersion = -1;
+		private string _historyBucketFilterKey;
+		private DateTime _historyBucketLocalDate;
+		private string _historyBucketAutoExpandKey;
+		private IReadOnlyList<ContentHistoryTimeBucketRow> _historyDisplayRows = Array.Empty<ContentHistoryTimeBucketRow>();
+		private bool _historyDisplayRowsDirty = true;
+		private string _hoveredHistoryRowKey;
 		private bool _isLoadingHistoryChanges;
 		private bool _isLoadingHistoryPreview;
 		private bool _isRestoringHistory;
@@ -46,6 +64,8 @@ namespace Beamable.Editor.UI.ContentWindow
 		private GUIStyle _historyRemovedChangeStyle;
 		private GUIStyle _historyDefaultChangeStyle;
 		private GUIStyle _historyRestoreButtonStyle;
+		private GUIStyle _historyEllipsisLabelStyle;
+		private readonly GUIContent _historyEllipsisMeasureContent = new();
 
 		private void DrawContentHistory()
 		{
@@ -84,6 +104,8 @@ namespace Beamable.Editor.UI.ContentWindow
 					_historyPageIndex = 0;
 					_historyEntriesScroll = Vector2.zero;
 					_historyFilterKey = null;
+					_historyBucketAutoExpandKey = null;
+					_historyDisplayRowsDirty = true;
 				}
 			};
 		}
@@ -101,18 +123,28 @@ namespace Beamable.Editor.UI.ContentWindow
 			}
 
 			var filteredEntries = GetFilteredHistoryEntries();
+			var historyBuckets = GetHistoryBuckets(filteredEntries);
+			AutoExpandHistoryBucketsForSearch(historyBuckets, _historySearchData?.searchText?.Trim());
+
+			/*
+			 * Publish pagination is intentionally disabled while Smart Time Buckets are enabled.
+			 * Paging entries before flattening the expandable hierarchy made a bucket header describe
+			 * history that was not actually visible on that page. Keep the existing pagination code
+			 * below for a future non-hierarchical view, but use one virtualized hierarchy here.
+			 *
 			var pageSize = ContentHistoryPagination.ClampPageSize(_contentConfiguration.HistoryEntriesPerPage);
 			var pageCount = ContentHistoryPagination.GetPageCount(filteredEntries.Count, pageSize);
 			_historyPageIndex = ContentHistoryPagination.ClampPageIndex(_historyPageIndex, pageCount);
 			var firstEntryIndex = _historyPageIndex * pageSize;
 			var currentEntryCount = Math.Min(pageSize, Math.Max(0, filteredEntries.Count - firstEntryIndex));
+			*/
 
 			if (_contentService.ContentHistoryWatcherError != null)
 			{
 				DrawHistoryOperationError(_contentService.ContentHistoryWatcherError, RetryContentHistory);
 			}
 
-			if (currentEntryCount == 0)
+			if (filteredEntries.Count == 0)
 			{
 				if (_contentService.ContentHistoryWatcherError == null)
 				{
@@ -121,10 +153,11 @@ namespace Beamable.Editor.UI.ContentWindow
 			}
 			else
 			{
-				DrawVirtualHistoryEntries(filteredEntries, firstEntryIndex, currentEntryCount);
+				DrawHistoryTableHeader();
+				DrawVirtualHistoryEntries(historyBuckets);
 			}
 
-			DrawHistoryPagination(filteredEntries.Count, pageSize, pageCount);
+			// DrawHistoryPagination(filteredEntries.Count, pageSize, pageCount);
 			EditorGUILayout.EndVertical();
 		}
 
@@ -171,36 +204,199 @@ namespace Beamable.Editor.UI.ContentWindow
 			return _filteredHistoryEntries;
 		}
 
-		private void DrawVirtualHistoryEntries(IReadOnlyList<BeamContentHistoryEntry> entries, int firstEntryIndex, int entryCount)
+		private IReadOnlyList<ContentHistoryTimeBucket> GetHistoryBuckets(IReadOnlyList<BeamContentHistoryEntry> entries)
 		{
+			var search = _historySearchData?.searchText?.Trim();
+			var historyVersion = _contentService.ContentHistoryVersion;
+			var localNow = DateTime.Now;
+			if (_historyBucketVersion == historyVersion && _historyBucketLocalDate == localNow.Date &&
+			    string.Equals(_historyBucketFilterKey, search, StringComparison.Ordinal))
+			{
+				return _historyBuckets;
+			}
+
+			var resetExpansion = _historyBucketVersion < 0 || !string.Equals(_historyBucketFilterKey, search, StringComparison.Ordinal);
+			if (resetExpansion)
+			{
+				_expandedHistoryBucketKeys.Clear();
+			}
+
+			_historyBuckets = ContentHistoryTimeBuckets.Create(entries, localNow);
+			_historyBucketVersion = historyVersion;
+			_historyBucketFilterKey = search;
+			_historyBucketLocalDate = localNow.Date;
+			_historyBucketAutoExpandKey = null;
+			_historyDisplayRowsDirty = true;
+			if (resetExpansion)
+			{
+				_expandedHistoryBucketKeys.UnionWith(ContentHistoryTimeBuckets.GetDefaultExpandedKeys(_historyBuckets));
+			}
+			return _historyBuckets;
+		}
+
+		private void AutoExpandHistoryBucketsForSearch(IReadOnlyList<ContentHistoryTimeBucket> buckets, string search)
+		{
+			if (string.IsNullOrEmpty(search))
+			{
+				return;
+			}
+
+			var key = $"{_historyBucketVersion}|{search}";
+			if (string.Equals(_historyBucketAutoExpandKey, key, StringComparison.Ordinal))
+			{
+				return;
+			}
+
+			var didExpandBucket = false;
+			foreach (var entry in _filteredHistoryEntries)
+			{
+				foreach (var ancestorKey in ContentHistoryTimeBuckets.GetAncestorKeys(buckets, entry.ManifestUid))
+				{
+					didExpandBucket |= _expandedHistoryBucketKeys.Add(ancestorKey);
+				}
+			}
+
+			_historyBucketAutoExpandKey = key;
+			_historyDisplayRowsDirty |= didExpandBucket;
+		}
+
+		private void DrawHistoryTableHeader()
+		{
+			EditorGUILayout.BeginHorizontal(EditorStyles.toolbar);
+			EditorGUILayout.LabelField("Time", EditorStyles.miniLabel, GUILayout.Width(HistoryTimeColumnWidth));
+			EditorGUILayout.LabelField("Changes", EditorStyles.miniLabel, GUILayout.Width(HistoryChangesColumnWidth));
+			EditorGUILayout.LabelField("Manifest ID", EditorStyles.miniLabel, GUILayout.ExpandWidth(true));
+			EditorGUILayout.LabelField("Author", EditorStyles.miniLabel, GUILayout.Width(HistoryAuthorColumnWidth));
+			EditorGUILayout.EndHorizontal();
+		}
+
+		private void DrawVirtualHistoryEntries(IReadOnlyList<ContentHistoryTimeBucket> buckets)
+		{
+			var rows = GetHistoryDisplayRows(buckets);
 			var areaRect = GUILayoutUtility.GetRect(GUIContent.none, GUIStyle.none, GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true));
-			var contentRect = new Rect(0, 0, Math.Max(0, areaRect.width - 16), entryCount * HistoryEntryRowHeight);
+			var contentRect = new Rect(0, 0, Math.Max(0, areaRect.width - 16), rows.Count * HistoryEntryRowHeight);
 			_historyEntriesScroll = GUI.BeginScrollView(areaRect, _historyEntriesScroll, contentRect, false, true);
-			var visibleRange = ContentHistoryPagination.GetVisibleRange(entryCount, _historyEntriesScroll.y, areaRect.height, HistoryEntryRowHeight);
+			var visibleRange = ContentHistoryPagination.GetVisibleRange(rows.Count, _historyEntriesScroll.y, areaRect.height, HistoryEntryRowHeight);
+			UpdateHistoryHover(rows, visibleRange, contentRect.width);
 			for (var index = visibleRange.FirstIndex; index < visibleRange.LastExclusive; index++)
 			{
-				DrawHistoryEntry(entries[firstEntryIndex + index], new Rect(0, index * HistoryEntryRowHeight, contentRect.width, HistoryEntryRowHeight));
+				DrawHistoryDisplayRow(rows[index], new Rect(0, index * HistoryEntryRowHeight, contentRect.width, HistoryEntryRowHeight));
 			}
 			GUI.EndScrollView();
 		}
 
-		private void DrawHistoryEntry(BeamContentHistoryEntry entry, Rect rowRect)
+		private void UpdateHistoryHover(IReadOnlyList<ContentHistoryTimeBucketRow> rows, ContentHistoryVisibleRange visibleRange,
+			float contentWidth)
+		{
+			if (Event.current.type != EventType.MouseMove && Event.current.type != EventType.MouseLeaveWindow)
 			{
+				return;
+			}
+
+			string nextHoveredRowKey = null;
+			if (Event.current.type == EventType.MouseMove)
+			{
+				for (var index = visibleRange.FirstIndex; index < visibleRange.LastExclusive; index++)
+				{
+					var rowRect = new Rect(0, index * HistoryEntryRowHeight, contentWidth, HistoryEntryRowHeight);
+					if (rowRect.Contains(Event.current.mousePosition))
+					{
+						nextHoveredRowKey = GetHistoryRowKey(rows[index]);
+						break;
+					}
+				}
+			}
+
+			if (!ContentHistoryRowInteraction.ShouldRepaint(_hoveredHistoryRowKey, nextHoveredRowKey))
+			{
+				return;
+			}
+
+			_hoveredHistoryRowKey = nextHoveredRowKey;
+			Repaint();
+		}
+
+		private IReadOnlyList<ContentHistoryTimeBucketRow> GetHistoryDisplayRows(IReadOnlyList<ContentHistoryTimeBucket> buckets)
+		{
+			if (_historyDisplayRowsDirty)
+			{
+				_historyDisplayRows = ContentHistoryTimeBuckets.BuildVisibleRows(buckets, _expandedHistoryBucketKeys);
+				_historyDisplayRowsDirty = false;
+			}
+
+			return _historyDisplayRows;
+		}
+
+		private void DrawHistoryDisplayRow(ContentHistoryTimeBucketRow row, Rect rowRect)
+		{
+			if (row.Bucket != null)
+			{
+				DrawHistoryBucket(row.Bucket, rowRect, GetHistoryRowKey(row));
+				return;
+			}
+
+			DrawHistoryEntry(row.Entry, rowRect, GetHistoryRowKey(row));
+		}
+
+		private static string GetHistoryRowKey(ContentHistoryTimeBucketRow row)
+		{
+			return row.Bucket != null ? row.Bucket.Key : row.Entry.ManifestUid;
+		}
+
+		private bool IsHistoryBucketExpanded(ContentHistoryTimeBucket bucket)
+		{
+			return _expandedHistoryBucketKeys.Contains(bucket.Key);
+		}
+
+		private void DrawHistoryBucket(ContentHistoryTimeBucket bucket, Rect rowRect, string rowKey)
+		{
+			var isExpanded = IsHistoryBucketExpanded(bucket);
+			var isHovering = string.Equals(_hoveredHistoryRowKey, rowKey, StringComparison.Ordinal);
+			var backgroundColor = isExpanded
+				? (isHovering ? HistoryExpandedBucketHoverColor : HistoryExpandedBucketColor)
+				: (isHovering ? HistoryCollapsedBucketHoverColor : HistoryCollapsedBucketColor);
+			EditorGUI.DrawRect(rowRect, backgroundColor);
+			EditorGUI.DrawRect(new Rect(rowRect.x, rowRect.yMax - 1, rowRect.width, 1), new Color(0f, 0f, 0f, .35f));
+			var chevron = isExpanded ? "v" : ">";
+			GUI.Label(new Rect(rowRect.x + 6, rowRect.y + 3, rowRect.width - 12, EditorGUIUtility.singleLineHeight),
+				$"{chevron} {bucket.Label} ({bucket.EntryCount})", EditorStyles.boldLabel);
+
+			if (GUI.Button(rowRect, GUIContent.none, GUIStyle.none))
+			{
+				if (isExpanded)
+				{
+					_expandedHistoryBucketKeys.Remove(bucket.Key);
+					_historyDisplayRowsDirty = true;
+				}
+				else
+				{
+					_expandedHistoryBucketKeys.Add(bucket.Key);
+					_historyDisplayRowsDirty = true;
+				}
+			}
+		}
+
+		private void DrawHistoryEntry(BeamContentHistoryEntry entry, Rect rowRect, string rowKey)
+		{
 			var isSelected = entry.ManifestUid == _selectedHistoryManifestUid;
-			if (isSelected)
+			var visualState = ContentHistoryRowInteraction.GetVisualState(isSelected,
+				string.Equals(_hoveredHistoryRowKey, rowKey, StringComparison.Ordinal));
+			if (visualState == ContentHistoryRowVisualState.Selected)
 			{
 				GUI.Box(rowRect, GUIContent.none, EditorStyles.selectionRect);
 			}
 			else
 			{
-				GUI.Box(rowRect, GUIContent.none, EditorStyles.helpBox);
+				EditorGUI.DrawRect(rowRect, visualState == ContentHistoryRowVisualState.Hovered
+					? HistoryEntryHoverColor
+					: HistoryEntryColor);
 			}
 
 			var date = DateTimeOffset.FromUnixTimeMilliseconds(entry.CreatedDate).LocalDateTime;
-			var primaryRect = new Rect(rowRect.x + 6, rowRect.y + 3, rowRect.width - 12, EditorGUIUtility.singleLineHeight);
-			var secondaryRect = new Rect(primaryRect.x, primaryRect.yMax, primaryRect.width, EditorGUIUtility.singleLineHeight);
-			GUI.Label(primaryRect, $"{date:g}   {entry.ManifestUid}   {entry.PublishedByName}");
-			GUI.Label(secondaryRect, $"{entry.AffectedContentIds?.Length ?? 0} changed content item(s)", EditorStyles.miniLabel);
+			var timeRect = new Rect(rowRect.x + 6, rowRect.y + 3, HistoryTimeColumnWidth - 6, EditorGUIUtility.singleLineHeight);
+			var changesRect = new Rect(timeRect.xMax, rowRect.y + 3, HistoryChangesColumnWidth, EditorGUIUtility.singleLineHeight);
+			var authorRect = new Rect(rowRect.xMax - HistoryAuthorColumnWidth, rowRect.y + 3, HistoryAuthorColumnWidth - 6, EditorGUIUtility.singleLineHeight);
+			var manifestRect = new Rect(changesRect.xMax, rowRect.y + 3, Math.Max(0, authorRect.x - changesRect.xMax), EditorGUIUtility.singleLineHeight);
 
 			using (new EditorGUI.DisabledScope(_isRestoringHistory))
 			{
@@ -209,6 +405,11 @@ namespace Beamable.Editor.UI.ContentWindow
 					SelectHistoryEntry(entry.ManifestUid);
 				}
 			}
+
+			GUI.Label(timeRect, date.ToString("h:mm tt"), EditorStyles.miniLabel);
+			GUI.Label(changesRect, $"{entry.AffectedContentIds?.Length ?? 0} changed", EditorStyles.miniLabel);
+			DrawHistoryTruncatedLabel(manifestRect, entry.ManifestUid);
+			DrawHistoryTruncatedLabel(authorRect, string.IsNullOrEmpty(entry.PublishedByName) ? entry.PublishedBy : entry.PublishedByName);
 		}
 
 		private void DrawHistoryPagination(int entryCount, int pageSize, int pageCount)
@@ -220,12 +421,12 @@ namespace Beamable.Editor.UI.ContentWindow
 
 			using (new EditorGUI.DisabledScope(_historyPageIndex == 0))
 			{
-				if (GUILayout.Button("<", GUILayout.Width(24))) _historyPageIndex--;
+				if (GUILayout.Button("<", GUILayout.Width(24))) SetHistoryPage(_historyPageIndex - 1);
 			}
 			EditorGUILayout.LabelField($"{_historyPageIndex + 1}/{Math.Max(pageCount, 1)}", GUILayout.Width(48));
 			using (new EditorGUI.DisabledScope(_historyPageIndex >= pageCount - 1))
 			{
-				if (GUILayout.Button(">", GUILayout.Width(24))) _historyPageIndex++;
+				if (GUILayout.Button(">", GUILayout.Width(24))) SetHistoryPage(_historyPageIndex + 1);
 			}
 
 			if (GUILayout.Button($"Per page: {pageSize}", EditorStyles.toolbarDropDown, GUILayout.Width(92)))
@@ -246,7 +447,18 @@ namespace Beamable.Editor.UI.ContentWindow
 			EditorUtility.SetDirty(_contentConfiguration);
 			AssetDatabase.SaveAssets();
 			_historyPageIndex = 0;
+			_historyEntriesScroll = Vector2.zero;
+			_historyBucketAutoExpandKey = null;
+			_historyDisplayRowsDirty = true;
 			Repaint();
+		}
+
+		private void SetHistoryPage(int pageIndex)
+		{
+			_historyPageIndex = pageIndex;
+			_historyEntriesScroll = Vector2.zero;
+			_historyBucketAutoExpandKey = null;
+			_historyDisplayRowsDirty = true;
 		}
 
 		private void DrawHistoryChanges()
@@ -317,6 +529,20 @@ namespace Beamable.Editor.UI.ContentWindow
 				EditorGUILayout.TextArea(_selectedHistoryJson, GUILayout.ExpandHeight(true));
 				EditorGUILayout.EndScrollView();
 			}
+		}
+
+		private void DrawHistoryTruncatedLabel(Rect rect, string value)
+		{
+			value ??= string.Empty;
+			GUI.Label(rect, value, _historyEllipsisLabelStyle);
+			_historyEllipsisMeasureContent.text = value;
+			if (!rect.Contains(Event.current.mousePosition) ||
+				_historyEllipsisLabelStyle.CalcSize(_historyEllipsisMeasureContent).x <= rect.width)
+			{
+				return;
+			}
+
+			GUI.Label(rect, new GUIContent(string.Empty, value), GUIStyle.none);
 		}
 
 		private void DrawVirtualHistoryChanges(int firstChangeIndex, int changeCount)
@@ -426,7 +652,6 @@ namespace Beamable.Editor.UI.ContentWindow
 			{
 				EditorGUI.DrawRect(new Rect(rect.x, rect.y, rect.width, 1), new Color(1f, 1f, 1f, .45f));
 			}
-			if (isEnabled) EditorGUIUtility.AddCursorRect(rect, MouseCursor.Link);
 			GUI.Label(rect, content, _historyRestoreButtonStyle);
 			return isEnabled && GUI.Button(rect, GUIContent.none, GUIStyle.none);
 		}
@@ -481,6 +706,11 @@ namespace Beamable.Editor.UI.ContentWindow
 			{
 				alignment = TextAnchor.MiddleCenter,
 				normal = { textColor = Color.white }
+			};
+			_historyEllipsisLabelStyle = new GUIStyle(EditorStyles.miniLabel)
+			{
+				clipping = TextClipping.Ellipsis,
+				wordWrap = false
 			};
 		}
 
@@ -656,5 +886,27 @@ namespace Beamable.Editor.UI.ContentWindow
 			}
 		}
 
+	}
+
+	public enum ContentHistoryRowVisualState
+	{
+		Normal,
+		Hovered,
+		Selected
+	}
+
+	public static class ContentHistoryRowInteraction
+	{
+		public static ContentHistoryRowVisualState GetVisualState(bool isSelected, bool isHovered)
+		{
+			return isSelected
+				? ContentHistoryRowVisualState.Selected
+				: isHovered ? ContentHistoryRowVisualState.Hovered : ContentHistoryRowVisualState.Normal;
+		}
+
+		public static bool ShouldRepaint(string currentHoveredRowKey, string nextHoveredRowKey)
+		{
+			return !string.Equals(currentHoveredRowKey, nextHoveredRowKey, StringComparison.Ordinal);
+		}
 	}
 }

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
@@ -48,12 +48,15 @@ namespace Beamable.Editor.UI.ContentWindow
 		private string _historyChangesFilterKey;
 		private IReadOnlyList<BeamContentHistoryChangelistEntry> _historyChangesFilterSource;
 		private IReadOnlyList<BeamContentHistoryChangelistEntry> _filteredHistoryChanges = Array.Empty<BeamContentHistoryChangelistEntry>();
+		private bool _hasFilteredHistoryChanges;
 		private int _historySelectionRequestVersion;
 		private int _historyPreviewRequestVersion;
 		private int _filteredHistoryVersion = -1;
 		private string _historyFilterKey;
 		private IReadOnlyList<BeamContentHistoryEntry> _filteredHistoryEntries = Array.Empty<BeamContentHistoryEntry>();
+		private bool _hasFilteredHistoryEntries;
 		private IReadOnlyList<ContentHistoryTimeBucket> _historyBuckets = Array.Empty<ContentHistoryTimeBucket>();
+		private bool _hasHistoryBuckets;
 		private readonly HashSet<string> _expandedHistoryBucketKeys = new();
 		private int _historyBucketVersion = -1;
 		private string _historyBucketFilterKey;
@@ -127,7 +130,8 @@ namespace Beamable.Editor.UI.ContentWindow
 				{
 					_historyPageIndex = 0;
 					_historyEntriesScroll = Vector2.zero;
-					_historyFilterKey = null;
+					_hasFilteredHistoryEntries = false;
+					_hasHistoryBuckets = false;
 					_historyBucketAutoExpandKey = null;
 					_historyDisplayRowsDirty = true;
 				}
@@ -147,7 +151,7 @@ namespace Beamable.Editor.UI.ContentWindow
 				{
 					_historyChangesPageIndex = 0;
 					_historyChangesScroll = Vector2.zero;
-					_historyChangesFilterKey = null;
+					_hasFilteredHistoryChanges = false;
 				}
 			};
 		}
@@ -228,7 +232,11 @@ namespace Beamable.Editor.UI.ContentWindow
 		{
 			var search = _historySearchData?.searchText?.Trim();
 			var historyVersion = _contentService.ContentHistoryVersion;
-			if (_filteredHistoryVersion == historyVersion && string.Equals(_historyFilterKey, search, StringComparison.Ordinal))
+			if (ContentHistoryFilterCache.CanReuse(
+				_hasFilteredHistoryEntries,
+				_filteredHistoryVersion == historyVersion,
+				_historyFilterKey,
+				search))
 			{
 				return _filteredHistoryEntries;
 			}
@@ -243,6 +251,7 @@ namespace Beamable.Editor.UI.ContentWindow
 					.ToList();
 			_filteredHistoryVersion = historyVersion;
 			_historyFilterKey = search;
+			_hasFilteredHistoryEntries = true;
 			return _filteredHistoryEntries;
 		}
 
@@ -251,7 +260,7 @@ namespace Beamable.Editor.UI.ContentWindow
 			var search = _historySearchData?.searchText?.Trim();
 			var historyVersion = _contentService.ContentHistoryVersion;
 			var localNow = DateTime.Now;
-			if (_historyBucketVersion == historyVersion && _historyBucketLocalDate == localNow.Date &&
+			if (_hasHistoryBuckets && _historyBucketVersion == historyVersion && _historyBucketLocalDate == localNow.Date &&
 			    string.Equals(_historyBucketFilterKey, search, StringComparison.Ordinal))
 			{
 				return _historyBuckets;
@@ -269,6 +278,7 @@ namespace Beamable.Editor.UI.ContentWindow
 			_historyBucketLocalDate = localNow.Date;
 			_historyBucketAutoExpandKey = null;
 			_historyDisplayRowsDirty = true;
+			_hasHistoryBuckets = true;
 			if (resetExpansion)
 			{
 				_expandedHistoryBucketKeys.UnionWith(ContentHistoryTimeBuckets.GetDefaultExpandedKeys(_historyBuckets));
@@ -611,8 +621,11 @@ namespace Beamable.Editor.UI.ContentWindow
 		private IReadOnlyList<BeamContentHistoryChangelistEntry> GetFilteredHistoryChanges()
 		{
 			var search = _historyChangesSearchData?.searchText?.Trim();
-			if (ReferenceEquals(_historyChangesFilterSource, _selectedHistoryChanges) &&
-				string.Equals(_historyChangesFilterKey, search, StringComparison.Ordinal))
+			if (ContentHistoryFilterCache.CanReuse(
+				_hasFilteredHistoryChanges,
+				ReferenceEquals(_historyChangesFilterSource, _selectedHistoryChanges),
+				_historyChangesFilterKey,
+				search))
 			{
 				return _filteredHistoryChanges;
 			}
@@ -620,6 +633,7 @@ namespace Beamable.Editor.UI.ContentWindow
 			_historyChangesFilterSource = _selectedHistoryChanges;
 			_historyChangesFilterKey = search;
 			_filteredHistoryChanges = ContentHistoryChangesSearch.Filter(_selectedHistoryChanges, search);
+			_hasFilteredHistoryChanges = true;
 			return _filteredHistoryChanges;
 		}
 
@@ -639,6 +653,7 @@ namespace Beamable.Editor.UI.ContentWindow
 			_historyChangesFilterKey = null;
 			_historyChangesFilterSource = null;
 			_filteredHistoryChanges = Array.Empty<BeamContentHistoryChangelistEntry>();
+			_hasFilteredHistoryChanges = false;
 		}
 
 		private void DrawVirtualHistoryChanges(IReadOnlyList<BeamContentHistoryChangelistEntry> changes, int firstChangeIndex,
@@ -1106,6 +1121,14 @@ namespace Beamable.Editor.UI.ContentWindow
 		private static bool Matches(string value, string search)
 		{
 			return !string.IsNullOrEmpty(value) && value.IndexOf(search, StringComparison.OrdinalIgnoreCase) >= 0;
+		}
+	}
+
+	internal static class ContentHistoryFilterCache
+	{
+		public static bool CanReuse(bool hasCachedRows, bool sourceMatches, string cachedSearch, string currentSearch)
+		{
+			return hasCachedRows && sourceMatches && string.Equals(cachedSearch, currentSearch, StringComparison.Ordinal);
 		}
 	}
 

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
@@ -1,0 +1,489 @@
+using Beamable.Common.BeamCli.Contracts;
+using Beamable.Editor.BeamCli.Commands;
+using Beamable.Editor.BeamCli.UI.LogHelpers;
+using Beamable.Editor.ThirdParty.Splitter;
+using Beamable.Editor.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+namespace Beamable.Editor.UI.ContentWindow
+{
+	public partial class ContentWindow
+	{
+		private static readonly int[] HistoryPageSizes = { 10, 20, 30, 40, 50 };
+		private const int HistoryChangesPageSize = 25;
+		private EditorGUISplitView _historySplitter;
+		private SearchData _historySearchData;
+		private Vector2 _historyEntriesScroll;
+		private Vector2 _historyChangesScroll;
+		private Vector2 _historyPreviewScroll;
+		private string _selectedHistoryManifestUid;
+		private BeamContentHistoryChangelistEntry[] _selectedHistoryChanges = Array.Empty<BeamContentHistoryChangelistEntry>();
+		private string _selectedHistoryJson = string.Empty;
+		private int _historyPageIndex;
+		private int _historyChangesPageIndex;
+		private int _historySelectionRequestVersion;
+		private bool _isLoadingHistoryChanges;
+		private bool _isLoadingHistoryPreview;
+		private bool _isRestoringHistory;
+		private string _historyRestoreError;
+
+		private void DrawContentHistory()
+		{
+			EnsureHistorySearchData();
+			if (IsContentHistoryLoading() || _isRestoringHistory)
+			{
+				Repaint();
+			}
+			if (_historySplitter == null || _historySplitter.cellCount < 2)
+			{
+				_historySplitter = new EditorGUISplitView(EditorGUISplitView.Direction.Horizontal, .5f, .5f);
+				EditorApplication.delayCall += Repaint;
+			}
+
+			EditorGUILayout.BeginVertical();
+			_historySplitter.BeginSplitView();
+			DrawHistoryEntries();
+			_historySplitter.Split(this);
+			DrawHistoryChanges();
+			_historySplitter.EndSplitView();
+			EditorGUILayout.EndVertical();
+		}
+
+		private void EnsureHistorySearchData()
+		{
+			if (_historySearchData != null)
+			{
+				return;
+			}
+
+			_historySearchData = new SearchData { onEndCheck = () => _historyPageIndex = 0 };
+		}
+
+		private void DrawHistoryEntries()
+		{
+			EditorGUILayout.BeginVertical();
+			EditorGUILayout.LabelField("Publish History", EditorStyles.boldLabel);
+			this.DrawSearchBar(_historySearchData);
+			if (IsContentHistoryLoading())
+			{
+				DrawHistoryLoadingState();
+				EditorGUILayout.EndVertical();
+				return;
+			}
+
+			var filteredEntries = GetFilteredHistoryEntries();
+			var pageSize = ContentHistoryPagination.ClampPageSize(_contentConfiguration.HistoryEntriesPerPage);
+			var pageCount = ContentHistoryPagination.GetPageCount(filteredEntries.Count, pageSize);
+			_historyPageIndex = ContentHistoryPagination.ClampPageIndex(_historyPageIndex, pageCount);
+			var currentEntries = filteredEntries.Skip(_historyPageIndex * pageSize).Take(pageSize).ToList();
+
+			_historyEntriesScroll = EditorGUILayout.BeginScrollView(_historyEntriesScroll, GUILayout.ExpandHeight(true));
+			if (currentEntries.Count == 0)
+			{
+				EditorGUILayout.HelpBox("No published content history matches this search.", MessageType.Info);
+			}
+			else
+			{
+				foreach (var entry in currentEntries)
+				{
+					DrawHistoryEntry(entry);
+				}
+			}
+			EditorGUILayout.EndScrollView();
+
+			DrawHistoryPagination(filteredEntries.Count, pageSize, pageCount);
+			EditorGUILayout.EndVertical();
+		}
+
+		private bool IsContentHistoryLoading()
+		{
+			return _contentService != null && _contentService.IsContentHistoryWatching &&
+			       !_contentService.HasReceivedInitialContentHistory;
+		}
+
+		private void DrawHistoryLoadingState()
+		{
+			var frame = (int)(EditorApplication.timeSinceStartup * 12) % 12;
+			var spinner = EditorGUIUtility.IconContent($"WaitSpin{frame:00}").image ?? BeamGUI.iconRefresh;
+			EditorGUILayout.BeginVertical(GUILayout.ExpandHeight(true));
+			GUILayout.FlexibleSpace();
+			EditorGUILayout.BeginHorizontal();
+			GUILayout.FlexibleSpace();
+			GUILayout.Label(new GUIContent(" Loading published history...", spinner), EditorStyles.label);
+			GUILayout.FlexibleSpace();
+			EditorGUILayout.EndHorizontal();
+			GUILayout.FlexibleSpace();
+			EditorGUILayout.EndVertical();
+		}
+
+		private List<BeamContentHistoryEntry> GetFilteredHistoryEntries()
+		{
+			var search = _historySearchData?.searchText?.Trim();
+			var entries = _contentService.ContentHistoryEntries;
+			if (string.IsNullOrEmpty(search))
+			{
+				return entries.ToList();
+			}
+
+			return entries.Where(entry =>
+				(entry.ManifestUid?.IndexOf(search, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0 ||
+				(entry.PublishedBy?.IndexOf(search, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0 ||
+				(entry.PublishedByName?.IndexOf(search, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0)
+				.ToList();
+		}
+
+		private void DrawHistoryEntry(BeamContentHistoryEntry entry)
+		{
+			var isSelected = entry.ManifestUid == _selectedHistoryManifestUid;
+			var rowRect = EditorGUILayout.GetControlRect(false, 42);
+			if (isSelected)
+			{
+				GUI.Box(rowRect, GUIContent.none, EditorStyles.selectionRect);
+			}
+			else
+			{
+				GUI.Box(rowRect, GUIContent.none, EditorStyles.helpBox);
+			}
+
+			var date = DateTimeOffset.FromUnixTimeMilliseconds(entry.CreatedDate).LocalDateTime;
+			var primaryRect = new Rect(rowRect.x + 6, rowRect.y + 3, rowRect.width - 12, EditorGUIUtility.singleLineHeight);
+			var secondaryRect = new Rect(primaryRect.x, primaryRect.yMax, primaryRect.width, EditorGUIUtility.singleLineHeight);
+			GUI.Label(primaryRect, $"{date:g}   {entry.ManifestUid}   {entry.PublishedByName}");
+			GUI.Label(secondaryRect, $"{entry.AffectedContentIds?.Length ?? 0} changed content item(s)", EditorStyles.miniLabel);
+
+			using (new EditorGUI.DisabledScope(_isRestoringHistory))
+			{
+				if (GUI.Button(rowRect, GUIContent.none, GUIStyle.none))
+				{
+					SelectHistoryEntry(entry.ManifestUid);
+				}
+			}
+		}
+
+		private void DrawHistoryPagination(int entryCount, int pageSize, int pageCount)
+		{
+			EditorGUILayout.BeginHorizontal(EditorStyles.helpBox);
+			var first = entryCount == 0 ? 0 : _historyPageIndex * pageSize + 1;
+			var last = Math.Min(entryCount, (_historyPageIndex + 1) * pageSize);
+			EditorGUILayout.LabelField($"{first}-{last} of {entryCount} publishes", GUILayout.ExpandWidth(true));
+
+			using (new EditorGUI.DisabledScope(_historyPageIndex == 0))
+			{
+				if (GUILayout.Button("<", GUILayout.Width(24))) _historyPageIndex--;
+			}
+			EditorGUILayout.LabelField($"{_historyPageIndex + 1}/{Math.Max(pageCount, 1)}", GUILayout.Width(48));
+			using (new EditorGUI.DisabledScope(_historyPageIndex >= pageCount - 1))
+			{
+				if (GUILayout.Button(">", GUILayout.Width(24))) _historyPageIndex++;
+			}
+
+			if (GUILayout.Button($"Per page: {pageSize}", EditorStyles.toolbarDropDown, GUILayout.Width(92)))
+			{
+				var menu = new GenericMenu();
+				foreach (var size in HistoryPageSizes)
+				{
+					menu.AddItem(new GUIContent(size.ToString()), size == pageSize, () => SetHistoryPageSize(size));
+				}
+				menu.ShowAsContext();
+			}
+			EditorGUILayout.EndHorizontal();
+		}
+
+		private void SetHistoryPageSize(int pageSize)
+		{
+			_contentConfiguration.HistoryEntriesPerPage = ContentHistoryPagination.ClampPageSize(pageSize);
+			EditorUtility.SetDirty(_contentConfiguration);
+			AssetDatabase.SaveAssets();
+			_historyPageIndex = 0;
+			Repaint();
+		}
+
+		private void DrawHistoryChanges()
+		{
+			EditorGUILayout.BeginVertical();
+			EditorGUILayout.LabelField("Changes in selected publish", EditorStyles.boldLabel);
+			if (string.IsNullOrEmpty(_selectedHistoryManifestUid))
+			{
+				EditorGUILayout.HelpBox("Select a published content history entry to inspect its changes.", MessageType.Info);
+				EditorGUILayout.EndVertical();
+				return;
+			}
+
+			EditorGUILayout.LabelField($"Manifest UID: {_selectedHistoryManifestUid}", EditorStyles.miniLabel);
+			if (_isLoadingHistoryChanges)
+			{
+				EditorGUILayout.HelpBox("Loading historical content changes...", MessageType.Info);
+			}
+			else
+			{
+				DrawHistoryChangesTable();
+			}
+
+			DrawHistoryActions();
+			EditorGUILayout.EndVertical();
+		}
+
+		private void DrawHistoryChangesTable()
+		{
+			EditorGUILayout.BeginHorizontal(EditorStyles.toolbar);
+			EditorGUILayout.LabelField("Change", GUILayout.Width(88));
+			EditorGUILayout.LabelField("Content", GUILayout.ExpandWidth(true));
+			EditorGUILayout.LabelField("Type", GUILayout.Width(110));
+			EditorGUILayout.LabelField("Preview", GUILayout.Width(55));
+			EditorGUILayout.EndHorizontal();
+
+			var pageCount = ContentHistoryPagination.GetPageCount(_selectedHistoryChanges.Length, HistoryChangesPageSize);
+			_historyChangesPageIndex = ContentHistoryPagination.ClampPageIndex(_historyChangesPageIndex, pageCount);
+			var currentChanges = _selectedHistoryChanges
+				.Skip(_historyChangesPageIndex * HistoryChangesPageSize)
+				.Take(HistoryChangesPageSize);
+
+			using (new EditorGUI.DisabledScope(IsHistoryRightPaneLocked()))
+			{
+				_historyChangesScroll = EditorGUILayout.BeginScrollView(_historyChangesScroll, GUILayout.ExpandHeight(true));
+				foreach (var entry in currentChanges)
+				{
+					EditorGUILayout.BeginHorizontal(EditorStyles.helpBox);
+					DrawHistoryChangeStatus(entry.ChangeStatus);
+					EditorGUILayout.LabelField(entry.FullId, GUILayout.ExpandWidth(true));
+					EditorGUILayout.LabelField(entry.TypeName, GUILayout.Width(110));
+					using (new EditorGUI.DisabledScope(_isLoadingHistoryPreview || string.IsNullOrEmpty(entry.JsonFilePath)))
+					{
+						if (GUILayout.Button("View", GUILayout.Width(55))) _ = LoadHistoryPreview(entry.FullId);
+					}
+					EditorGUILayout.EndHorizontal();
+				}
+				EditorGUILayout.EndScrollView();
+				DrawHistoryChangesPagination(_selectedHistoryChanges.Length, pageCount);
+			}
+
+			if (!string.IsNullOrEmpty(_selectedHistoryJson))
+			{
+				EditorGUILayout.LabelField("Historical JSON", EditorStyles.boldLabel);
+				_historyPreviewScroll = EditorGUILayout.BeginScrollView(_historyPreviewScroll, GUILayout.Height(120));
+				EditorGUILayout.TextArea(_selectedHistoryJson, GUILayout.ExpandHeight(true));
+				EditorGUILayout.EndScrollView();
+			}
+		}
+
+		private bool IsHistoryRightPaneLocked()
+		{
+			return _isLoadingHistoryChanges || _isRestoringHistory;
+		}
+
+		private void DrawHistoryChangesPagination(int changeCount, int pageCount)
+		{
+			EditorGUILayout.BeginHorizontal(EditorStyles.helpBox);
+			var first = changeCount == 0 ? 0 : _historyChangesPageIndex * HistoryChangesPageSize + 1;
+			var last = Math.Min(changeCount, (_historyChangesPageIndex + 1) * HistoryChangesPageSize);
+			EditorGUILayout.LabelField($"{first}-{last} of {changeCount} changes", GUILayout.ExpandWidth(true));
+
+			using (new EditorGUI.DisabledScope(_historyChangesPageIndex == 0))
+			{
+				if (GUILayout.Button("<", GUILayout.Width(24))) _historyChangesPageIndex--;
+			}
+			EditorGUILayout.LabelField($"{_historyChangesPageIndex + 1}/{Math.Max(pageCount, 1)}", GUILayout.Width(48));
+			using (new EditorGUI.DisabledScope(_historyChangesPageIndex >= pageCount - 1))
+			{
+				if (GUILayout.Button(">", GUILayout.Width(24))) _historyChangesPageIndex++;
+			}
+			EditorGUILayout.EndHorizontal();
+		}
+
+		private static void DrawHistoryChangeStatus(int changeStatus)
+		{
+			var (label, icon, color) = ((ContentStatus)changeStatus) switch
+			{
+				ContentStatus.Created => ("Added", BeamGUI.iconStatusAdded, new Color(.45f, .8f, .3f)),
+				ContentStatus.Modified => ("Modified", BeamGUI.iconStatusModified, new Color(1f, .65f, .15f)),
+				ContentStatus.Deleted => ("Removed", BeamGUI.iconStatusDeleted, new Color(1f, .35f, .3f)),
+				_ => ("Changed", BeamGUI.iconStatusModified, EditorStyles.label.normal.textColor)
+			};
+
+			var rect = GUILayoutUtility.GetRect(110, EditorGUIUtility.singleLineHeight, GUILayout.Width(110));
+			var iconRect = new Rect(rect.x + 2, rect.y + 1, 16, 16);
+			GUI.DrawTexture(iconRect, icon, ScaleMode.ScaleToFit);
+			var labelStyle = new GUIStyle(EditorStyles.label);
+			labelStyle.normal.textColor = color;
+			GUI.Label(new Rect(iconRect.xMax + 5, rect.y, rect.width - 23, rect.height), label, labelStyle);
+		}
+
+		private void DrawHistoryActions()
+		{
+			EditorGUILayout.BeginHorizontal();
+			if (_isRestoringHistory)
+			{
+				DrawHistoryRestoreProgress();
+			}
+			else
+			{
+				using (new EditorGUI.DisabledScope(IsHistoryRightPaneLocked()))
+				{
+					if (GUILayout.Button("Copy manifest ID")) EditorGUIUtility.systemCopyBuffer = _selectedHistoryManifestUid;
+					GUILayout.FlexibleSpace();
+					if (DrawHistoryRestoreButton(!IsHistoryRightPaneLocked())) RestoreSelectedHistory();
+				}
+			}
+			EditorGUILayout.EndHorizontal();
+			EditorGUILayout.LabelField("Restores local files only — review and publish to update the realm.", EditorStyles.miniLabel);
+			if (!string.IsNullOrEmpty(_historyRestoreError))
+			{
+				EditorGUILayout.HelpBox(_historyRestoreError, MessageType.Error);
+				if (GUILayout.Button("Dismiss error")) _historyRestoreError = string.Empty;
+			}
+		}
+
+		private static bool DrawHistoryRestoreButton(bool isEnabled)
+		{
+			var content = new GUIContent("Restore changed files...");
+			var rect = GUILayoutUtility.GetRect(content, GUI.skin.button, GUILayout.Width(172));
+			var isHover = isEnabled && rect.Contains(Event.current.mousePosition);
+			var isPressed = isHover && Event.current.type == EventType.MouseDown;
+			var color = !isEnabled ? new Color(.28f, .12f, .1f) : isPressed
+				? new Color(.42f, .08f, .06f)
+				: isHover ? new Color(.78f, .2f, .16f) : new Color(.62f, .14f, .11f);
+			EditorGUI.DrawRect(rect, color);
+			if (isHover)
+			{
+				EditorGUI.DrawRect(new Rect(rect.x, rect.y, rect.width, 1), new Color(1f, 1f, 1f, .45f));
+			}
+			if (isEnabled) EditorGUIUtility.AddCursorRect(rect, MouseCursor.Link);
+			GUI.Label(rect, content, new GUIStyle(EditorStyles.label)
+			{
+				alignment = TextAnchor.MiddleCenter,
+				normal = { textColor = Color.white }
+			});
+			return isEnabled && GUI.Button(rect, GUIContent.none, GUIStyle.none);
+		}
+
+		private static void DrawHistoryRestoreProgress()
+		{
+			var frame = (int)(EditorApplication.timeSinceStartup * 12) % 12;
+			var spinner = EditorGUIUtility.IconContent($"WaitSpin{frame:00}").image ?? BeamGUI.iconRefresh;
+			GUILayout.Label(new GUIContent(" Restoring local files...", spinner), EditorStyles.label);
+			GUILayout.FlexibleSpace();
+		}
+
+		private void SelectHistoryEntry(string manifestUid)
+		{
+			if (_selectedHistoryManifestUid == manifestUid)
+			{
+				return;
+			}
+
+			_selectedHistoryManifestUid = manifestUid;
+			_selectedHistoryChanges = Array.Empty<BeamContentHistoryChangelistEntry>();
+			_selectedHistoryJson = string.Empty;
+			_historyChangesPageIndex = 0;
+			var requestVersion = ++_historySelectionRequestVersion;
+			_ = LoadHistoryChanges(manifestUid, requestVersion);
+		}
+
+		private void ResetHistorySelection()
+		{
+			_historySelectionRequestVersion++;
+			_selectedHistoryManifestUid = string.Empty;
+			_selectedHistoryChanges = Array.Empty<BeamContentHistoryChangelistEntry>();
+			_selectedHistoryJson = string.Empty;
+			_historyChangesPageIndex = 0;
+			_historyChangesScroll = Vector2.zero;
+			_historyPreviewScroll = Vector2.zero;
+			_isLoadingHistoryChanges = false;
+			_isLoadingHistoryPreview = false;
+			_isRestoringHistory = false;
+			_historyRestoreError = string.Empty;
+		}
+
+		private async Task LoadHistoryChanges(string manifestUid, int requestVersion)
+		{
+			_isLoadingHistoryChanges = true;
+			Repaint();
+			try
+			{
+				var changes = await _contentService.GetContentHistoryChanges(manifestUid);
+				if (requestVersion == _historySelectionRequestVersion)
+				{
+					_selectedHistoryChanges = changes;
+				}
+			}
+			finally
+			{
+				if (requestVersion == _historySelectionRequestVersion)
+				{
+					_isLoadingHistoryChanges = false;
+				}
+				Repaint();
+			}
+		}
+
+		private async Task LoadHistoryPreview(string contentId)
+		{
+			_isLoadingHistoryPreview = true;
+			Repaint();
+			try
+			{
+				_selectedHistoryJson = await _contentService.GetContentHistoryJson(_selectedHistoryManifestUid, contentId);
+			}
+			finally
+			{
+				_isLoadingHistoryPreview = false;
+				Repaint();
+			}
+		}
+
+		private void RestoreSelectedHistory()
+		{
+			if (_isRestoringHistory)
+			{
+				return;
+			}
+
+			if (!EditorUtility.DisplayDialog("Restore Changed Files",
+					$"Restore local content files changed by publish {_selectedHistoryManifestUid}? This does not publish to the realm.",
+					"Restore Local Files", "Cancel"))
+			{
+				return;
+			}
+
+			_ = RestoreSelectedHistoryAsync();
+		}
+
+		private async Task RestoreSelectedHistoryAsync()
+		{
+			_isRestoringHistory = true;
+			_historyRestoreError = string.Empty;
+			Repaint();
+			try
+			{
+				await _contentService.RestoreContentHistory(_selectedHistoryManifestUid);
+				ChangeWindowStatus(ContentWindowStatus.Normal);
+			}
+			catch (Exception exception)
+			{
+				Debug.LogException(exception);
+				_historyRestoreError = $"Restore failed. Check your connection and try again. {exception.Message}";
+			}
+			finally
+			{
+				_isRestoringHistory = false;
+				Repaint();
+			}
+		}
+
+		private static string GetChangeLabel(int changeStatus)
+		{
+			return ((ContentStatus)changeStatus) switch
+			{
+				ContentStatus.Created => "Added",
+				ContentStatus.Modified => "Modified",
+				ContentStatus.Deleted => "Removed",
+				_ => "Changed"
+			};
+		}
+	}
+}

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
@@ -1110,7 +1110,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		}
 	}
 
-	internal static class ContentHistoryChangesSearch
+	public static class ContentHistoryChangesSearch
 	{
 		public static IReadOnlyList<BeamContentHistoryChangelistEntry> Filter(
 			IReadOnlyList<BeamContentHistoryChangelistEntry> changes, string search)
@@ -1137,7 +1137,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		}
 	}
 
-	internal readonly struct ContentHistoryPublishSearchResult
+	public readonly struct ContentHistoryPublishSearchResult
 	{
 		public IReadOnlyList<BeamContentHistoryEntry> Entries { get; }
 		public bool ShowNoExactIdHint { get; }
@@ -1149,7 +1149,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		}
 	}
 
-	internal static class ContentHistoryPublishSearch
+	public static class ContentHistoryPublishSearch
 	{
 		public static ContentHistoryPublishSearchResult Filter(IReadOnlyList<BeamContentHistoryEntry> entries, string search)
 		{
@@ -1185,7 +1185,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		}
 	}
 
-	internal static class ContentHistoryFilterCache
+	public static class ContentHistoryFilterCache
 	{
 		public static bool CanReuse(bool hasCachedRows, bool sourceMatches, string cachedSearch, string currentSearch)
 		{
@@ -1193,7 +1193,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		}
 	}
 
-	internal readonly struct ContentHistoryManifestCopyLayout
+	public readonly struct ContentHistoryManifestCopyLayout
 	{
 		public Rect ManifestRect { get; }
 		public Rect CopyButtonRect { get; }
@@ -1218,7 +1218,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		}
 	}
 
-	internal static class ContentHistoryInspectorPreview
+	public static class ContentHistoryInspectorPreview
 	{
 		private static readonly HashSet<int> PreviewInstanceIds = new();
 
@@ -1297,7 +1297,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		}
 	}
 
-	internal static class ContentHistoryPreviewRequest
+	public static class ContentHistoryPreviewRequest
 	{
 		public static bool IsCurrent(int currentSelectionVersion, int requestSelectionVersion,
 			int currentPreviewVersion, int requestPreviewVersion)

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
@@ -1,6 +1,7 @@
 using Beamable.Common.BeamCli.Contracts;
 using Beamable.Common.Content;
 using Beamable.Common.Content.Serialization;
+using Beamable.Content.Utility;
 using Beamable.Editor.BeamCli.Commands;
 using Beamable.Editor.BeamCli.UI.LogHelpers;
 using Beamable.Editor.ContentService;
@@ -8,6 +9,7 @@ using Beamable.Editor.ThirdParty.Splitter;
 using Beamable.Editor.Util;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -24,7 +26,7 @@ namespace Beamable.Editor.UI.ContentWindow
 		private const int HistoryChangesPageSize = 25;
 		private const float HistoryEntryRowHeight = 24f;
 		private const float HistoryChangeRowHeight = 22f;
-		private const float HistoryTimeColumnWidth = 74f;
+		private const float HistoryTimeColumnWidth = 156f;
 		private const float HistoryChangesColumnWidth = 82f;
 		private const float HistoryAuthorColumnWidth = 112f;
 		private const float HistoryManifestCopyButtonWidth = 20f;
@@ -445,7 +447,6 @@ namespace Beamable.Editor.UI.ContentWindow
 					: HistoryEntryColor);
 			}
 
-			var date = DateTimeOffset.FromUnixTimeMilliseconds(entry.CreatedDate).LocalDateTime;
 			var timeRect = new Rect(rowRect.x + 6, rowRect.y + 3, HistoryTimeColumnWidth - 6, EditorGUIUtility.singleLineHeight);
 			var changesRect = new Rect(timeRect.xMax, rowRect.y + 3, HistoryChangesColumnWidth, EditorGUIUtility.singleLineHeight);
 			var manifestLayout = ContentHistoryManifestCopyLayout.Create(rowRect, changesRect,
@@ -466,7 +467,7 @@ namespace Beamable.Editor.UI.ContentWindow
 				}
 			}
 
-			GUI.Label(timeRect, date.ToString("h:mm tt"), EditorStyles.miniLabel);
+			GUI.Label(timeRect, FormatHistoryTimestamp(entry.CreatedDate), EditorStyles.miniLabel);
 			GUI.Label(changesRect, $"{entry.AffectedContentIds?.Length ?? 0} changed", EditorStyles.miniLabel);
 			DrawHistoryTruncatedLabel(manifestRect, entry.ManifestUid);
 			DrawHistoryTruncatedLabel(authorRect, string.IsNullOrEmpty(entry.PublishedByName) ? entry.PublishedBy : entry.PublishedByName);
@@ -475,6 +476,13 @@ namespace Beamable.Editor.UI.ContentWindow
 				EditorGUIUtility.systemCopyBuffer = entry.ManifestUid;
 			}
 			GUI.Label(copyManifestRect, _historyCopyManifestTooltipContent, GUIStyle.none);
+		}
+
+		private static string FormatHistoryTimestamp(long timestampMilliseconds)
+		{
+			return DateTimeOffset.FromUnixTimeMilliseconds(timestampMilliseconds)
+				.ToUniversalTime()
+				.ToString(DateUtility.ISO_FORMAT, CultureInfo.InvariantCulture);
 		}
 
 		private void DrawHistoryPagination(int entryCount, int pageSize, int pageCount)

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
@@ -1,4 +1,6 @@
 using Beamable.Common.BeamCli.Contracts;
+using Beamable.Common.Content;
+using Beamable.Common.Content.Serialization;
 using Beamable.Editor.BeamCli.Commands;
 using Beamable.Editor.BeamCli.UI.LogHelpers;
 using Beamable.Editor.ContentService;
@@ -7,9 +9,12 @@ using Beamable.Editor.Util;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
+
+[assembly: InternalsVisibleTo("Unity.Beamable.Tests.Editor")]
 
 namespace Beamable.Editor.UI.ContentWindow
 {
@@ -56,8 +61,11 @@ namespace Beamable.Editor.UI.ContentWindow
 		private bool _isLoadingHistoryPreview;
 		private bool _isRestoringHistory;
 		private string _historyPreviewContentId;
+		private string _historyPreviewContentType;
+		private ContentObject _historyInspectorPreview;
 		private ContentHistoryOperationException _historyChangesError;
 		private ContentHistoryOperationException _historyPreviewError;
+		private ContentHistoryOperationException _historyPreviewRenderError;
 		private ContentHistoryOperationException _historyRestoreError;
 		private GUIStyle _historyAddedChangeStyle;
 		private GUIStyle _historyModifiedChangeStyle;
@@ -521,6 +529,10 @@ namespace Beamable.Editor.UI.ContentWindow
 			{
 				DrawHistoryOperationError(_historyPreviewError, RetryHistoryPreview);
 			}
+			if (_historyPreviewRenderError != null)
+			{
+				DrawHistoryOperationError(_historyPreviewRenderError, RetryHistoryPreview);
+			}
 
 			if (!string.IsNullOrEmpty(_selectedHistoryJson))
 			{
@@ -571,7 +583,7 @@ namespace Beamable.Editor.UI.ContentWindow
 			GUI.Label(typeRect, entry.TypeName);
 			using (new EditorGUI.DisabledScope(_isLoadingHistoryPreview || string.IsNullOrEmpty(entry.JsonFilePath)))
 			{
-				if (GUI.Button(previewRect, "View")) _ = LoadHistoryPreview(entry.FullId);
+				if (GUI.Button(previewRect, "View")) _ = LoadHistoryPreview(entry.FullId, entry.TypeName);
 			}
 		}
 
@@ -685,9 +697,9 @@ namespace Beamable.Editor.UI.ContentWindow
 
 		private void RetryHistoryPreview()
 		{
-			if (!string.IsNullOrEmpty(_historyPreviewContentId))
+			if (!string.IsNullOrEmpty(_historyPreviewContentId) && !string.IsNullOrEmpty(_historyPreviewContentType))
 			{
-				_ = LoadHistoryPreview(_historyPreviewContentId);
+				_ = LoadHistoryPreview(_historyPreviewContentId, _historyPreviewContentType);
 			}
 		}
 
@@ -737,12 +749,15 @@ namespace Beamable.Editor.UI.ContentWindow
 			}
 
 			_selectedHistoryManifestUid = manifestUid;
+			ClearHistoryInspectorPreview();
 			_selectedHistoryChanges = Array.Empty<BeamContentHistoryChangelistEntry>();
 			_selectedHistoryJson = string.Empty;
 			_historyChangesPageIndex = 0;
 			_historyChangesError = null;
 			_historyPreviewError = null;
+			_historyPreviewRenderError = null;
 			_historyPreviewContentId = string.Empty;
+			_historyPreviewContentType = string.Empty;
 			_historyPreviewRequestVersion++;
 			_isLoadingHistoryPreview = false;
 			_historyPreviewScroll = Vector2.zero;
@@ -752,6 +767,7 @@ namespace Beamable.Editor.UI.ContentWindow
 
 		private void ResetHistorySelection()
 		{
+			ClearHistoryInspectorPreview();
 			_historySelectionRequestVersion++;
 			_historyPreviewRequestVersion++;
 			_selectedHistoryManifestUid = string.Empty;
@@ -764,8 +780,10 @@ namespace Beamable.Editor.UI.ContentWindow
 			_isLoadingHistoryPreview = false;
 			_isRestoringHistory = false;
 			_historyPreviewContentId = string.Empty;
+			_historyPreviewContentType = string.Empty;
 			_historyChangesError = null;
 			_historyPreviewError = null;
+			_historyPreviewRenderError = null;
 			_historyRestoreError = null;
 		}
 
@@ -804,26 +822,33 @@ namespace Beamable.Editor.UI.ContentWindow
 			}
 		}
 
-		private async Task LoadHistoryPreview(string contentId)
+		private async Task LoadHistoryPreview(string contentId, string contentType)
 		{
 			var manifestUid = _selectedHistoryManifestUid;
 			var selectionRequestVersion = _historySelectionRequestVersion;
 			var previewRequestVersion = ++_historyPreviewRequestVersion;
 			_isLoadingHistoryPreview = true;
 			_historyPreviewError = null;
+			_historyPreviewRenderError = null;
 			_historyPreviewContentId = contentId;
+			_historyPreviewContentType = contentType;
+			_selectedHistoryJson = string.Empty;
+			ClearHistoryInspectorPreview();
 			Repaint();
 			try
 			{
 				var historyJson = await _contentService.GetContentHistoryJson(manifestUid, contentId);
-				if (selectionRequestVersion == _historySelectionRequestVersion && previewRequestVersion == _historyPreviewRequestVersion)
+				if (ContentHistoryPreviewRequest.IsCurrent(_historySelectionRequestVersion, selectionRequestVersion,
+					_historyPreviewRequestVersion, previewRequestVersion))
 				{
 					_selectedHistoryJson = historyJson;
+					TryShowHistoryInspectorPreview(historyJson, contentId, contentType, manifestUid);
 				}
 			}
 			catch (Exception exception)
 			{
-				if (selectionRequestVersion == _historySelectionRequestVersion && previewRequestVersion == _historyPreviewRequestVersion)
+				if (ContentHistoryPreviewRequest.IsCurrent(_historySelectionRequestVersion, selectionRequestVersion,
+					_historyPreviewRequestVersion, previewRequestVersion))
 				{
 					_historyPreviewError = ContentHistoryOperationException.FromException(
 						"Preview historical content",
@@ -835,12 +860,64 @@ namespace Beamable.Editor.UI.ContentWindow
 			}
 			finally
 			{
-				if (previewRequestVersion == _historyPreviewRequestVersion)
+				if (ContentHistoryPreviewRequest.IsCurrent(_historySelectionRequestVersion, selectionRequestVersion,
+					_historyPreviewRequestVersion, previewRequestVersion))
 				{
 					_isLoadingHistoryPreview = false;
 				}
 				Repaint();
 			}
+		}
+
+		private void TryShowHistoryInspectorPreview(string historyJson, string contentId, string contentType, string manifestUid)
+		{
+			ContentObject preview = null;
+			try
+			{
+				if (string.IsNullOrWhiteSpace(contentType) || !_contentTypeReflectionCache.TryGetType(contentType, out var type))
+				{
+					throw new InvalidOperationException($"No local content type is registered for historical type '{contentType}'.");
+				}
+				if (!ContentHistoryInspectorPreview.TryCreate(historyJson, contentId, type, out preview, out var createException))
+				{
+					throw createException;
+				}
+
+				ContentHistoryInspectorPreview.Register(preview);
+				Selection.activeObject = preview;
+				_historyInspectorPreview = preview;
+			}
+			catch (Exception exception)
+			{
+				if (preview != null)
+				{
+					ContentHistoryInspectorPreview.Release(preview);
+					DestroyImmediate(preview);
+				}
+
+				_historyPreviewRenderError = ContentHistoryOperationException.FromException(
+					"Render historical content in Inspector",
+					"Unable to render this historical content in the Inspector. Raw JSON is shown below.",
+					manifestUid,
+					exception);
+				Debug.LogError(_historyPreviewRenderError.Diagnostic);
+			}
+		}
+
+		private void ClearHistoryInspectorPreview()
+		{
+			if (_historyInspectorPreview == null)
+			{
+				return;
+			}
+
+			if (ContentHistoryInspectorPreview.ShouldClearSelection(_historyInspectorPreview, Selection.activeObject))
+			{
+				Selection.activeObject = null;
+			}
+			ContentHistoryInspectorPreview.Release(_historyInspectorPreview);
+			DestroyImmediate(_historyInspectorPreview);
+			_historyInspectorPreview = null;
 		}
 
 		private void RestoreSelectedHistory()
@@ -907,6 +984,94 @@ namespace Beamable.Editor.UI.ContentWindow
 		public static bool ShouldRepaint(string currentHoveredRowKey, string nextHoveredRowKey)
 		{
 			return !string.Equals(currentHoveredRowKey, nextHoveredRowKey, StringComparison.Ordinal);
+		}
+	}
+
+	internal static class ContentHistoryInspectorPreview
+	{
+		private static readonly HashSet<int> PreviewInstanceIds = new();
+
+		public static void Register(ContentObject content)
+		{
+			if (content != null)
+			{
+				PreviewInstanceIds.Add(content.GetInstanceID());
+			}
+		}
+
+		public static bool IsReadOnly(ContentObject content)
+		{
+			return content != null && PreviewInstanceIds.Contains(content.GetInstanceID());
+		}
+
+		public static void Release(ContentObject content)
+		{
+			if (content != null)
+			{
+				PreviewInstanceIds.Remove(content.GetInstanceID());
+			}
+		}
+
+		public static bool ShouldClearSelection(ContentObject preview, UnityEngine.Object currentSelection)
+		{
+			return preview != null && currentSelection == preview;
+		}
+
+		public static bool TryCreate(string json, string contentId, Type contentType, out ContentObject preview,
+			out Exception exception)
+		{
+			preview = null;
+			exception = null;
+			ContentObject candidate = null;
+			if (contentType == null || !typeof(ContentObject).IsAssignableFrom(contentType))
+			{
+				exception = new InvalidOperationException($"Historical type '{contentType?.FullName ?? "(missing)"}' is not a ContentObject.");
+				return false;
+			}
+
+			try
+			{
+				candidate = ScriptableObject.CreateInstance(contentType) as ContentObject;
+				if (candidate == null)
+				{
+					throw new InvalidOperationException($"Unable to create a historical preview for content type '{contentType.FullName}'.");
+				}
+
+				preview = ClientContentSerializer.DeserializeContentFromCli(json, candidate, contentId,
+					out _, disableExceptions: false) as ContentObject;
+				if (preview == null)
+				{
+					throw new InvalidOperationException($"Historical JSON for '{contentId}' did not deserialize to a ContentObject.");
+				}
+				if (preview != candidate)
+				{
+					UnityEngine.Object.DestroyImmediate(candidate);
+				}
+				return true;
+			}
+			catch (Exception caughtException)
+			{
+				if (preview != null)
+				{
+					UnityEngine.Object.DestroyImmediate(preview);
+				}
+				if (candidate != null && candidate != preview)
+				{
+					UnityEngine.Object.DestroyImmediate(candidate);
+				}
+				preview = null;
+				exception = caughtException;
+				return false;
+			}
+		}
+	}
+
+	internal static class ContentHistoryPreviewRequest
+	{
+		public static bool IsCurrent(int currentSelectionVersion, int requestSelectionVersion,
+			int currentPreviewVersion, int requestPreviewVersion)
+		{
+			return currentSelectionVersion == requestSelectionVersion && currentPreviewVersion == requestPreviewVersion;
 		}
 	}
 }

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
@@ -78,8 +78,18 @@ namespace Beamable.Editor.UI.ContentWindow
 		private GUIStyle _historyDefaultChangeStyle;
 		private GUIStyle _historyRestoreButtonStyle;
 		private GUIStyle _historyEllipsisLabelStyle;
+		private GUIStyle _historyManifestCopyButtonStyle;
 		private readonly GUIContent _historyEllipsisMeasureContent = new();
-		private static readonly GUIContent HistoryCopyManifestContent = new(EditorGUIUtility.FindTexture("Clipboard"), "Copy manifest ID");
+		private readonly GUIContent _historyCopyManifestTooltipContent = new(string.Empty, "Copy manifest ID");
+		private GUIContent _historyCopyManifestContent;
+
+		private void EnsureHistoryCopyManifestContent()
+		{
+			if (_historyCopyManifestContent == null)
+			{
+				_historyCopyManifestContent = new GUIContent(EditorGUIUtility.FindTexture("Clipboard"), "Copy manifest ID");
+			}
+		}
 
 		private void DrawContentHistory()
 		{
@@ -427,11 +437,11 @@ namespace Beamable.Editor.UI.ContentWindow
 			var date = DateTimeOffset.FromUnixTimeMilliseconds(entry.CreatedDate).LocalDateTime;
 			var timeRect = new Rect(rowRect.x + 6, rowRect.y + 3, HistoryTimeColumnWidth - 6, EditorGUIUtility.singleLineHeight);
 			var changesRect = new Rect(timeRect.xMax, rowRect.y + 3, HistoryChangesColumnWidth, EditorGUIUtility.singleLineHeight);
-			var authorRect = new Rect(rowRect.xMax - HistoryAuthorColumnWidth, rowRect.y + 3, HistoryAuthorColumnWidth - 6, EditorGUIUtility.singleLineHeight);
-			var copyManifestRect = new Rect(authorRect.x - HistoryManifestCopyButtonWidth, rowRect.y + 2,
-				HistoryManifestCopyButtonWidth, EditorGUIUtility.singleLineHeight + 2);
-			var manifestRect = new Rect(changesRect.xMax, rowRect.y + 3,
-				Math.Max(0, copyManifestRect.x - changesRect.xMax), EditorGUIUtility.singleLineHeight);
+			var manifestLayout = ContentHistoryManifestCopyLayout.Create(rowRect, changesRect,
+				HistoryAuthorColumnWidth, HistoryManifestCopyButtonWidth, EditorGUIUtility.singleLineHeight);
+			var authorRect = manifestLayout.AuthorRect;
+			var copyManifestRect = manifestLayout.CopyButtonRect;
+			var manifestRect = manifestLayout.ManifestRect;
 
 			using (new EditorGUI.DisabledScope(_isRestoringHistory))
 			{
@@ -449,10 +459,11 @@ namespace Beamable.Editor.UI.ContentWindow
 			GUI.Label(changesRect, $"{entry.AffectedContentIds?.Length ?? 0} changed", EditorStyles.miniLabel);
 			DrawHistoryTruncatedLabel(manifestRect, entry.ManifestUid);
 			DrawHistoryTruncatedLabel(authorRect, string.IsNullOrEmpty(entry.PublishedByName) ? entry.PublishedBy : entry.PublishedByName);
-			if (GUI.Button(copyManifestRect, HistoryCopyManifestContent, EditorStyles.iconButton))
+			if (GUI.Button(copyManifestRect, _historyCopyManifestContent, _historyManifestCopyButtonStyle))
 			{
 				EditorGUIUtility.systemCopyBuffer = entry.ManifestUid;
 			}
+			GUI.Label(copyManifestRect, _historyCopyManifestTooltipContent, GUIStyle.none);
 		}
 
 		private void DrawHistoryPagination(int entryCount, int pageSize, int pageCount)
@@ -798,6 +809,12 @@ namespace Beamable.Editor.UI.ContentWindow
 				clipping = TextClipping.Ellipsis,
 				wordWrap = false
 			};
+			_historyManifestCopyButtonStyle = new GUIStyle(EditorStyles.iconButton)
+			{
+				alignment = TextAnchor.MiddleCenter,
+				imagePosition = ImagePosition.ImageOnly,
+				padding = new RectOffset(0, 0, 0, 0)
+			};
 		}
 
 		private static GUIStyle CreateHistoryChangeStyle(Color color)
@@ -1089,6 +1106,31 @@ namespace Beamable.Editor.UI.ContentWindow
 		private static bool Matches(string value, string search)
 		{
 			return !string.IsNullOrEmpty(value) && value.IndexOf(search, StringComparison.OrdinalIgnoreCase) >= 0;
+		}
+	}
+
+	internal readonly struct ContentHistoryManifestCopyLayout
+	{
+		public Rect ManifestRect { get; }
+		public Rect CopyButtonRect { get; }
+		public Rect AuthorRect { get; }
+
+		private ContentHistoryManifestCopyLayout(Rect manifestRect, Rect copyButtonRect, Rect authorRect)
+		{
+			ManifestRect = manifestRect;
+			CopyButtonRect = copyButtonRect;
+			AuthorRect = authorRect;
+		}
+
+		public static ContentHistoryManifestCopyLayout Create(Rect rowRect, Rect changesRect, float authorColumnWidth,
+			float copyButtonWidth, float lineHeight)
+		{
+			var authorRect = new Rect(rowRect.xMax - authorColumnWidth, rowRect.y + 3,
+				authorColumnWidth - 6, lineHeight);
+			var copyButtonRect = new Rect(changesRect.xMax, rowRect.y + 2, copyButtonWidth, lineHeight + 2);
+			var manifestRect = new Rect(copyButtonRect.xMax + 2, rowRect.y + 3,
+				Math.Max(0, authorRect.x - copyButtonRect.xMax - 2), lineHeight);
+			return new ContentHistoryManifestCopyLayout(manifestRect, copyButtonRect, authorRect);
 		}
 	}
 

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs.meta
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b509434f6b38a0540bd6b1ac8151cc04

--- a/client/Packages/com.beamable/Runtime/Modules/Content/ContentConfiguration.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/Content/ContentConfiguration.cs
@@ -89,6 +89,11 @@ namespace Beamable.Content
 		[Header("Content Editor")]
 		[Tooltip("This option will change the Max size of Content Items before showing it as a list.")]
 		public int MaxContentVisibleItems = 15;
+
+		[Tooltip("Controls how many published content history entries are shown per page in the Content Manager. Values are clamped between 10 and 50.")]
+		[Range(10, 50)]
+		public int HistoryEntriesPerPage = 10;
+
 		public ContentTextureConfiguration ContentTextureConfiguration;
 
 		public ContentParameterProvider ParameterProvider
@@ -112,6 +117,10 @@ namespace Beamable.Content
 
 		private void OnValidate()
 		{
+#if UNITY_EDITOR
+			HistoryEntriesPerPage = Mathf.Clamp(HistoryEntriesPerPage, 10, 50);
+#endif
+
 #if UNITY_EDITOR
             if (!IsValidManifestID(EditorManifestID, out var message))
             {

--- a/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
+++ b/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using UnityEngine;
 
 namespace Beamable.Editor.Tests
@@ -177,6 +178,31 @@ namespace Beamable.Editor.Tests
 			};
 
 			Assert.That(ContentHistoryChangesSearch.Filter(changes, "  "), Is.SameAs(changes));
+		}
+
+		[Test]
+		public void ContentHistoryManifestCopyLayout_PlacesCopyButtonBeforeManifestText()
+		{
+			var rowRect = new Rect(0, 10, 400, 24);
+			const float lineHeight = 18f;
+			var changesRect = new Rect(74, 13, 82, lineHeight);
+
+			var layout = ContentHistoryManifestCopyLayout.Create(rowRect, changesRect, 112, 20,
+				lineHeight);
+
+			Assert.That(layout.CopyButtonRect.x, Is.EqualTo(changesRect.xMax));
+			Assert.That(layout.ManifestRect.x, Is.EqualTo(layout.CopyButtonRect.xMax + 2));
+			Assert.That(layout.AuthorRect.x, Is.EqualTo(rowRect.xMax - 112));
+		}
+
+		[Test]
+		public void ContentWindow_DoesNotStoreStaticGuiContent()
+		{
+			var staticGuiContentFields = typeof(ContentWindow).GetFields(
+				BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+				.Where(field => field.FieldType == typeof(GUIContent));
+
+			Assert.That(staticGuiContentFields, Is.Empty);
 		}
 
 		[Test]

--- a/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
+++ b/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
@@ -1,6 +1,8 @@
 using Beamable.Editor.UI.ContentWindow;
 using Beamable.Editor.ContentService;
 using Beamable.Editor.BeamCli.Commands;
+using Beamable.Common.Content;
+using Beamable.Common.Inventory;
 using Beamable.Content;
 using NUnit.Framework;
 using System;
@@ -274,6 +276,99 @@ namespace Beamable.Editor.Tests
 			string nextRowKey, bool shouldRepaint)
 		{
 			Assert.That(ContentHistoryRowInteraction.ShouldRepaint(currentRowKey, nextRowKey), Is.EqualTo(shouldRepaint));
+		}
+
+		[Test]
+		public void ContentHistoryInspectorPreview_MarksOnlyRegisteredPreviewAsReadOnly()
+		{
+			var preview = ScriptableObject.CreateInstance<ContentObject>();
+			var ordinaryContent = ScriptableObject.CreateInstance<ContentObject>();
+			try
+			{
+				ContentHistoryInspectorPreview.Register(preview);
+
+				Assert.That(ContentHistoryInspectorPreview.IsReadOnly(preview), Is.True);
+				Assert.That(ContentHistoryInspectorPreview.IsReadOnly(ordinaryContent), Is.False);
+
+				ContentHistoryInspectorPreview.Release(preview);
+				Assert.That(ContentHistoryInspectorPreview.IsReadOnly(preview), Is.False);
+			}
+			finally
+			{
+				ContentHistoryInspectorPreview.Release(preview);
+				UnityEngine.Object.DestroyImmediate(preview);
+				UnityEngine.Object.DestroyImmediate(ordinaryContent);
+			}
+		}
+
+		[Test]
+		public void ContentHistoryInspectorPreview_ClearsOnlyItsOwnSelection()
+		{
+			var preview = ScriptableObject.CreateInstance<ContentObject>();
+			var unrelatedSelection = ScriptableObject.CreateInstance<ContentObject>();
+			try
+			{
+				Assert.That(ContentHistoryInspectorPreview.ShouldClearSelection(preview, preview), Is.True);
+				Assert.That(ContentHistoryInspectorPreview.ShouldClearSelection(preview, unrelatedSelection), Is.False);
+			}
+			finally
+			{
+				UnityEngine.Object.DestroyImmediate(preview);
+				UnityEngine.Object.DestroyImmediate(unrelatedSelection);
+			}
+		}
+
+		[TestCase(4, 4, 9, 9, true)]
+		[TestCase(5, 4, 9, 9, false)]
+		[TestCase(4, 4, 10, 9, false)]
+		public void ContentHistoryPreviewRequest_RequiresBothRequestVersionsToMatch(int currentSelectionVersion,
+			int requestSelectionVersion, int currentPreviewVersion, int requestPreviewVersion, bool expectedCurrent)
+		{
+			Assert.That(ContentHistoryPreviewRequest.IsCurrent(currentSelectionVersion, requestSelectionVersion,
+				currentPreviewVersion, requestPreviewVersion), Is.EqualTo(expectedCurrent));
+		}
+
+		[Test]
+		public void ContentHistoryInspectorPreview_CreatesTypedPreviewFromCliJson()
+		{
+			const string json = "{\"id\":\"currency.gems\",\"version\":\"123\",\"properties\":{\"clientPermission\":{\"data\":{\"write_self\":false}},\"icon\":{\"data\":{\"referenceKey\":\"f819a6beb22c04c8d9f8222f930252b5\",\"subObjectName\":\"\"}},\"startingAmount\":{\"data\":0}}}";
+			ContentObject preview = null;
+			try
+			{
+				var created = ContentHistoryInspectorPreview.TryCreate(json, "currency.gems", typeof(CurrencyContent),
+					out preview, out var exception);
+
+				Assert.That(created, Is.True, exception?.ToString());
+				Assert.That(preview, Is.TypeOf<CurrencyContent>());
+				Assert.That(preview.Id, Is.EqualTo("currency.gems"));
+				Assert.That(((CurrencyContent)preview).startingAmount, Is.EqualTo(0));
+			}
+			finally
+			{
+				UnityEngine.Object.DestroyImmediate(preview);
+			}
+		}
+
+		[Test]
+		public void ContentHistoryInspectorPreview_RejectsMalformedJson()
+		{
+			var created = ContentHistoryInspectorPreview.TryCreate("{", "currency.gems", typeof(CurrencyContent),
+				out var preview, out var exception);
+
+			Assert.That(created, Is.False);
+			Assert.That(preview, Is.Null);
+			Assert.That(exception, Is.Not.Null);
+		}
+
+		[Test]
+		public void ContentHistoryInspectorPreview_RejectsNonContentObjectType()
+		{
+			var created = ContentHistoryInspectorPreview.TryCreate("{}", "currency.gems", typeof(ScriptableObject),
+				out var preview, out var exception);
+
+			Assert.That(created, Is.False);
+			Assert.That(preview, Is.Null);
+			Assert.That(exception, Is.Not.Null);
 		}
 
 		private static BeamContentHistoryEntry HistoryEntry(string manifestUid, DateTime createdAt)

--- a/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
+++ b/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
@@ -108,6 +108,28 @@ namespace Beamable.Editor.Tests
 		}
 
 		[Test]
+		public void ContentHistoryExtensionPoints_ArePublic()
+		{
+			var types = new[]
+			{
+				typeof(SearchBarClearInteraction),
+				typeof(ContentHistoryRequestFactory),
+				typeof(ContentHistoryRequestSlot<>),
+				typeof(ContentHistoryChangesSearch),
+				typeof(ContentHistoryPublishSearchResult),
+				typeof(ContentHistoryPublishSearch),
+				typeof(ContentHistoryFilterCache),
+				typeof(ContentHistoryManifestCopyLayout),
+				typeof(ContentHistoryInspectorPreview),
+				typeof(ContentHistoryPreviewRequest)
+			};
+
+			Assert.That(types, Is.All.Matches<Type>(type => type.IsPublic));
+			Assert.That(typeof(CliContentService).GetMethod("CancelContentHistoryRequests",
+				BindingFlags.Instance | BindingFlags.Public), Is.Not.Null);
+		}
+
+		[Test]
 		public void ContentHistoryTimestamp_UsesIso8601UtcFormat()
 		{
 			var formatter = typeof(ContentWindow).GetMethod("FormatHistoryTimestamp",

--- a/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
+++ b/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
@@ -108,6 +108,18 @@ namespace Beamable.Editor.Tests
 		}
 
 		[Test]
+		public void ContentHistoryTimestamp_UsesIso8601UtcFormat()
+		{
+			var formatter = typeof(ContentWindow).GetMethod("FormatHistoryTimestamp",
+				BindingFlags.Static | BindingFlags.NonPublic);
+
+			Assert.That(formatter, Is.Not.Null, "Content history needs a dedicated timestamp formatter.");
+			var formatted = (string)formatter.Invoke(null, new object[] { 0L });
+
+			Assert.That(formatted, Is.EqualTo("1970-01-01T00:00:00Z"));
+		}
+
+		[Test]
 		public void ContentHistoryOperationException_FormatsFullCopyableDiagnostic()
 		{
 			var error = new ContentHistoryOperationException(

--- a/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
+++ b/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
@@ -64,6 +64,59 @@ namespace Beamable.Editor.Tests
 		}
 
 		[Test]
+		public void ContentHistoryEntryCache_ReusesSortedSnapshotUntilEntriesChange()
+		{
+			var cache = new ContentHistoryEntryCache();
+			cache.Apply(new[] { new BeamContentHistoryEntry { ManifestUid = "first", CreatedDate = 1 } });
+
+			var initialSnapshot = cache.Entries;
+			Assert.That(cache.Entries, Is.SameAs(initialSnapshot));
+
+			cache.Apply(new[] { new BeamContentHistoryEntry { ManifestUid = "second", CreatedDate = 2 } });
+
+			var updatedSnapshot = cache.Entries;
+			Assert.That(updatedSnapshot, Is.Not.SameAs(initialSnapshot));
+			Assert.That(updatedSnapshot.Select(entry => entry.ManifestUid), Is.EqualTo(new[] { "second", "first" }));
+
+			cache.Apply(null, new[] { "second" });
+			var removedSnapshot = cache.Entries;
+			Assert.That(removedSnapshot, Is.Not.SameAs(updatedSnapshot));
+			Assert.That(removedSnapshot.Select(entry => entry.ManifestUid), Is.EqualTo(new[] { "first" }));
+
+			cache.Clear();
+			Assert.That(cache.Entries, Is.Empty);
+		}
+
+		[TestCase(0, 0f, 100f, 20f, 0, 0)]
+		[TestCase(10, 0f, 40f, 20f, 0, 3)]
+		[TestCase(10, 40f, 40f, 20f, 2, 5)]
+		[TestCase(10, 180f, 40f, 20f, 9, 10)]
+		[TestCase(2, 0f, 200f, 20f, 0, 2)]
+		public void GetVisibleRange_ReturnsOnlyRowsIntersectingTheViewport(int itemCount, float scrollPosition, float viewportHeight,
+			float rowHeight, int expectedFirstIndex, int expectedLastExclusive)
+		{
+			var range = ContentHistoryPagination.GetVisibleRange(itemCount, scrollPosition, viewportHeight, rowHeight);
+
+			Assert.That(range.FirstIndex, Is.EqualTo(expectedFirstIndex));
+			Assert.That(range.LastExclusive, Is.EqualTo(expectedLastExclusive));
+		}
+
+		[Test]
+		public void ContentHistoryOperationException_FormatsFullCopyableDiagnostic()
+		{
+			var error = new ContentHistoryOperationException(
+				"Load publish changes",
+				"Unable to load changes for this publish. Check your connection and try again.",
+				"manifest-123",
+				new InvalidOperationException("Network connection was lost."));
+
+			Assert.That(error.Diagnostic, Does.Contain("Load publish changes"));
+			Assert.That(error.Diagnostic, Does.Contain("manifest-123"));
+			Assert.That(error.Diagnostic, Does.Contain("InvalidOperationException"));
+			Assert.That(error.Diagnostic, Does.Contain("Network connection was lost."));
+		}
+
+		[Test]
 		public void ContentHistoryStreamParser_ParsesCamelCaseEntryFields()
 		{
 			var entries = string.Join(",", Enumerable.Range(1, 21).Select(index =>
@@ -102,6 +155,15 @@ namespace Beamable.Editor.Tests
 			Assert.That(streamEntries, Has.Length.EqualTo(1));
 			Assert.That(ContentHistoryStreamParser.TryParseChanges(terminalJson, out _), Is.False);
 			Assert.That(streamEntries[0].FullId, Is.EqualTo("stores.Store_Coin"));
+		}
+
+		[Test]
+		public void ContentHistoryStreamParser_TryParseChanges_RejectsStreamWithoutChangeEntries()
+		{
+			const string streamJson = "{\"ts\":1,\"type\":\"stream\",\"data\":{}}";
+
+			Assert.That(ContentHistoryStreamParser.TryParseChanges(streamJson, out var entries), Is.False);
+			Assert.That(entries, Is.Empty);
 		}
 
 		[Test]

--- a/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
+++ b/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
@@ -1,6 +1,7 @@
 using Beamable.Editor.UI.ContentWindow;
 using Beamable.Editor.ContentService;
 using Beamable.Editor.BeamCli.Commands;
+using Beamable.Editor.BeamCli.UI.LogHelpers;
 using Beamable.Common.BeamCli.Contracts;
 using Beamable.Common.Content;
 using Beamable.Common.Inventory;
@@ -178,6 +179,41 @@ namespace Beamable.Editor.Tests
 			};
 
 			Assert.That(ContentHistoryChangesSearch.Filter(changes, "  "), Is.SameAs(changes));
+		}
+
+		[Test]
+		public void ContentHistoryFilterCache_DoesNotReuseRowsAfterTheEmptySearchCacheIsInvalidated()
+		{
+			Assert.That(ContentHistoryFilterCache.CanReuse(
+				hasCachedRows: false,
+				sourceMatches: true,
+				cachedSearch: null,
+				currentSearch: null), Is.False);
+		}
+
+		[Test]
+		public void SearchBarClearInteraction_ClearsSearchAndNotifiesTheView()
+		{
+			var callbackCount = 0;
+			var searchData = new SearchData
+			{
+				searchText = "manifest-198",
+				onEndCheck = () => callbackCount++
+			};
+
+			SearchBarClearInteraction.Clear(searchData);
+
+			Assert.That(searchData.searchText, Is.Null);
+			Assert.That(callbackCount, Is.EqualTo(1));
+		}
+
+		[TestCase(EventType.MouseDown, true, true)]
+		[TestCase(EventType.MouseUp, true, false)]
+		[TestCase(EventType.MouseDown, false, false)]
+		public void SearchBarClearInteraction_RecognizesOnlyClearGlyphMouseDown(EventType eventType, bool isPointerOverClearGlyph,
+			bool expected)
+		{
+			Assert.That(SearchBarClearInteraction.IsClearClick(eventType, isPointerOverClearGlyph), Is.EqualTo(expected));
 		}
 
 		[Test]

--- a/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
+++ b/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
@@ -182,6 +182,85 @@ namespace Beamable.Editor.Tests
 		}
 
 		[Test]
+		public void ContentHistoryPublishSearch_UsesCaseInsensitiveExactAffectedContentIdMatches()
+		{
+			var firstMatch = new BeamContentHistoryEntry
+			{
+				ManifestUid = "manifest-first",
+				AffectedContentIds = new[] { "currency.New_currency_0" }
+			};
+			var nonMatch = new BeamContentHistoryEntry
+			{
+				ManifestUid = "manifest-other",
+				AffectedContentIds = new[] { "currency.coins" }
+			};
+			var secondMatch = new BeamContentHistoryEntry
+			{
+				ManifestUid = "manifest-second",
+				AffectedContentIds = new[] { "items.sword", "currency.New_currency_0" }
+			};
+
+			var result = ContentHistoryPublishSearch.Filter(
+				new[] { firstMatch, nonMatch, secondMatch }, "CURRENCY.NEW_CURRENCY_0");
+
+			Assert.That(result.Entries, Is.EqualTo(new[] { firstMatch, secondMatch }));
+			Assert.That(result.ShowNoExactIdHint, Is.False);
+		}
+
+		[Test]
+		public void ContentHistoryPublishSearch_FallsBackToNormalSearchForAnUnmatchedContentIdPrefix()
+		{
+			var exactPrefixOnly = new BeamContentHistoryEntry
+			{
+				ManifestUid = "currency.New_currency_0-candidate",
+				AffectedContentIds = new[] { "items.sword" }
+			};
+			var unrelated = new BeamContentHistoryEntry
+			{
+				ManifestUid = "manifest-other",
+				AffectedContentIds = new[] { "currency.New_currency_0" }
+			};
+
+			var result = ContentHistoryPublishSearch.Filter(
+				new[] { exactPrefixOnly, unrelated }, "currency.New_currency");
+
+			Assert.That(result.Entries, Is.EqualTo(new[] { exactPrefixOnly }));
+			Assert.That(result.ShowNoExactIdHint, Is.True);
+		}
+
+		[Test]
+		public void ContentHistoryPublishSearch_PreservesNormalAuthorSearchWithoutAnAuditHint()
+		{
+			var matchingAuthor = new BeamContentHistoryEntry
+			{
+				ManifestUid = "manifest-first",
+				PublishedBy = "dev@beamable.com",
+				PublishedByName = "Moe Developer"
+			};
+			var unrelated = new BeamContentHistoryEntry { ManifestUid = "manifest-second" };
+
+			var result = ContentHistoryPublishSearch.Filter(new[] { matchingAuthor, unrelated }, "moe");
+
+			Assert.That(result.Entries, Is.EqualTo(new[] { matchingAuthor }));
+			Assert.That(result.ShowNoExactIdHint, Is.False);
+		}
+
+		[Test]
+		public void ContentHistoryPublishSearch_HandlesEmptySearchAndMissingAffectedContentIds()
+		{
+			var entryWithoutAffectedIds = new BeamContentHistoryEntry { ManifestUid = "manifest-first" };
+			var entries = new[] { entryWithoutAffectedIds };
+
+			var emptySearch = ContentHistoryPublishSearch.Filter(entries, "  ");
+			var unmatchedId = ContentHistoryPublishSearch.Filter(entries, "currency.missing");
+
+			Assert.That(emptySearch.Entries, Is.SameAs(entries));
+			Assert.That(emptySearch.ShowNoExactIdHint, Is.False);
+			Assert.That(unmatchedId.Entries, Is.Empty);
+			Assert.That(unmatchedId.ShowNoExactIdHint, Is.True);
+		}
+
+		[Test]
 		public void ContentHistoryFilterCache_DoesNotReuseRowsAfterTheEmptySearchCacheIsInvalidated()
 		{
 			Assert.That(ContentHistoryFilterCache.CanReuse(

--- a/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
+++ b/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
@@ -1,0 +1,113 @@
+using Beamable.Editor.UI.ContentWindow;
+using Beamable.Editor.ContentService;
+using Beamable.Editor.BeamCli.Commands;
+using Beamable.Content;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using UnityEngine;
+
+namespace Beamable.Editor.Tests
+{
+	public class ContentHistoryPaginationTests
+	{
+		[TestCase(1, 10)]
+		[TestCase(10, 10)]
+		[TestCase(50, 50)]
+		[TestCase(51, 50)]
+		public void ClampPageSize_StaysWithinSupportedRange(int requestedPageSize, int expectedPageSize)
+		{
+			Assert.That(ContentHistoryPagination.ClampPageSize(requestedPageSize), Is.EqualTo(expectedPageSize));
+		}
+
+		[TestCase(0, 10, 0)]
+		[TestCase(1, 10, 1)]
+		[TestCase(10, 10, 1)]
+		[TestCase(11, 10, 2)]
+		[TestCase(127, 10, 13)]
+		public void GetPageCount_ReturnsExpectedPageCount(int entryCount, int pageSize, int expectedPageCount)
+		{
+			Assert.That(ContentHistoryPagination.GetPageCount(entryCount, pageSize), Is.EqualTo(expectedPageCount));
+		}
+
+		[TestCase(-1, 0, 0)]
+		[TestCase(0, 3, 0)]
+		[TestCase(4, 3, 2)]
+		public void ClampPageIndex_KeepsSelectionInsideAvailablePages(int requestedPageIndex, int pageCount, int expectedPageIndex)
+		{
+			Assert.That(ContentHistoryPagination.ClampPageIndex(requestedPageIndex, pageCount), Is.EqualTo(expectedPageIndex));
+		}
+
+		[Test]
+		public void ContentConfiguration_HistoryEntriesPerPage_DefaultsToTen()
+		{
+			var configuration = ScriptableObject.CreateInstance<ContentConfiguration>();
+
+			Assert.That(configuration.HistoryEntriesPerPage, Is.EqualTo(10));
+		}
+
+		[Test]
+		public void ContentHistoryEntryCache_MergesNewestEntriesAndRemovesDeletedEntries()
+		{
+			var cache = new ContentHistoryEntryCache();
+			cache.Apply(new[]
+			{
+				new BeamContentHistoryEntry { ManifestUid = "older", CreatedDate = 1 },
+				new BeamContentHistoryEntry { ManifestUid = "newer", CreatedDate = 2 }
+			});
+
+			cache.Apply(new[] { new BeamContentHistoryEntry { ManifestUid = "older", CreatedDate = 3 } }, new[] { "newer" });
+
+			Assert.That(cache.Entries, Has.Count.EqualTo(1));
+			Assert.That(cache.Entries[0].ManifestUid, Is.EqualTo("older"));
+			Assert.That(cache.Entries[0].CreatedDate, Is.EqualTo(3));
+		}
+
+		[Test]
+		public void ContentHistoryStreamParser_ParsesCamelCaseEntryFields()
+		{
+			var entries = string.Join(",", Enumerable.Range(1, 21).Select(index =>
+				$"{{\"manifestUid\":\"manifest-{index}\",\"createdDate\":{index},\"publishedBy\":\"user-{index}\",\"publishedByName\":\"User {index}\",\"affectedContentIds\":[\"currency.coins\"]}}"));
+			var streamJson = $"{{\"ts\":1,\"type\":\"stream\",\"data\":{{\"EventType\":0,\"EntriesPage\":{{\"Entries\":[{entries}]}},\"EntriesToRemove\":[]}}}}";
+
+			var parsedEntries = ContentHistoryStreamParser.ParseEntries(streamJson);
+
+			Assert.That(parsedEntries.Count, Is.EqualTo(21));
+			Assert.That(parsedEntries.All(entry => !string.IsNullOrEmpty(entry.ManifestUid)), Is.True);
+			Assert.That(parsedEntries[0].ManifestUid, Is.EqualTo("manifest-1"));
+			Assert.That(parsedEntries[20].AffectedContentIds, Is.EqualTo(new[] { "currency.coins" }));
+		}
+
+		[Test]
+		public void ContentHistoryStreamParser_ParsesCamelCaseChangeEntries()
+		{
+			const string streamJson = "{\"ts\":1,\"type\":\"stream\",\"data\":{\"ContentEntries\":[{\"fullId\":\"currency.New_currency_1\",\"typeName\":\"currency\",\"changeStatus\":2,\"jsonFilePath\":\"deleted.json\"},{\"fullId\":\"currency.coins\",\"typeName\":\"currency\",\"changeStatus\":4,\"jsonFilePath\":\"modified.json\"}]}}";
+
+			var parsedChanges = ContentHistoryStreamParser.ParseChanges(streamJson);
+
+			Assert.That(parsedChanges, Has.Length.EqualTo(2));
+			Assert.That(parsedChanges[0].FullId, Is.EqualTo("currency.New_currency_1"));
+			Assert.That(parsedChanges[0].ChangeStatus, Is.EqualTo(2));
+			Assert.That(parsedChanges[1].TypeName, Is.EqualTo("currency"));
+			Assert.That(parsedChanges[1].ChangeStatus, Is.EqualTo(4));
+		}
+
+		[Test]
+		public void ContentHistoryStreamParser_TryParseChanges_RejectsTerminalReportsWithoutReplacingStreamEntries()
+		{
+			const string streamJson = "{\"ts\":1,\"type\":\"stream\",\"data\":{\"ContentEntries\":[{\"fullId\":\"stores.Store_Coin\",\"typeName\":\"stores\",\"changeStatus\":4,\"jsonFilePath\":\"content.json\"}]}}";
+			const string terminalJson = "{\"ts\":2,\"type\":\"eof\",\"data\":{}}";
+
+			Assert.That(ContentHistoryStreamParser.TryParseChanges(streamJson, out var streamEntries), Is.True);
+			Assert.That(streamEntries, Has.Length.EqualTo(1));
+			Assert.That(ContentHistoryStreamParser.TryParseChanges(terminalJson, out _), Is.False);
+			Assert.That(streamEntries[0].FullId, Is.EqualTo("stores.Store_Coin"));
+		}
+
+		[Test]
+		public void ContentWindowStatus_ContainsHistoryMode()
+		{
+			Assert.That(Enum.IsDefined(typeof(ContentWindowStatus), "History"), Is.True);
+		}
+	}
+}

--- a/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
+++ b/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
@@ -1,6 +1,7 @@
 using Beamable.Editor.UI.ContentWindow;
 using Beamable.Editor.ContentService;
 using Beamable.Editor.BeamCli.Commands;
+using Beamable.Common.BeamCli.Contracts;
 using Beamable.Common.Content;
 using Beamable.Common.Inventory;
 using Beamable.Content;
@@ -149,6 +150,36 @@ namespace Beamable.Editor.Tests
 		}
 
 		[Test]
+		public void ContentHistoryChangesSearch_FiltersByContentIdNameAndType()
+		{
+			var changes = new[]
+			{
+				new BeamContentHistoryChangelistEntry { FullId = "currency.gems", Name = "gems", TypeName = "economy" },
+				new BeamContentHistoryChangelistEntry { FullId = "items.sword", Name = "Bronze Sword", TypeName = "items" },
+				new BeamContentHistoryChangelistEntry { FullId = "stores.shop", Name = "Starter Shop", TypeName = "stores" }
+			};
+
+			Assert.That(ContentHistoryChangesSearch.Filter(changes, "currency"),
+				Is.EqualTo(new[] { changes[0] }));
+			Assert.That(ContentHistoryChangesSearch.Filter(changes, "ECONOMY"),
+				Is.EqualTo(new[] { changes[0] }));
+			Assert.That(ContentHistoryChangesSearch.Filter(changes, " starter "),
+				Is.EqualTo(new[] { changes[2] }));
+		}
+
+		[Test]
+		public void ContentHistoryChangesSearch_ReturnsEveryEntryForAnEmptySearch()
+		{
+			var changes = new[]
+			{
+				new BeamContentHistoryChangelistEntry { FullId = "currency.gems" },
+				new BeamContentHistoryChangelistEntry { FullId = "items.sword" }
+			};
+
+			Assert.That(ContentHistoryChangesSearch.Filter(changes, "  "), Is.SameAs(changes));
+		}
+
+		[Test]
 		public void ContentHistoryStreamParser_TryParseChanges_RejectsTerminalReportsWithoutReplacingStreamEntries()
 		{
 			const string streamJson = "{\"ts\":1,\"type\":\"stream\",\"data\":{\"ContentEntries\":[{\"fullId\":\"stores.Store_Coin\",\"typeName\":\"stores\",\"changeStatus\":4,\"jsonFilePath\":\"content.json\"}]}}";
@@ -167,6 +198,86 @@ namespace Beamable.Editor.Tests
 
 			Assert.That(ContentHistoryStreamParser.TryParseChanges(streamJson, out var entries), Is.False);
 			Assert.That(entries, Is.Empty);
+		}
+
+		[Test]
+		public void ContentHistoryStreamParser_ParsesMetadataOnlyChangelistEntries()
+		{
+			const string streamJson = "{\"type\":\"stream\",\"data\":{\"Changelist\":{\"publishedAt\":1234,\"added\":{\"currency.gems\":{\"newVersion\":\"1\",\"newChecksum\":\"new\",\"newTags\":[\"currency\"]}},\"modified\":{\"items.sword\":{\"oldVersion\":\"1\",\"newVersion\":\"2\",\"oldTags\":[\"old\"],\"newTags\":[\"new\"]}},\"removed\":{\"stores.shop\":{\"oldVersion\":\"3\",\"oldChecksum\":\"old\",\"oldTags\":[\"store\"]}}}}}";
+
+			var parsed = ContentHistoryStreamParser.TryParseChangelist(streamJson, out var entries);
+
+			Assert.That(parsed, Is.True);
+			Assert.That(entries, Has.Length.EqualTo(3));
+			Assert.That(entries.Select(entry => entry.FullId), Is.EqualTo(new[] { "currency.gems", "items.sword", "stores.shop" }));
+			Assert.That(entries.Select(entry => entry.TypeName), Is.EqualTo(new[] { "currency", "items", "stores" }));
+			Assert.That(entries.Select(entry => entry.Name), Is.EqualTo(new[] { "gems", "sword", "shop" }));
+			Assert.That(entries.Select(entry => entry.ChangeStatus), Is.EqualTo(new[]
+			{
+				(int)ContentStatus.Created,
+				(int)ContentStatus.Modified,
+				(int)ContentStatus.Deleted
+			}));
+			Assert.That(entries.All(entry => entry.ChangeDate == 1234), Is.True);
+			Assert.That(entries.All(entry => string.IsNullOrEmpty(entry.JsonFilePath)), Is.True);
+			Assert.That(entries[0].NewTags, Is.EqualTo(new[] { "currency" }));
+			Assert.That(entries[1].OldTags, Is.EqualTo(new[] { "old" }));
+			Assert.That(entries[1].NewTags, Is.EqualTo(new[] { "new" }));
+			Assert.That(entries[2].OldTags, Is.EqualTo(new[] { "store" }));
+		}
+
+		[Test]
+		public void ContentHistoryStreamParser_LeavesMalformedContentIdsListable()
+		{
+			const string streamJson = "{\"type\":\"stream\",\"data\":{\"Changelist\":{\"publishedAt\":1,\"added\":{\"malformed\":{\"newVersion\":\"1\"}}}}}";
+
+			var parsed = ContentHistoryStreamParser.TryParseChangelist(streamJson, out var entries);
+
+			Assert.That(parsed, Is.True);
+			Assert.That(entries, Has.Length.EqualTo(1));
+			Assert.That(entries[0].FullId, Is.EqualTo("malformed"));
+			Assert.That(entries[0].TypeName, Is.Empty);
+			Assert.That(entries[0].Name, Is.EqualTo("malformed"));
+		}
+
+		[TestCase("{\"type\":\"eof\",\"data\":{}}")]
+		[TestCase("{\"type\":\"stream\",\"data\":{}}")]
+		public void ContentHistoryStreamParser_RejectsInvalidChangelistStream(string streamJson)
+		{
+			var parsed = ContentHistoryStreamParser.TryParseChangelist(streamJson, out var entries);
+
+			Assert.That(parsed, Is.False);
+			Assert.That(entries, Is.Empty);
+		}
+
+		[Test]
+		public void ContentHistoryRequestFactory_CreatesSingleContentSyncRequest()
+		{
+			var request = ContentHistoryRequestFactory.CreateContentSync("manifest-123", "currency.gems");
+
+			Assert.That(request.manifestUid, Is.EqualTo("manifest-123"));
+			Assert.That(request.contentIds, Is.EqualTo(new[] { "currency.gems" }));
+		}
+
+		[Test]
+		public void ContentHistoryRequestSlot_CancelsReplacedRequestAndKeepsTheNewestCurrent()
+		{
+			var cancelled = new List<object>();
+			var slot = new ContentHistoryRequestSlot<object>(cancelled.Add);
+			var first = new object();
+			var second = new object();
+
+			slot.Replace(first);
+			slot.Replace(second);
+			slot.Release(first);
+
+			Assert.That(cancelled, Is.EqualTo(new[] { first }));
+			Assert.That(slot.IsCurrent(second), Is.True);
+
+			slot.CancelActive();
+
+			Assert.That(cancelled, Is.EqualTo(new[] { first, second }));
+			Assert.That(slot.IsCurrent(second), Is.False);
 		}
 
 		[Test]

--- a/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
+++ b/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs
@@ -4,6 +4,7 @@ using Beamable.Editor.BeamCli.Commands;
 using Beamable.Content;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -170,6 +171,119 @@ namespace Beamable.Editor.Tests
 		public void ContentWindowStatus_ContainsHistoryMode()
 		{
 			Assert.That(Enum.IsDefined(typeof(ContentWindowStatus), "History"), Is.True);
+		}
+
+		[Test]
+		public void ContentHistoryTimeBuckets_GroupsRecentPublishesAndArchivesOlderMonths()
+		{
+			var now = new DateTime(2026, 7, 15, 12, 0, 0, DateTimeKind.Local);
+			var buckets = ContentHistoryTimeBuckets.Create(new[]
+			{
+				HistoryEntry("today", now.AddHours(-1)),
+				HistoryEntry("this-week", now.Date.AddDays(-1)),
+				HistoryEntry("earlier-this-month", now.Date.AddDays(-8)),
+				HistoryEntry("june", new DateTime(2026, 6, 30, 12, 0, 0, DateTimeKind.Local)),
+				HistoryEntry("may", new DateTime(2026, 5, 31, 12, 0, 0, DateTimeKind.Local)),
+				HistoryEntry("april", new DateTime(2026, 4, 30, 12, 0, 0, DateTimeKind.Local)),
+				HistoryEntry("last-year", new DateTime(2025, 12, 31, 12, 0, 0, DateTimeKind.Local))
+			}, now);
+
+			Assert.That(buckets.Select(bucket => bucket.Label), Is.EqualTo(new[]
+			{
+				"Today", "This week", "Earlier this month", "June 2026", "May 2026", "2026", "2025"
+			}));
+			Assert.That(buckets.Take(3).All(bucket => bucket.IsExpandedByDefault), Is.True);
+			Assert.That(buckets[3].IsExpandedByDefault, Is.False);
+			Assert.That(buckets[5].Children.Select(bucket => bucket.Label), Is.EqualTo(new[] { "April 2026" }));
+			Assert.That(buckets[6].Children.Select(bucket => bucket.Label), Is.EqualTo(new[] { "December 2025" }));
+		}
+
+		[Test]
+		public void ContentHistoryTimeBuckets_ReturnsAncestorKeysForOlderPublish()
+		{
+			var now = new DateTime(2026, 7, 15, 12, 0, 0, DateTimeKind.Local);
+			var entry = HistoryEntry("april", new DateTime(2026, 4, 30, 12, 0, 0, DateTimeKind.Local));
+			var buckets = ContentHistoryTimeBuckets.Create(new[] { entry }, now);
+
+			Assert.That(ContentHistoryTimeBuckets.GetAncestorKeys(buckets, entry.ManifestUid),
+				Is.EqualTo(new[] { "year:2026", "month:2026-04" }));
+		}
+
+		[Test]
+		public void ContentHistoryTimeBuckets_UsesMondayAsTheStartOfThisWeek()
+		{
+			var monday = new DateTime(2026, 7, 6, 12, 0, 0, DateTimeKind.Local);
+			var buckets = ContentHistoryTimeBuckets.Create(new[]
+			{
+				HistoryEntry("sunday", monday.AddDays(-1)),
+				HistoryEntry("saturday", monday.AddDays(-2))
+			}, monday);
+
+			Assert.That(buckets.Select(bucket => bucket.Label), Is.EqualTo(new[] { "Earlier this month" }));
+			Assert.That(buckets[0].EntryCount, Is.EqualTo(2));
+		}
+
+		[Test]
+		public void ContentHistoryTimeBuckets_ExpandingMonthShowsEveryPublishInThatMonth()
+		{
+			var now = new DateTime(2026, 7, 15, 12, 0, 0, DateTimeKind.Local);
+			var buckets = ContentHistoryTimeBuckets.Create(Enumerable.Range(1, 12)
+				.Select(day => HistoryEntry($"may-{day}", new DateTime(2026, 5, day, 12, 0, 0, DateTimeKind.Local)))
+				.ToArray(), now);
+			var mayBucket = buckets.Single(bucket => bucket.Label == "May 2026");
+
+			var rows = ContentHistoryTimeBuckets.BuildVisibleRows(buckets, new HashSet<string> { mayBucket.Key });
+
+			Assert.That(rows.Count(row => row.Entry != null), Is.EqualTo(12));
+		}
+
+		[Test]
+		public void ContentHistoryTimeBuckets_DefaultWeekCanBeCollapsed()
+		{
+			var now = new DateTime(2026, 7, 15, 12, 0, 0, DateTimeKind.Local);
+			var buckets = ContentHistoryTimeBuckets.Create(new[]
+			{
+				HistoryEntry("today", now.AddHours(-1)),
+				HistoryEntry("this-week", now.Date.AddDays(-1))
+			}, now);
+			var expandedKeys = ContentHistoryTimeBuckets.GetDefaultExpandedKeys(buckets).ToHashSet();
+
+			expandedKeys.Remove("this-week");
+			var rows = ContentHistoryTimeBuckets.BuildVisibleRows(buckets, expandedKeys);
+
+			Assert.That(rows.Any(row => row.Entry?.ManifestUid == "today"), Is.True);
+			Assert.That(rows.Any(row => row.Entry?.ManifestUid == "this-week"), Is.False);
+		}
+
+		[TestCase(false, false, ContentHistoryRowVisualState.Normal)]
+		[TestCase(false, true, ContentHistoryRowVisualState.Hovered)]
+		[TestCase(true, false, ContentHistoryRowVisualState.Selected)]
+		[TestCase(true, true, ContentHistoryRowVisualState.Selected)]
+		public void ContentHistoryRowInteraction_PrioritizesSelectionOverHover(bool isSelected, bool isHovered,
+			ContentHistoryRowVisualState expectedState)
+		{
+			Assert.That(ContentHistoryRowInteraction.GetVisualState(isSelected, isHovered), Is.EqualTo(expectedState));
+		}
+
+		[TestCase(null, null, false)]
+		[TestCase("entry:one", "entry:one", false)]
+		[TestCase(null, "entry:one", true)]
+		[TestCase("entry:one", "bucket:this-week", true)]
+		[TestCase("entry:one", null, true)]
+		public void ContentHistoryRowInteraction_RepaintsOnlyWhenTheHoveredRowChanges(string currentRowKey,
+			string nextRowKey, bool shouldRepaint)
+		{
+			Assert.That(ContentHistoryRowInteraction.ShouldRepaint(currentRowKey, nextRowKey), Is.EqualTo(shouldRepaint));
+		}
+
+		private static BeamContentHistoryEntry HistoryEntry(string manifestUid, DateTime createdAt)
+		{
+			return new BeamContentHistoryEntry
+			{
+				ManifestUid = manifestUid,
+				CreatedDate = new DateTimeOffset(createdAt).ToUnixTimeMilliseconds(),
+				AffectedContentIds = Array.Empty<string>()
+			};
 		}
 	}
 }

--- a/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs.meta
+++ b/client/Packages/com.beamable/Tests/Editor/ContentHistoryPaginationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 610891e05a695514b94fc011523f2ee9


### PR DESCRIPTION
Fixes #4509 

# Description

Adds a new Content History tab for inspecting published content changes without leaving the editor.

- Browse publishes in time-based groups, including older monthly history.
- Search by manifest or content ID to narrow the audit trail.
- See publish author, changed-content count, and UTC ISO 8601 timestamps.
- Inspect a publish’s changelist and view historical content in a read-only preview.
- Restore selected historical content when needed, with loading and failure states kept separate from the history list.
- Includes fixes for search reset behavior, manifest ID copying, and history-stream resilience.

Tests: Unity EditMode content-history suite — 68/68 passing.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
