### PR TITLE
Allow tuples in microservice callables outside Unreal compatibility

### DIFF
--- a/cli/tests/Unity/ValueTupleMicroserviceClientTests.cs
+++ b/cli/tests/Unity/ValueTupleMicroserviceClientTests.cs
@@ -19,7 +19,7 @@ namespace tests.Unity;
 public class ValueTupleMicroserviceClientTests
 {
 	[Test]
-	public void ClientGenerator_PreservesValueTupleCallableParameterType()
+	public void ClientGenerator_PreservesValueTupleCallableTypes()
 	{
 		InitializeLogging();
 		var document = GenerateServiceDocument();
@@ -34,6 +34,8 @@ public class ValueTupleMicroserviceClientTests
 				Does.Contain("System.ValueTuple<int, int> value"));
 			Assert.That(generatedClient,
 				Does.Contain("serializedFields.Add(\"value\", raw_value)"));
+			Assert.That(generatedClient,
+				Does.Contain("Beamable.Common.Promise<System.ValueTuple<int, int>> GetTuple()"));
 		}
 		finally
 		{
@@ -94,5 +96,8 @@ public class ValueTupleMicroserviceClientTests
 	{
 		[ClientCallable]
 		public int AddTuple((int, int) value) => value.Item1 + value.Item2;
+
+		[ClientCallable]
+		public (int, int) GetTuple() => (1, 3);
 	}
 }

--- a/cli/tests/Unity/ValueTupleMicroserviceClientTests.cs
+++ b/cli/tests/Unity/ValueTupleMicroserviceClientTests.cs
@@ -59,6 +59,17 @@ public class ValueTupleMicroserviceClientTests
 		Assert.That(deserialized.Item2, Is.EqualTo(3));
 	}
 
+	[Test]
+	public void ResponseDeserialization_RoundTripsValueTupleReturn()
+	{
+		const string ResponseJson = "{\"Item1\":1,\"Item2\":3}";
+
+		var deserialized = Json.Deserialize<(int, int)>(ResponseJson);
+
+		Assert.That(deserialized.Item1, Is.EqualTo(1));
+		Assert.That(deserialized.Item2, Is.EqualTo(3));
+	}
+
 	private static Microsoft.OpenApi.Models.OpenApiDocument GenerateServiceDocument()
 	{
 		var builder = new DependencyBuilder();

--- a/cli/tests/Unity/ValueTupleMicroserviceClientTests.cs
+++ b/cli/tests/Unity/ValueTupleMicroserviceClientTests.cs
@@ -1,0 +1,87 @@
+using Beamable.Common.Dependencies;
+using Beamable.Serialization.SmallerJSON;
+using Beamable.Server;
+using Beamable.Server.Common;
+using Beamable.Server.Generator;
+using Beamable.Tooling.Common.OpenAPI;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using ZLogger;
+
+namespace tests.Unity;
+
+public class ValueTupleMicroserviceClientTests
+{
+	[Test]
+	public void ClientGenerator_PreservesValueTupleCallableParameterType()
+	{
+		InitializeLogging();
+		var document = GenerateServiceDocument();
+		var outputPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.cs");
+
+		try
+		{
+			new OpenApiClientCodeGenerator(document).GenerateCSharpCode(outputPath);
+			var generatedClient = File.ReadAllText(outputPath);
+
+			Assert.That(generatedClient,
+				Does.Contain("System.ValueTuple<int, int> value"));
+			Assert.That(generatedClient,
+				Does.Contain("serializedFields.Add(\"value\", raw_value)"));
+		}
+		finally
+		{
+			File.Delete(outputPath);
+		}
+	}
+
+	[Test]
+	public void RequestSerialization_RoundTripsValueTupleParameter()
+	{
+		var requestFields = new Dictionary<string, object>
+		{
+			["value"] = (1, 3)
+		};
+
+		var requestJson = Json.Serialize(requestFields, new StringBuilder());
+		var tupleJson = JObject.Parse(requestJson)["value"]!.ToString(Formatting.None);
+		var deserialized = JsonConvert.DeserializeObject<(int, int)>(
+			tupleJson,
+			UnitySerializationSettings.Instance);
+
+		Assert.That(deserialized.Item1, Is.EqualTo(1));
+		Assert.That(deserialized.Item2, Is.EqualTo(3));
+	}
+
+	private static Microsoft.OpenApi.Models.OpenApiDocument GenerateServiceDocument()
+	{
+		var builder = new DependencyBuilder();
+		builder.AddSingleton<BeamStandardTelemetryAttributeProvider>();
+		builder.AddSingleton<SingletonDependencyList<ITelemetryAttributeProvider>>();
+		builder.AddSingleton<IMicroserviceArgs>(new MicroserviceArgs());
+
+		return new ServiceDocGenerator().Generate<ValueTupleParameterService>(builder.Build());
+	}
+
+	private static void InitializeLogging()
+	{
+		BeamableZLoggerProvider.Provider = new BeamableZLoggerProvider();
+		BeamableZLoggerProvider.LogContext.Value = LoggerFactory.Create(builder =>
+		{
+			builder.AddZLoggerConsole();
+		}).CreateLogger<ValueTupleMicroserviceClientTests>();
+	}
+
+	[Microservice("tuple_parameter_tests")]
+	private class ValueTupleParameterService : Microservice
+	{
+		[ClientCallable]
+		public int AddTuple((int, int) value) => value.Item1 + value.Item2;
+	}
+}

--- a/templates/MicroserviceSourceGen/MicroserviceSourceGen/Analyzers/ServicesAnalyzer.cs
+++ b/templates/MicroserviceSourceGen/MicroserviceSourceGen/Analyzers/ServicesAnalyzer.cs
@@ -870,7 +870,7 @@ public class ServicesAnalyzer : DiagnosticAnalyzer
 			}
 			
 			
