### PR TITLE
Refactor ContentHistoryInspectorPreview for Unity versions

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Updated ContentWindow_History to now use EntityId to support unity's new object ID system. This change only affects versions 6000.4 and up.
+
 - Added build-scoped suppression and per-player runtime opt-in for automatic Player Social friend-invitation Mail checks.
 
 ## [6.0.1] - 2026-07-31

--- a/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
+++ b/client/Packages/com.beamable/Editor/UI/ContentWindow/ContentWindow_History.cs
@@ -1224,26 +1224,42 @@ namespace Beamable.Editor.UI.ContentWindow
 
 	public static class ContentHistoryInspectorPreview
 	{
+		#if UNITY_6000_4_OR_NEWER
+		private static readonly HashSet<EntityId> PreviewIds = new();
+		#else
 		private static readonly HashSet<int> PreviewInstanceIds = new();
+		#endif
 
 		public static void Register(ContentObject content)
 		{
 			if (content != null)
 			{
+				#if UNITY_6000_4_OR_NEWER
+				PreviewIds.Add(content.GetEntityId());
+				#else
 				PreviewInstanceIds.Add(content.GetInstanceID());
+				#endif
 			}
 		}
 
 		public static bool IsReadOnly(ContentObject content)
 		{
+			#if UNITY_6000_4_OR_NEWER
+			return content != null && PreviewIds.Contains(content.GetEntityId());
+			#else
 			return content != null && PreviewInstanceIds.Contains(content.GetInstanceID());
+			#endif
 		}
 
 		public static void Release(ContentObject content)
 		{
 			if (content != null)
 			{
+				#if UNITY_6000_4_OR_NEWER
+				PreviewIds.Remove(content.GetEntityId());
+				#else
 				PreviewInstanceIds.Remove(content.GetInstanceID());
+				#endif
 			}
 		}
 


### PR DESCRIPTION
# Ticket

https://disruptorbeam.atlassian.net/browse/BEAM-XXXX

# Brief Description

> Changed ContentWindow_History to support unity's new EntityId system for Objects.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [x] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [x] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
