### PR TITLE
Fix orphaned Unity meta files during generated code cleanup

### DIFF
--- a/.github/workflows/buildPR.yml
+++ b/.github/workflows/buildPR.yml
@@ -248,20 +248,8 @@ jobs:
       - name: Build and Install BEAM CLI 
         working-directory: ./
         run: |
-          CLI_VERSION=$(jq -r .nugetPackageVersion client/Packages/com.beamable/Runtime/Environment/Resources/versions-default.json)
-          echo "Pinned CLI version: $CLI_VERSION"
-          case "$CLI_VERSION" in
-            0.0.123*)
-              echo "Local dev version detected; building CLI from source."
-              ./setup.sh
-              SKIP_GENERATION=true ./dev.sh --skip-unreal
-              ;;
-            *)
-              echo "Released version detected; installing Beamable.Tools $CLI_VERSION."
-              dotnet tool install Beamable.Tools --version "$CLI_VERSION" --global
-              echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
-              ;;
-          esac
+          ./setup.sh
+          SKIP_GENERATION=true ./dev.sh --skip-unreal
         env:
           PROJECT_DIR_OVERRIDE: ${{ github.workspace }}/NugetBuildDir/
       - name: Check Beam CLI
@@ -417,20 +405,8 @@ jobs:
       - name: Build and Install BEAM CLI
         working-directory: ./
         run: |
-          CLI_VERSION=$(jq -r .nugetPackageVersion client/Packages/com.beamable/Runtime/Environment/Resources/versions-default.json)
-          echo "Pinned CLI version: $CLI_VERSION"
-          case "$CLI_VERSION" in
-            0.0.123*)
-              echo "Local dev version detected; building CLI from source."
-              ./setup.sh
-              SKIP_GENERATION=true ./dev.sh --skip-unreal
-              ;;
-            *)
-              echo "Released version detected; installing Beamable.Tools $CLI_VERSION."
-              dotnet tool install Beamable.Tools --version "$CLI_VERSION" --global
-              echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
-              ;;
-          esac
+          ./setup.sh
+          SKIP_GENERATION=true ./dev.sh --skip-unreal
         env:
           PROJECT_DIR_OVERRIDE: ${{ github.workspace }}/NugetBuildDir/
       - name: Check Beam CLI
@@ -579,20 +555,8 @@ jobs:
       - name: Build and Install BEAM CLI 
         working-directory: ./
         run: |
-          CLI_VERSION=$(jq -r .nugetPackageVersion client/Packages/com.beamable/Runtime/Environment/Resources/versions-default.json)
-          echo "Pinned CLI version: $CLI_VERSION"
-          case "$CLI_VERSION" in
-            0.0.123*)
-              echo "Local dev version detected; building CLI from source."
-              ./setup.sh
-              SKIP_GENERATION=true ./dev.sh
-              ;;
-            *)
-              echo "Released version detected; installing Beamable.Tools $CLI_VERSION."
-              dotnet tool install Beamable.Tools --version "$CLI_VERSION" --global
-              echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
-              ;;
-          esac
+          ./setup.sh
+          SKIP_GENERATION=true ./dev.sh
         env:
           PROJECT_DIR_OVERRIDE: ${{ github.workspace }}/NugetBuildDir/
       - name: Check Beam CLI

--- a/.github/workflows/buildPR.yml
+++ b/.github/workflows/buildPR.yml
@@ -248,8 +248,20 @@ jobs:
       - name: Build and Install BEAM CLI 
         working-directory: ./
         run: |
-          ./setup.sh
-          SKIP_GENERATION=true ./dev.sh --skip-unreal
+          CLI_VERSION=$(jq -r .nugetPackageVersion client/Packages/com.beamable/Runtime/Environment/Resources/versions-default.json)
+          echo "Pinned CLI version: $CLI_VERSION"
+          case "$CLI_VERSION" in
+            0.0.123*)
+              echo "Local dev version detected; building CLI from source."
+              ./setup.sh
+              SKIP_GENERATION=true ./dev.sh --skip-unreal
+              ;;
+            *)
+              echo "Released version detected; installing Beamable.Tools $CLI_VERSION."
+              dotnet tool install Beamable.Tools --version "$CLI_VERSION" --global
+              echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+              ;;
+          esac
         env:
           PROJECT_DIR_OVERRIDE: ${{ github.workspace }}/NugetBuildDir/
       - name: Check Beam CLI
@@ -405,8 +417,20 @@ jobs:
       - name: Build and Install BEAM CLI
         working-directory: ./
         run: |
-          ./setup.sh
-          SKIP_GENERATION=true ./dev.sh --skip-unreal
+          CLI_VERSION=$(jq -r .nugetPackageVersion client/Packages/com.beamable/Runtime/Environment/Resources/versions-default.json)
+          echo "Pinned CLI version: $CLI_VERSION"
+          case "$CLI_VERSION" in
+            0.0.123*)
+              echo "Local dev version detected; building CLI from source."
+              ./setup.sh
+              SKIP_GENERATION=true ./dev.sh --skip-unreal
+              ;;
+            *)
+              echo "Released version detected; installing Beamable.Tools $CLI_VERSION."
+              dotnet tool install Beamable.Tools --version "$CLI_VERSION" --global
+              echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+              ;;
+          esac
         env:
           PROJECT_DIR_OVERRIDE: ${{ github.workspace }}/NugetBuildDir/
       - name: Check Beam CLI