-			ValidateMembersInSymbol(compilation, reportDiagnostic, fieldSymbol.Type, checkBeamGenAttr, isBlueprintCompatible, fallbackLocation, processedTypes);
+			ValidateMembersInSymbol(compilation, reportDiagnostic, fieldSymbol.Type, isBlueprintCompatible, checkBeamGenAttr, fallbackLocation, processedTypes);
 			
 			
 			// Check if parent was type with BeamGen attribute, if so, need to check if class or type members are as well

--- a/templates/MicroserviceSourceGen/MicroserviceSourceGen/Analyzers/ServicesAnalyzer.cs
+++ b/templates/MicroserviceSourceGen/MicroserviceSourceGen/Analyzers/ServicesAnalyzer.cs
@@ -93,7 +93,7 @@ public class ServicesAnalyzer : DiagnosticAnalyzer
 					
 					var location = Diagnostics.GetValidLocation(classDeclaration.Identifier.GetLocation(), context.Compilation);
 					ValidateNestedType(context.Compilation, context.ReportDiagnostic, location, namedSymbol);
-					ValidateSerializableAttributeOnSymbol(context.Compilation, context.ReportDiagnostic, namedSymbol, location);
+					ValidateSerializableAttributeOnSymbol(context.Compilation, context.ReportDiagnostic, namedSymbol, isBlueprintCompatible, location);
 					ValidateMembersInSymbol(context.Compilation, context.ReportDiagnostic, namedSymbol, isBlueprintCompatible, true, location);
 				}
 			}
@@ -471,7 +471,7 @@ public class ServicesAnalyzer : DiagnosticAnalyzer
 		}
 		
 		ValidateNestedType(context.Compilation, context.ReportDiagnostic, returnLocation, methodSymbolReturnType, methodSymbol.Name);
