### PR TITLE
Fix Unity Editor hitches during content saves

### DIFF
--- a/client/Packages/com.beamable/CHANGELOG.md
+++ b/client/Packages/com.beamable/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added build-scoped suppression and per-player runtime opt-in for automatic Player Social friend-invitation Mail checks.
 - Content Manifest caching between runs.
 
+### Fixed
+
+- Fixed Unity Editor hitches after editing content properties by avoiding synchronous end-of-stream checks while reading streamed CLI responses.
+
 ## [6.0.1] - 2026-07-31
 
 ### Changed

--- a/client/Packages/com.beamable/Editor/BeamCli/BeamWebCommand.cs
+++ b/client/Packages/com.beamable/Editor/BeamCli/BeamWebCommand.cs
@@ -470,7 +470,7 @@ namespace Beamable.Editor.BeamCli
 				using StreamReader reader = new StreamReader(streamToReadFrom);
 
 				Task<string> readTask = null;
-				while (!reader.EndOfStream)
+				while (true)
 				{
 					if (_cts.Token.IsCancellationRequested)
 					{
@@ -483,13 +483,27 @@ namespace Beamable.Editor.BeamCli
 					{
 						await Task.WhenAny(readTask, cancelTcs.Task);
 					}
+
 					if (_cts.Token.IsCancellationRequested)
 					{
+						_ = readTask.ContinueWith(completedReadTask => { _ = completedReadTask.Exception;},
+							CancellationToken.None,
+							TaskContinuationOptions.OnlyOnFaulted |
+							TaskContinuationOptions.ExecuteSynchronously,
+							TaskScheduler.Default);
 						break;
 					}
 
 					var line = await readTask;
-					if (string.IsNullOrEmpty(line)) continue; // TODO: what if the message contains a \n character?
+					if (line == null)
+					{
+						break;
+					}
+
+					if (line.Length == 0)
+					{
+						continue;
+					}
 
 					// remove life-cycle zero-width character
 					line = line.Replace("\u200b", "");


### PR DESCRIPTION
Fixes #4728 

## Summary

- Read streamed CLI responses until `ReadLineAsync()` returns `null` instead of polling synchronous `EndOfStream`.
- Preserve prompt cancellation and observe faults from abandoned pending reads.

## Verification

- Confirmed fast and slow Inspector typing remain smooth.
- Confirmed the previous main-thread hitch no longer appears in Unity profiling.
- Canceled an idle `content ps --watch` command; cancellation completed promptly, history reached Completed, and no delayed warnings or errors appeared.

# Checklist

* [x] Have you added appropriate text to the CHANGELOG.md files?

Add those to list or remove the list below altogether:

> * [ ] Have you documented all your public methods and interfaces? [Have you identified intention and assumptions?](https://github.com/beamable/BeamableProduct/wiki/Docstrings)
> * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`? [You need to provide a docs file.](https://github.com/beamable/BeamableProduct/wiki/Template)


# Notes

When you are merging a feature branch into `main`, please squash merge and make sure the final commit contains any relevent JIRA ticket number. If you are merging from `main` to `staging`, or `staging` to `production`, please use a regular merge commit. 

Does this introduce tech-debt? If so, have you added an entry to the [Tech-debt document?](https://docs.google.com/spreadsheets/d/141h1o9ZTdpdTP9JuQT7QP5MK5UAFQ00bfymqVtyCHyU/edit?usp=sharing)
