### PR TITLE
Roll bootstrap global.json forward to any installed .NET SDK feature band

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the Content window Snapshot tab hanging at "Loading snapshots" when snapshots in different realm folders share a name (e.g. `LastPublished-global.json` auto snapshots from publishing to multiple realms)
 - Unity SDK version headers were not being sent by default.
 - Fixed `BeamContext` initialization throwing `IndexOutOfRangeException` from its own retry handler when initialization kept failing with infinite context retries enabled, which masked the underlying initialization error.
+- Fixed CLI bootstrap failing when the installed .NET SDK is a supported version newer than the pinned feature band (for example 10.0.301 when the pin is 10.0.100); the generated `global.json` now rolls forward to any compatible installed SDK.
 
 ## [5.1.2] - 2026-07-16
 

--- a/client/Packages/com.beamable/Editor/Dotnet/DotnetUtil.cs
+++ b/client/Packages/com.beamable/Editor/Dotnet/DotnetUtil.cs
@@ -29,7 +29,10 @@ namespace Beamable.Editor.Dotnet
 		public static readonly string DOTNET_GLOBAL_CONFIG_PATH = "global.json";
 
 		public const string DOTNET_TEMPLATE_ARG_VERSION = "__DOTNET_VERSION__";
-		public const string DOTNET_TEMPLATE_GLOBAL_CONFIG = "{\n  \"sdk\": {\n    \"version\": \"" + DOTNET_TEMPLATE_ARG_VERSION +  "\"\n} \n}";
+		// rollForward:latestFeature treats the templated version as a floor so the written global.json
+		// resolves against any newer same-major SDK the user has installed (matching the >= detection in
+		// DotnetInfoResult), rather than demanding that exact feature band and failing when it is absent.
+		public const string DOTNET_TEMPLATE_GLOBAL_CONFIG = "{\n  \"sdk\": {\n    \"version\": \"" + DOTNET_TEMPLATE_ARG_VERSION +  "\",\n    \"rollForward\": \"latestFeature\"\n} \n}";
 
 		static bool DotnetHandled
 		{


### PR DESCRIPTION
# Brief Description

The Beamable editor bootstrap (`DotnetUtil`) writes a `global.json` pinning the **exact** floor SDK version (`DOTNET_10_VERSION = 10.0.100`, or `DOTNET_8_VERSION = 8.0.302`) with **no `rollForward`**. Because .NET's default resolution (`latestPatch`) does not cross feature bands, a machine that has a newer *same-major* SDK — e.g. `10.0.301` — but not the exact `10.0.1xx` band fails to bootstrap the CLI:

```
Requested SDK version: 10.0.100
A compatible .NET SDK was not found.
```

This is self-contradictory: `DotnetInfoResult` accepts any `version >= floor` (`HasNet10`/`HasNet8`), then writes a `global.json` demanding the exact band it never required. Since .NET 10 is servicing quickly (10.0.100 → 10.0.301 already), most current .NET 10 installs hit this.

## Fix

Add `"rollForward": "latestFeature"` to the `global.json` template so the pinned version acts as a **floor**, resolving against any newer same-major SDK installed — matching the `>=` detection the SDK already does. `latestFeature` stays within a major (an `8.0.302` floor will not silently jump to 9.x/10.x), which respects the supported-8-or-10 matrix. Validated locally: `10.0.100` floor resolves `10.0.301`; `8.0.302` floor stays on 8.x.

Unity-SDK-only change; no CLI/nuget release required.

# Checklist

* [x] CHANGELOG.md updated (`client/Packages/com.beamable/CHANGELOG.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)