### PR TITLE
Leave a shipped milestone open when it still holds open items

### DIFF
--- a/.github/workflows/release-unity.yml
+++ b/.github/workflows/release-unity.yml
@@ -396,22 +396,39 @@ jobs:
               }
             }'
 
-      # Close the matching "Unity X.Y.Z" milestone once a production release ships.
-      # Warns (does not fail) when no open milestone matches, so it never blocks a release. ~Claude
+      # Close the matching "Unity X.Y.Z" milestone once a production release ships,
+      # but only when nothing is still open in it. A milestone holding open issues has
+      # not shipped everything it claims, and closing it drops it off the default
+      # milestones view -- the issues stay open and stay attached, but they stop being
+      # somewhere anyone looks. So leave it open and name the stragglers instead.
+      # Warns, never fails: this step cannot block or redden a release.
       - name: Close shipped milestone
         if: ${{ inputs.dryRun == false && inputs.releaseType == 'production' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           title="Unity ${{ inputs.major }}.${{ inputs.minor }}.${{ inputs.patch }}"
-          num=$(gh api "repos/${{ github.repository }}/milestones?state=open&per_page=100" \
-                --jq ".[] | select(.title==\"$title\") | .number")
-          if [ -n "$num" ]; then
-            gh api -X PATCH "repos/${{ github.repository }}/milestones/$num" -f state=closed
-            echo "Closed milestone $title (#$num)"
-          else
+          milestone=$(gh api "repos/${{ github.repository }}/milestones?state=open&per_page=100" \
+                      --jq ".[] | select(.title==\"$title\")" || true)
+
+          if [ -z "$milestone" ]; then
             echo "::warning::No open milestone titled '$title' to close"
+            exit 0
           fi
+
+          num=$(printf '%s' "$milestone" | jq -r '.number')
+          open_count=$(printf '%s' "$milestone" | jq -r '.open_issues')
+
+          if [ "$open_count" -gt 0 ]; then
+            echo "::warning::Milestone '$title' still has $open_count open item(s), so it was left OPEN. Move them to the next milestone, then close '$title' by hand."
+            gh issue list --repo "${{ github.repository }}" --milestone "$title" \
+              --state open --limit 100 --json number,title \
+              --jq '.[] | "::warning::still open in milestone: #\(.number) \(.title)"' || true
+            exit 0
+          fi
+
+          gh api -X PATCH "repos/${{ github.repository }}/milestones/$num" -f state=closed
+          echo "Closed milestone $title (#$num)"
 
   lightbeam:
     needs: package


### PR DESCRIPTION
## What

Follow-up to #4701. The `Close shipped milestone` step in `release-unity.yml` now checks the milestone's `open_issues` before closing it. If anything is still open, the milestone is **left open** and each straggler is named in the log.

## Why

Closing a milestone does not close or detach its open issues - they stay open, stay attached, and stay findable with `is:open milestone:"Unity X.Y.Z"`. What closing costs is *visibility*: the milestone drops off the default milestones view and its progress bar reads complete, so an overlooked issue keeps being overlooked.

A milestone that still holds open items also has not, in fact, shipped everything it claims. Leaving it open is the honest state and puts the triage where it belongs.

Worth noting the automation is not the problem here. Four closed milestones in this repo carry open issues - `CLI 2.0.1`, `CLI 4.2.0`, `CLI 5.1.0`, `Unity 1.19.20` - and all four predate #4701 and were closed by hand. Every milestone closed since #4701 merged has zero stragglers. This change closes the remaining gap: that it closed *silently*.

## Behavior

| Milestone state | Before | After |
|---|---|---|
| No matching open milestone | warn | warn (unchanged) |
| Matches, nothing open | close | close (unchanged) |
| Matches, N items still open | **close silently** | **leave open + warn per item** |

Deliberately *not* a failure. #4701 asked whether a missing milestone should fail as a hygiene gate; the answer here is no. A release is the moment least tolerant of a spurious delay, and a red job two steps removed from the artifact would obstruct exactly then. Every path exits 0, including a failed API lookup.

## Testing

The step's shell was extracted and exercised against a stubbed `gh` across four scenarios - no matching milestone, clean milestone, milestone with two open issues, and a failing API call. All four produce the intended output and exit 0. The workflow file parses as YAML.

Sample output for the straggler case:

```
::warning::Milestone 'Unity 6.1.0' still has 2 open item(s), so it was left OPEN. Move them to the next milestone, then close 'Unity 6.1.0' by hand.
::warning::still open in milestone: #1234 Bundles CLI verbs still registered
::warning::still open in milestone: #1235 Folder meta backfill missing
```

## Note

Leaves the `inputs.dryRun == false` guard in place rather than folding in the pending `dryRun` removal, to keep this diff to one concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

