### PR TITLE
Allow opting out of the init-time commerce SKU request #4595

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added Content Manager publish history with diff inspection, pagination, preview, and local file restoration.
 - Add support for the version 5 of the Unity IAP package
+- Added `CoreConfiguration.SkipCommerceInitialization` to opt out of automatic purchaser initialization and its commerce SKU request. [4595](https://github.com/beamable/BeamableProduct/issues/4595)
 
 ### Fixed
 

--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added Content Manager publish history with diff inspection, pagination, preview, and local file restoration.
 - Add support for the version 5 of the Unity IAP package
-- Added `CoreConfiguration.SkipCommerceInitialization` to opt out of automatic purchaser initialization and its commerce SKU request. [4595](https://github.com/beamable/BeamableProduct/issues/4595)
+- Added `CoreConfiguration.SkipCommerceInitialization` to opt out of automatic purchaser initialization and its commerce SKU request.
 
 ### Fixed
 

--- a/client/Packages/com.beamable/Runtime/Modules/CoreConfiguration.cs
+++ b/client/Packages/com.beamable/Runtime/Modules/CoreConfiguration.cs
@@ -1,7 +1,9 @@
 using System;
 using Beamable.Api;
 using Beamable.Api.Commerce;
+using Beamable.Api.Payments;
 using Beamable.Common.Content;
+using Beamable.Common.Dependencies;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -87,6 +89,14 @@ namespace Beamable
 				 "in a buffer and optimistically simulate the effects locally in memory. When your player comes back " +
 				 "online, the buffer will be replayed. If this isn't desirable, you should disable the feature.")]
 		public OfflineStrategy InventoryOfflineMode = OfflineStrategy.Optimistic;
+
+		/// <summary>
+		/// When enabled, Beamable skips automatic purchasing initialization and does not request commerce SKUs during <see cref="BeamContext"/> initialization.
+		/// </summary>
+		[Header("Commerce")]
+		[Tooltip("When enabled, Beamable skips automatic purchasing initialization and does not request commerce SKUs when a BeamContext initializes.")]
+		public bool SkipCommerceInitialization = false;
+
 		[Tooltip(@"The CommerceService will use the PlayerStoreView.nextDeltaSeconds value
 to automatically refresh the store content.
 
@@ -268,6 +278,22 @@ The default is 60 seconds.
 			}
 #endif
 			return new string[] { };
+		}
+	}
+
+	[BeamContextSystem]
+	public static class BeamablePurchaserConfigurationRegister
+	{
+		[RegisterBeamableDependencies(1)]
+		public static void RegisterServices(IDependencyBuilder builder)
+		{
+			if (!CoreConfiguration.Instance.SkipCommerceInitialization)
+			{
+				return;
+			}
+
+			builder.RemoveIfExists<IBeamablePurchaser>();
+			builder.AddSingleton<IBeamablePurchaser, DummyPurchaser>();
 		}
 	}
 	

--- a/client/Packages/com.beamable/Tests/Runtime/Beamable/BeamContextInitTests.cs
+++ b/client/Packages/com.beamable/Tests/Runtime/Beamable/BeamContextInitTests.cs
@@ -1,12 +1,16 @@
 using Beamable;
+using Beamable.Api.Payments;
 using Beamable.Common;
 using Beamable.Common.Api;
 using Beamable.Common.Api.Auth;
+using Beamable.Common.Dependencies;
 using Beamable.Platform.Tests;
+using Beamable.Purchasing;
 using Beamable.Tests.Runtime;
 using NUnit.Framework;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -180,6 +184,73 @@ namespace Tests.Runtime.Beamable
 				LogAssert.ignoreFailingMessages = false;
 			}
 		}
+	}
+
+	public class CommerceInitializationTests : BeamContextTest
+	{
+		private bool _originalSkipCommerceInitialization;
+		private MockPlatformRoute<GetSKUsResponse> _getSkusRoute;
+
+		[SetUp]
+		public void SaveConfiguration()
+		{
+			_originalSkipCommerceInitialization = CoreConfiguration.Instance.SkipCommerceInitialization;
+		}
+
+		[TearDown]
+		public void RestoreConfiguration()
+		{
+			CoreConfiguration.Instance.SkipCommerceInitialization = _originalSkipCommerceInitialization;
+		}
+
+		protected override void OnRegister(IDependencyBuilder builder)
+		{
+			base.OnRegister(builder);
+			UnityBeamablePurchaserRegister.RegisterServices(builder);
+			BeamablePurchaserConfigurationRegister.RegisterServices(builder);
+		}
+
+		protected override void OnInit(MockBeamContext ctx)
+		{
+			base.OnInit(ctx);
+			_getSkusRoute = ctx.Requester.MockRequest<GetSKUsResponse>(Method.GET, "/basic/commerce/skus")
+				.WithResponse(new GetSKUsResponse
+				{
+					skus = new SKUDefinitions
+					{
+						version = 1,
+						created = string.Empty,
+						definitions = new List<SKU>()
+					}
+				})
+				.WithToken(MockBeamContext.ACCESS_TOKEN);
+		}
+
+		[UnityTest]
+		public IEnumerator SkippedCommerceInitializationUsesDummyPurchaserWithoutRequestingSkus()
+		{
+			CoreConfiguration.Instance.SkipCommerceInitialization = true;
+
+			TriggerContextInit();
+			yield return Context.OnReady.ToYielder();
+
+			Assert.AreEqual(0, _getSkusRoute.CallCount);
+			Assert.IsInstanceOf<DummyPurchaser>(Context.Api.BeamableIAP.GetResult());
+		}
+
+#if !BEAMABLE_PURCHASING_IMPLEMENTATION_DISABLED
+		[UnityTest]
+		public IEnumerator DefaultCommerceInitializationUsesUnityPurchaserAndRequestsSkus()
+		{
+			CoreConfiguration.Instance.SkipCommerceInitialization = false;
+
+			TriggerContextInit();
+			yield return Context.OnReady.ToYielder();
+
+			Assert.AreEqual(1, _getSkusRoute.CallCount);
+			Assert.IsInstanceOf<UnityBeamablePurchaser>(Context.Api.BeamableIAP.GetResult());
+		}
+#endif
 	}
 
 }

--- a/client/Packages/com.beamable/Tests/Runtime/Unity.Beamable.Tests.asmdef
+++ b/client/Packages/com.beamable/Tests/Runtime/Unity.Beamable.Tests.asmdef
@@ -10,6 +10,7 @@
         "Beamable.JsonSerializable",
         "Unity.Addressables",
         "Unity.Beamable.Runtime.Common",
+        "Unity.Beamable.Purchasing",
         "Beamable.SmallerJSON"
     ],
     "optionalUnityReferences": [


### PR DESCRIPTION
Fixes #4595 

## Summary

- Adds `CoreConfiguration.SkipCommerceInitialization`, defaulting to `false`.
- When enabled, Beamable registers `DummyPurchaser` and skips the init-time `GET /basic/commerce/skus` request.
- We apply the override from `Unity.Beamable` because it already references `Unity.Beamable.Purchasing`. Referencing `CoreConfiguration` from the purchasing assembly would create a circular assembly dependency.

## Testing

- Added Play Mode coverage for both the default and opt-out initialization paths.
- Manual A/B testing, when config is enabled `GetSkus` doesn't get called and the runtime purchaser becomes the `DummyPurchaser`.

##Screenshot
<img width="549" height="64" alt="image" src="https://github.com/user-attachments/assets/e36ff1b9-3a49-4979-bdbb-b7dcc53be44d" />

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