-		ValidateSerializableAttributeOnSymbol(context.Compilation, context.ReportDiagnostic, methodSymbolReturnType, returnLocation);
+		ValidateSerializableAttributeOnSymbol(context.Compilation, context.ReportDiagnostic, methodSymbolReturnType, isBlueprintCompatible, returnLocation);
 		ValidateMembersInSymbol(context.Compilation, context.ReportDiagnostic, methodSymbolReturnType, isBlueprintCompatible, fallbackLocation: returnLocation);
 		ValidateContentObjectType(context.ReportDiagnostic, methodSymbolReturnType, returnLocation, $"{methodSymbol.Name} return");
 		
@@ -524,7 +524,7 @@ public class ServicesAnalyzer : DiagnosticAnalyzer
 			}
 			
 			ValidateNestedType(context.Compilation, context.ReportDiagnostic, parameterLocation, parameterSymbol.Type, methodSymbol.Name);
-			ValidateSerializableAttributeOnSymbol(context.Compilation, context.ReportDiagnostic, parameterSymbol.Type, parameterLocation);
+			ValidateSerializableAttributeOnSymbol(context.Compilation, context.ReportDiagnostic, parameterSymbol.Type, isBlueprintCompatible, parameterLocation);
 			ValidateMembersInSymbol(context.Compilation, context.ReportDiagnostic, parameterSymbol.Type, isBlueprintCompatible, fallbackLocation: parameterLocation);
 			ValidateContentObjectType(context.ReportDiagnostic, parameterSymbol.Type, parameterLocation, $"parameter {parameterSymbol.Name}");
 			
@@ -609,7 +609,7 @@ public class ServicesAnalyzer : DiagnosticAnalyzer
 	}
 
 	private static void ValidateSerializableAttributeOnSymbol(Compilation compilation, Action<Diagnostic> reportDiagnostic,
-		ITypeSymbol typeSymbol, Location fallbackLocation = null, HashSet<string> processedTypes = null)
+		ITypeSymbol typeSymbol, bool isBlueprintCompatible, Location fallbackLocation = null, HashSet<string> processedTypes = null)
 	{
 		processedTypes ??= new HashSet<string>();
 		
@@ -634,16 +634,21 @@ public class ServicesAnalyzer : DiagnosticAnalyzer
 			
 			foreach (ITypeSymbol typeMember in namedTypeSymbol.TypeArguments)
 			{
-				ValidateSerializableAttributeOnSymbol(compilation, reportDiagnostic, typeMember, fallbackLocation, processedTypes);
+				ValidateSerializableAttributeOnSymbol(compilation, reportDiagnostic, typeMember, isBlueprintCompatible, fallbackLocation, processedTypes);
 			}
 		}
 
 		if (typeSymbol is IArrayTypeSymbol arrayTypeSymbol)
 		{
-			ValidateSerializableAttributeOnSymbol(compilation, reportDiagnostic, arrayTypeSymbol.ElementType, fallbackLocation, processedTypes);
+			ValidateSerializableAttributeOnSymbol(compilation, reportDiagnostic, arrayTypeSymbol.ElementType, isBlueprintCompatible, fallbackLocation, processedTypes);
 			return;
 		}
 		
+		//Unity supports C# tuple serialization, but Unreal Blueprint generation does not.
+		if (!isBlueprintCompatible && typeSymbol.IsTupleType)
+		{
+			return;
+		}
 		
 		bool isKnownTypeOrNullable = IsKnownTypeOrNullable(typeSymbol);
 		bool isSerializable = typeSymbol.AnyBaseTypes(baseType => baseType is INamedTypeSymbol { IsSerializable: true });
@@ -695,6 +700,10 @@ public class ServicesAnalyzer : DiagnosticAnalyzer
 			}
 		}
 		
+		if (!isBlueprintCompatible && typeSymbol.IsTupleType)
+		{
+			return;
+		}
 		
 		bool isKnownTypeOrNullable = IsKnownTypeOrNullable(typeSymbol);
 		bool isClassOrStruct = typeSymbol.TypeKind is TypeKind.Class or TypeKind.Struct;
