### PR TITLE
Give CLI 7.1.0 its own changelog section

### DIFF
--- a/cli/cli/CHANGELOG.md
+++ b/cli/cli/CHANGELOG.md
@@ -53,31 +53,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [7.2.0] - 2026-06-16
 
 ### Added
-- New Commands `project add-replacement-type`, `project list-replacement-type`, `project remove-replacement-type` to manage Unreal replacement types.
-- Unreal Types for Microservices FColor, FVector, FLinearColor, FIntVector, FGameplayTag, FGameplayTagCOntainer, FSoftObjectPath.
-- Semantic Types for Beamable Classes with custom serialization and deserialization
-- A `.beamroot` file will stop the CLI's search for a `.beamable` folder. 
-- Added internal `content history` command suite to power engine integrations for inspecting history of content changes to a realm.
 - MCP Server Configuration for Beamable CLI. Use `beam mcp setup` to configure in your project.
 - Agentic AI Skills for working with beamable. Use `beam install-ai-skill` to install it in your project.
 
 ### Changed
-- Update `AbsInventoryApi` and `MicroserviceInventoryApi` to use new Auto-generated IInventoryApi with Inventory filtering support.
-- Update `deploy release` and `deploy plan` with new optional parameter `--max-parallel-count` to control the max number of services that can be built simultaneously. This is to help with out-of-memory issues on machines with low resources.
-- Removed 5% sample rating for OTEL traces so we can get all traces from portal extensions and errors that happens in the CLI.
 - Improved Content Publish command performance by adding size-aware batching and retry.
 - Refactored calculation of directory size, 2x performance improvement.
 - Refactored generation of local manifest data, 20x performance improvement.
 - Added support to Max Concurrent Upload for `deploy release`.
 
 ### Fixed
+- Setting environment variable ``BEAM_NO_TELEMETRY`` or the ``BeamCliAllowTelemetry`` config now prevents collector ps process from starting
+- Fixed .NET framework argument parsing issues related to culture and locale handling.
+
+## [7.1.0] - 2026-04-16
+
+### Added
+- New Commands `project add-replacement-type`, `project list-replacement-type`, `project remove-replacement-type` to manage Unreal replacement types.
+- Unreal Types for Microservices FColor, FVector, FLinearColor, FIntVector, FGameplayTag, FGameplayTagCOntainer, FSoftObjectPath.
+- Semantic Types for Beamable Classes with custom serialization and deserialization
+- A `.beamroot` file will stop the CLI's search for a `.beamable` folder.
+- Added internal `content history` command suite to power engine integrations for inspecting history of content changes to a realm.
+
+### Changed
+- Update `AbsInventoryApi` and `MicroserviceInventoryApi` to use new Auto-generated IInventoryApi with Inventory filtering support.
+- Update `deploy release` and `deploy plan` with new optional parameter `--max-parallel-count` to control the max number of services that can be built simultaneously. This is to help with out-of-memory issues on machines with low resources.
+- Removed 5% sample rating for OTEL traces so we can get all traces from portal extensions and errors that happens in the CLI.
+
+### Fixed
 - Resolved issues in the token refresh flow where the CLI did not properly refresh, and persist the access token.
 - Concurrency issue in `Promise` code that could lead to deadlock scenario in multi-threaded code
 - Fixed issue that considered types used in ServerCallable methods on Microservices to be generated to client code.
 - Creating microservices when CultureInfo is expecting `,` instead of `.` as the decimal separator.
-- Fix an issue where some summary tag were missing the closing tag, which produced a truncated summary tag.
-- Setting environment variable ``BEAM_NO_TELEMETRY`` or the ``BeamCliAllowTelemetry`` config now prevents collector ps process from starting
-- Fixed .NET framework argument parsing issues related to culture and locale handling.
 
 ## [7.0.1] - 2026-04-02
 ### Fixed


### PR DESCRIPTION
`cli-7.1.0` (2026-04-16) shipped **166 commits, 750 files, +30185/-2643** - Portal Extensions (proof of concept, planning/deployment, performance tracking), zstd websocket compression, inter-service communication and event handling, the `content history` command suite, Unreal replacement types and stubs - with **no changelog section of its own**.

The entries were written. At the `cli-7.1.0` tag they sat under a heading spelled `## Unreleased`, **without brackets**, and were never renamed to `## [7.1.0] - 2026-04-16`. When `7.2.0` was cut in June that same block was renamed to `## [7.2.0] - 2026-06-16`, so the content was misfiled rather than lost.

Surfaced by the changelog backfill of existing production GitHub Releases (see #4812): `cli-7.1.0` was one of only two production releases whose Release body could not be populated, and the other (`cli-2.0.0`) simply predates the changelog. An audit of every production tag against its lane changelog found no other primary-package gaps in the whole history.

## What this changes

Splits the block back apart. The `[7.1.0]` entry set is taken **verbatim** from the `Unreleased` block present at the `cli-7.1.0` tag, so nothing is invented and nothing is reworded.

The truncated-summary-tag bullet is **dropped rather than duplicated**: it is a cherry-pick twin already documented under `[7.0.1]`, where it actually shipped. That is the `-` twin case runbook step 2 warns about.

## Companion changes

- `fix/cli-710-changelog-61x` - the same split on `release/unity-6.1.x`.
- The `cli-7.1.0` GitHub Release body will be regenerated from the corrected changelog.
- `release/unity-6.0.x` and `release/unity-5.1.x` carry the same uncorrected block. Left alone per the runbook rule of backporting only if a line cuts another patch; worth doing if either does.
- `beamable/Changelogs` (production branch, feeding changes.beamable.com) also carries it. It is force-overwritten wholesale by the next production release, so it self-heals - but not until then.

## Prevention

Runbook step 3 already says to rename the `[Unreleased]` heading to the version and date it; that runbook postdates this release. With #4812, a version with no changelog section now emits a `::warning` in the release job, so the next occurrence surfaces at release time rather than years later.