@@ -555,8 +579,20 @@ jobs:
       - name: Build and Install BEAM CLI 
         working-directory: ./
         run: |
-          ./setup.sh
-          SKIP_GENERATION=true ./dev.sh
+          CLI_VERSION=$(jq -r .nugetPackageVersion client/Packages/com.beamable/Runtime/Environment/Resources/versions-default.json)
+          echo "Pinned CLI version: $CLI_VERSION"
+          case "$CLI_VERSION" in
+            0.0.123*)
+              echo "Local dev version detected; building CLI from source."
+              ./setup.sh
+              SKIP_GENERATION=true ./dev.sh
+              ;;
+            *)
+              echo "Released version detected; installing Beamable.Tools $CLI_VERSION."
+              dotnet tool install Beamable.Tools --version "$CLI_VERSION" --global
+              echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+              ;;
+          esac
         env:
           PROJECT_DIR_OVERRIDE: ${{ github.workspace }}/NugetBuildDir/
       - name: Check Beam CLI

--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Portal extension scanning no longer excludes sym linked package files
+- Fixed orphaned Unity .meta files left behind when cleaning generated Beamable source directories.
 
 ## [7.2.2] - 2026-07-16
 

--- a/cli/cli/Commands/UnityCommands/DownloadAllNugetDepsToUnityCommand.cs
+++ b/cli/cli/Commands/UnityCommands/DownloadAllNugetDepsToUnityCommand.cs
@@ -43,9 +43,9 @@ public class DownloadAllNugetDepsToUnityCommand : AtomicCommand<DownloadAllNuget
 			throw new CliException("Cannot download nuget packages for developer 0.0.123 version.");
 		}
 
-		UnityProjectUtil.DeleteAllFilesWithExtensions(Path.Combine(info.packageFolder, "Common"), new string[]{".cs", ".cs.meta"});
-		UnityProjectUtil.DeleteAllFilesWithExtensions(Path.Combine(infoServer.packageFolder, "SharedRuntime"), new string[]{".cs", ".cs.meta"});
-		UnityProjectUtil.DeleteAllFilesWithExtensions(Path.Combine(infoServer.packageFolder, "Runtime/Common"), new string[]{".cs", ".cs.meta"});
+		UnityProjectUtil.DeleteAllFilesWithExtensionsAndEmptyDirectories(Path.Combine(info.packageFolder, "Common"), new string[]{".cs", ".cs.meta"});
+		UnityProjectUtil.DeleteAllFilesWithExtensionsAndEmptyDirectories(Path.Combine(infoServer.packageFolder, "SharedRuntime"), new string[]{".cs", ".cs.meta"});
+		UnityProjectUtil.DeleteAllFilesWithExtensionsAndEmptyDirectories(Path.Combine(infoServer.packageFolder, "Runtime/Common"), new string[]{".cs", ".cs.meta"});
 
 		await UnityProjectUtil.DownloadPackage("Beamable.Common", info.beamableNugetVersion,
 			"content/sourceCode/", Path.Combine(info.packageFolder, "Common"));

--- a/cli/cli/Commands/UnityCommands/ReleaseSharedUnityCodeCommand.cs
+++ b/cli/cli/Commands/UnityCommands/ReleaseSharedUnityCodeCommand.cs
@@ -96,7 +96,7 @@ public class ReleaseSharedUnityCodeCommand : AtomicCommand<ReleaseSharedUnityCod
 		Log.Information($"Copying code src=[{args.csProjPath}] to dst=[{dstPath}]");
 
 		// clean up all old cs and meta files, while leaving possible Unity specific files, like asmdef files.
-		UnityProjectUtil.DeleteAllFilesWithExtensions(dstPath, new string[]{".cs", ".cs.meta"});
+		UnityProjectUtil.DeleteAllFilesWithExtensionsAndEmptyDirectories(dstPath, new string[]{".cs", ".cs.meta"});
 
 		var srcDir = Path.Combine(Path.GetDirectoryName(args.csProjPath), args.relativeSrc);
 		UnityProjectUtil.CopyProject(srcDir, dstPath);

--- a/cli/cli/Services/Unity/UnityProjectUtil.cs
+++ b/cli/cli/Services/Unity/UnityProjectUtil.cs
@@ -302,11 +302,17 @@ public static class UnityProjectUtil
 		public string version;
 	}
 