@@ -851,7 +860,7 @@ public class ServicesAnalyzer : DiagnosticAnalyzer
 			
 
 			//Validate if field type is also serializable
-			ValidateSerializableAttributeOnSymbol(compilation, reportDiagnostic, fieldSymbol.Type, fallbackLocation);
+			ValidateSerializableAttributeOnSymbol(compilation, reportDiagnostic, fieldSymbol.Type, isBlueprintCompatible, fallbackLocation);
 
 			// We only need to validate Members for Classes and Structs
 			if (!isMemberClassOrStruct)

--- a/templates/MicroserviceSourceGen/MicroserviceSourceGen/Analyzers/ServicesAnalyzer.cs
+++ b/templates/MicroserviceSourceGen/MicroserviceSourceGen/Analyzers/ServicesAnalyzer.cs
@@ -645,7 +645,7 @@ public class ServicesAnalyzer : DiagnosticAnalyzer
 		}
 		
 		//Unity supports C# tuple serialization, but Unreal Blueprint generation does not.
-		if (!isBlueprintCompatible && typeSymbol.IsTupleType)
+		if (IsAllowedTuple(isBlueprintCompatible, typeSymbol))
 		{
 			return;
 		}
@@ -700,7 +700,8 @@ public class ServicesAnalyzer : DiagnosticAnalyzer
 			}
 		}
 		
-		if (!isBlueprintCompatible && typeSymbol.IsTupleType)
+		//Unity supports C# tuple serialization, but Unreal Blueprint generation does not.
+		if (IsAllowedTuple(isBlueprintCompatible, typeSymbol))
 		{
 			return;
 		}
@@ -1056,4 +1057,23 @@ public class ServicesAnalyzer : DiagnosticAnalyzer
 		return attributeClass.BaseType?.Name == callableAttributeName;
 	}
 	
+	/// <summary>
+	/// Determines whether a tuple is supported for the current client-generation target.
+	/// </summary>
+	/// <remarks>
+	/// Tuple containers are supported when Unreal Blueprint compatibility is disabled.
+	/// Their element types must still be validated before container-level validation is skipped.
+	/// </remarks>
+	/// <param name="isBlueprintCompatible">
+	/// Whether Unreal Blueprint compatibility is enabled for the current build.
+	/// </param>
+	/// <param name="typeSymbol">The type being validated.</param>
+	/// <returns>
+	/// <see langword="true"/> when <paramref name="typeSymbol"/> is a tuple and Unreal
+	/// Blueprint compatibility is disabled; otherwise, <see langword="false"/>.
+	/// </returns>
+	private static bool IsAllowedTuple(bool isBlueprintCompatible, ITypeSymbol typeSymbol)
+	{
+		return !isBlueprintCompatible && typeSymbol.IsTupleType;
+	}
 }

--- a/templates/SourceGen/MicroserviceSourceGen.Tests/BeamableSourceGeneratorTests.Srv.cs
+++ b/templates/SourceGen/MicroserviceSourceGen.Tests/BeamableSourceGeneratorTests.Srv.cs
@@ -432,6 +432,63 @@ public partial class MyMicroservice : Microservice
 	}
 
 	[Fact]
+	public async Task Test_ClientCallable_TupleField_IsAllowedWhenUnrealBlueprintCompatibilityIsDisabled()
+	{
+		const string UserCode = @"
+using Beamable.Server;
+using System;
+
+namespace TestNamespace;
+
+[Microservice(""MyMicroservice"")]
+public partial class MyMicroservice : Microservice
+{
+	[ClientCallable]
+	public TupleResponse GetTupleResponse()
+	{
+		return new TupleResponse { value = (1, 3) };
+	}
+}
+
+[Serializable]
+public class TupleResponse
+{
+	public (int, int) value;
+}
+";
+		var ctx = new CSharpAnalyzerTest<ServicesAnalyzer, DefaultVerifier>();
+
+		PrepareForRun(ctx, UserCode, enableUnrealBlueprintCompatibility: false);
+
+		await ctx.RunAsync();
+	}
+
+	[Fact]
+	public async Task Test_ClientCallable_TupleParameter_IsAllowedWhenUnrealBlueprintCompatibilityIsDisabled()
+	{
+		const string UserCode = @"
+using Beamable.Server;
+
+namespace TestNamespace;
+
+[Microservice(""MyMicroservice"")]
+public partial class MyMicroservice : Microservice
+{
+	[ClientCallable]
+	public int AddTuple((int, int) value)
+	{
+		return value.Item1 + value.Item2;
+	}
+}
+";
+		var ctx = new CSharpAnalyzerTest<ServicesAnalyzer, DefaultVerifier>();
+
+		PrepareForRun(ctx, UserCode, enableUnrealBlueprintCompatibility: false);
+
+		await ctx.RunAsync();
+	}
+
+	[Fact]
 	public async Task Test_ClientCallable_TupleReturn_StillValidatesItsElements()
 	{
 		const string UserCode = @"

--- a/templates/SourceGen/MicroserviceSourceGen.Tests/BeamableSourceGeneratorTests.Srv.cs
+++ b/templates/SourceGen/MicroserviceSourceGen.Tests/BeamableSourceGeneratorTests.Srv.cs
@@ -407,6 +407,94 @@ public partial class MyMicroservice : Microservice
 	}
 	
 	[Fact]