-	public static void DeleteAllFilesWithExtensions(string folder, string[] extensions)
+	/// <summary>
+	/// Deletes files with the specified extensions, then removes any descendant directories left empty.
+	/// Directories containing Unity-owned files, such as assembly definitions, are preserved.
+	/// </summary>
+	/// <param name="folder">The root folder to clean. The root folder itself is never deleted.</param>
+	/// <param name="extensions">The file extensions to delete.</param>
+	public static void DeleteAllFilesWithExtensionsAndEmptyDirectories(string folder, string[] extensions)
 	{
 		if (!Directory.Exists(folder))
 			return;
-		
+
 		foreach (var ext in extensions)
 		{
 			var filesToDelete = Directory.GetFiles(folder, $"*{ext}", SearchOption.AllDirectories);
@@ -315,6 +321,24 @@ public static class UnityProjectUtil
 				File.SetAttributes(file, FileAttributes.None);
 				File.Delete(file);
 			}
+		}
+
+		var directories = Directory.GetDirectories(folder, "*", SearchOption.AllDirectories)
+			.OrderByDescending(directory => directory.Length);
+
+		foreach (var directory in directories)
+		{
+			if (Directory.EnumerateFileSystemEntries(directory).Any())
+				continue;
+
+			Directory.Delete(directory);
+
+			var metaFile = $"{directory}.meta";
+			if (!File.Exists(metaFile))
+				continue;
+
+			File.SetAttributes(metaFile, FileAttributes.None);
+			File.Delete(metaFile);
 		}
 	}
 }

--- a/cli/tests/Unity/UnityProjectUtilTests.cs
+++ b/cli/tests/Unity/UnityProjectUtilTests.cs
@@ -1,0 +1,62 @@
+using cli.Services.Unity;
+using NUnit.Framework;
+using System.IO;
+
+namespace tests.Unity;
+
+public class UnityProjectUtilTests
+{
+	private string _root = null!;
+
+	[SetUp]
+	public void SetUp()
+	{
+		_root = Path.Combine(Path.GetTempPath(), "unity-project-util-tests", Path.GetRandomFileName());
+		Directory.CreateDirectory(_root);
+	}
+
+	[TearDown]
+	public void TearDown()
+	{
+		if (Directory.Exists(_root))
+			Directory.Delete(_root, true);
+	}
+
+	[Test]
+	public void DeleteAllFilesWithExtensionsAndEmptyDirectories_RemovesEmptyDirectoriesAndTheirMetaFiles()
+	{
+		var contractsDirectory = Path.Combine(_root, "Contracts");
+		var bundlesServiceDirectory = Path.Combine(contractsDirectory, "BundlesService");
+		var bundlesServiceMetaFile = $"{bundlesServiceDirectory}.meta";
+		Directory.CreateDirectory(bundlesServiceDirectory);
+		File.WriteAllText(Path.Combine(bundlesServiceDirectory, "BundleTagInfo.cs"), string.Empty);
+		File.WriteAllText(Path.Combine(bundlesServiceDirectory, "BundleTagInfo.cs.meta"), string.Empty);
+		File.WriteAllText(bundlesServiceMetaFile, string.Empty);
+
+		UnityProjectUtil.DeleteAllFilesWithExtensionsAndEmptyDirectories(_root, new[] { ".cs", ".cs.meta" });
+
+		Assert.That(Directory.Exists(_root), Is.True);
+		Assert.That(Directory.Exists(bundlesServiceDirectory), Is.False);
+		Assert.That(File.Exists(bundlesServiceMetaFile), Is.False);
+	}
+
+	[Test]
+	public void DeleteAllFilesWithExtensionsAndEmptyDirectories_PreservesDirectoriesContainingUnityOwnedFiles()
+	{
+		var generatedDirectory = Path.Combine(_root, "Generated");
+		var generatedDirectoryMetaFile = $"{generatedDirectory}.meta";
+		var assemblyDefinitionFile = Path.Combine(generatedDirectory, "Beamable.Generated.asmdef");
+		var generatedSourceFile = Path.Combine(generatedDirectory, "GeneratedSource.cs");
+		Directory.CreateDirectory(generatedDirectory);
+		File.WriteAllText(generatedSourceFile, string.Empty);
+		File.WriteAllText(assemblyDefinitionFile, string.Empty);
+		File.WriteAllText(generatedDirectoryMetaFile, string.Empty);
+
+		UnityProjectUtil.DeleteAllFilesWithExtensionsAndEmptyDirectories(_root, new[] { ".cs", ".cs.meta" });
+
+		Assert.That(File.Exists(generatedSourceFile), Is.False);
+		Assert.That(Directory.Exists(generatedDirectory), Is.True);
+		Assert.That(File.Exists(assemblyDefinitionFile), Is.True);
+		Assert.That(File.Exists(generatedDirectoryMetaFile), Is.True);
+	}
+}


### PR DESCRIPTION
# Brief Description

The fix has been implemented after noticing warning existing meta files for empty directories in `ckages/com.beamable/Common/Runtime/BeamCli/Contracts/BundlesService` whenever a unity project is opened after `V6 RC 7`.

Removes empty directories and their .meta files after `Beamable.Tools` cleans generated Unity source. Directories containing Unity-owned files such as `.asmdef` remain untouched.
Added tests covering the `BundlesService.meta` regression and directory preservation.

Updated PR builds to install the CLI version pinned by the Unity SDK, preventing generated-code mismatches with the locally built CLI.

## Validation

Focused tests pass
CLI solution builds with 0 errors

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