+	public async Task Test_ClientCallable_TupleReturn_IsAllowedWhenUnrealBlueprintCompatibilityIsDisabled()
+	{
+		const string UserCode = @"
+using Beamable.Server;
+
+namespace TestNamespace;
+
+[Microservice(""MyMicroservice"")]
+public partial class MyMicroservice : Microservice
+{
+	[ClientCallable]
+	public (int, int) GetTuple()
+	{
+		return (1, 3);
+	}
+}
+";
+		var ctx = new CSharpAnalyzerTest<ServicesAnalyzer, DefaultVerifier>();
+
+		PrepareForRun(ctx, UserCode, enableUnrealBlueprintCompatibility: false);
+
+		await ctx.RunAsync();
+	}
+
+	[Fact]
+	public async Task Test_ClientCallable_TupleReturn_StillValidatesItsElements()
+	{
+		const string UserCode = @"
+using Beamable.Server;
+
+namespace TestNamespace;
+
+[Microservice(""MyMicroservice"")]
+public partial class MyMicroservice : Microservice
+{
+	[ClientCallable]
+	public (int, InvalidResponse) GetTuple()
+	{
+		return (1, new InvalidResponse());
+	}
+}
+
+public class {|#0:InvalidResponse|}
+{
+	public int value;
+}
+";
+		var ctx = new CSharpAnalyzerTest<ServicesAnalyzer, DefaultVerifier>();
+
+		PrepareForRun(ctx, UserCode, enableUnrealBlueprintCompatibility: false);
+		ctx.ExpectedDiagnostics.Add(
+			new DiagnosticResult(Diagnostics.Srv.MissingSerializableAttributeOnType)
+				.WithLocation(0)
+				.WithArguments("InvalidResponse"));
+
+		await ctx.RunAsync();
+	}
+
+	[Fact]
+	public async Task Test_ClientCallable_TupleReturn_IsRejectedWhenUnrealBlueprintCompatibilityIsEnabled()
+	{
+		const string UserCode = @"
+using Beamable.Server;
+
+namespace TestNamespace;
+
+[Microservice(""MyMicroservice"")]
+public partial class MyMicroservice : Microservice
+{
+	[ClientCallable]
+	public {|#0:(int, int)|} GetTuple()
+	{
+		return (1, 3);
+	}
+}
+";
+		var ctx = new CSharpAnalyzerTest<ServicesAnalyzer, DefaultVerifier>();
+
+		PrepareForRun(ctx, UserCode);
+		ctx.ExpectedDiagnostics.Add(
+			new DiagnosticResult(Diagnostics.Srv.InvalidGenericTypeOnMicroservice)
+				.WithLocation(0)
+				.WithArguments("GetTuple return", "GetTuple"));
+
+		await ctx.RunAsync();
+	}
+
+	[Fact]
 	public async Task Test_Diagnostic_Srv_MissingSerializableOnType()
 	{
 		const string UserCode = @"

--- a/templates/SourceGen/MicroserviceSourceGen.Tests/BeamableSourceGeneratorTests.Srv.cs
+++ b/templates/SourceGen/MicroserviceSourceGen.Tests/BeamableSourceGeneratorTests.Srv.cs
@@ -489,6 +489,103 @@ public partial class MyMicroservice : Microservice
 	}
 
 	[Fact]
+	public async Task Test_ClientCallable_TupleParameter_IsRejectedWhenUnrealBlueprintCompatibilityIsEnabled()
+	{
+		const string UserCode = @"
+using Beamable.Server;
+
+namespace TestNamespace;
+
+[Microservice(""MyMicroservice"")]
+public partial class MyMicroservice : Microservice
+{
+	[ClientCallable]
+	public int AddTuple((int, int) {|#0:value|})
+	{
+		return value.Item1 + value.Item2;
+	}
+}
+";
+		var ctx = new CSharpAnalyzerTest<ServicesAnalyzer, DefaultVerifier>();
+
+		PrepareForRun(ctx, UserCode);
+		ctx.ExpectedDiagnostics.Add(
+			new DiagnosticResult(Diagnostics.Srv.InvalidGenericTypeOnMicroservice)
+				.WithLocation(0)
+				.WithArguments("parameter value", "AddTuple"));
+
+		await ctx.RunAsync();
+	}
+
+	[Fact]
+	public async Task Test_ClientCallable_NestedTupleField_IsRejectedWhenUnrealBlueprintCompatibilityIsEnabled()
+	{
+		const string UserCode = @"
+using Beamable.Server;
+using System;
+
+namespace TestNamespace;
+
+[Microservice(""MyMicroservice"")]
+public partial class MyMicroservice : Microservice
+{
+	[ClientCallable]
+	public OuterResponse GetTupleResponse()
+	{
+		return new OuterResponse();
+	}
+}
+
+[Serializable]
+public class OuterResponse
+{
+	public InnerResponse inner;
+}
+
+[Serializable]
+public class InnerResponse
+{
+	public (int, int) {|#0:value|};
+}
+";
+		var ctx = new CSharpAnalyzerTest<ServicesAnalyzer, DefaultVerifier>();
+
+		PrepareForRun(ctx, UserCode);
+		ctx.ExpectedDiagnostics.Add(
+			new DiagnosticResult(Diagnostics.Srv.InvalidGenericTypeOnMicroservice)
+				.WithLocation(0)
+				.WithArguments("field value", "InnerResponse"));
+
+		await ctx.RunAsync();
+	}
+
+	[Fact]
+	public async Task Test_BeamGenerateSchema_TupleField_IsRejected()
+	{
+		const string UserCode = @"
+using System;
+
+namespace TestNamespace;
+
+[Serializable]
+[Beamable.BeamGenerateSchema]
+public class TupleSchema
+{
+	public {|#0:(int, int)|} value;
+}
+";
+		var ctx = new CSharpAnalyzerTest<ServicesAnalyzer, DefaultVerifier>();
+
+		PrepareForRun(ctx, UserCode, enableUnrealBlueprintCompatibility: false);
+		ctx.ExpectedDiagnostics.Add(
+			new DiagnosticResult(Diagnostics.Srv.TypeInBeamGeneratedIsMissingBeamGeneratedAttribute)
+				.WithLocation(0)
+				.WithArguments("ValueTuple"));
+
+		await ctx.RunAsync();
+	}
+
+	[Fact]
 	public async Task Test_ClientCallable_TupleReturn_StillValidatesItsElements()
 	{
 		const string UserCode = @"

--- a/templates/SourceGen/MicroserviceSourceGen.Tests/BeamableSourceGeneratorTests.cs
+++ b/templates/SourceGen/MicroserviceSourceGen.Tests/BeamableSourceGeneratorTests.cs
@@ -58,16 +58,16 @@ public partial class BeamableSourceGeneratorTests : IDisposable
 	}
 
 	private static void PrepareForRun<T>(CSharpAnalyzerTest<T, DefaultVerifier> ctx,
-		string userCode, string[]? extraGlobalConfigs = null) where T : DiagnosticAnalyzer, new()
+		string userCode, string[]? extraGlobalConfigs = null, bool enableUnrealBlueprintCompatibility = true) where T : DiagnosticAnalyzer, new()
 	{
 		ctx.DisabledDiagnostics.Add("BEAM_DBG_0001");
 		AddAssemblyReferences(ctx.TestState);
 
 		ctx.TestCode = userCode;
 
-		string globalConfig = @"
+		string globalConfig = $@"
 is_global = true 
-build_property.EnableUnrealBlueprintCompatibility = true";
+build_property.EnableUnrealBlueprintCompatibility = {(enableUnrealBlueprintCompatibility ? "true" : "false")}";
 		if (extraGlobalConfigs != null)
 		{
 			foreach (string extraGlobalConfig in extraGlobalConfigs)


### PR DESCRIPTION
# Ticket

Closes #4582

# Brief Description

`ValueTuple` return values already serialize correctly for Unity clients, but the microservice source analyzer treated the tuple container as a normal struct and required `[Serializable]`. Tuples cannot carry that attribute, so developers had to disable the analyzer even though the runtime path worked.

This PR allows tuple containers when Unreal Blueprint compatibility is disabled. We still validate every tuple element, so unsupported nested types continue to report diagnostics.

We keep the platform boundary explicit:

- Unity/C# client callables can use tuples in return types, parameters, and serializable response fields.
- Unreal Blueprint-compatible callables still reject tuples.
- `[BeamGenerateSchema]` fields still reject tuples because schema generation requires attribute-bearing types.

The branch also corrects the recursive analyzer argument order so nested fields receive the intended Unreal-compatibility and `BeamGenerateSchema` flags.

Client-side coverage confirms that generated methods preserve tuple parameter and return types, request serialization round-trips tuple parameters, and response deserialization round-trips tuple returns.

# Developer Impact

Developers using Unity/C# can keep the source analyzer enabled when a client callable uses tuples. Unreal projects retain the existing diagnostic instead of generating an unsupported Blueprint type.

# Verification

- `dotnet test templates/SourceGen/MicroserviceSourceGen.Tests/MicroserviceSourceGen.Tests.csproj --no-build --no-restore --nologo --verbosity quiet`
  - 36 passed, 0 failed
- `dotnet test cli/tests/tests.csproj --no-restore --nologo --verbosity minimal --filter "FullyQualifiedName~ValueTupleMicroserviceClientTests"`
  - 3 passed, 0 failed
- Mutation check: restoring the previous swapped recursive arguments makes the nested Unreal tuple-field test fail.

# Checklist

- [x] Added focused analyzer, code-generation, request-serialization, and response-deserialization coverage.
- [x] Changelog entry is not required; this fixes analyzer behavior without adding or changing a public API.
- [x] Public API documentation is not required; no public methods or interfaces were added.

# Notes

This does not introduce a new compatibility promise for Unreal or `[BeamGenerateSchema]`. Those paths remain intentionally unsupported for tuples.
