### PR TITLE
Fix - Add openTrackingUrl to MessageRailRecipient

### DIFF
--- a/cli/beamable.common/Runtime/Federation/FederatedMessageRail.cs
+++ b/cli/beamable.common/Runtime/Federation/FederatedMessageRail.cs
@@ -27,6 +27,22 @@ namespace Beamable.Common
 		/// back to this exact recipient. Optional on the wire (empty when the producer omits it).
 		/// </summary>
 		public string outreachId;
+
+		/// <summary>
+		/// Ready-made open-tracking pixel URL for this recipient. A rendering federation places it as
+		/// <c>&lt;img src="..." width="1" height="1" alt=""&gt;</c> and needs to understand nothing
+		/// about it — the URL is opaque, signed by the platform, and identifies this one recipient.
+		/// <para>EMPTY means tracking is not configured, and empty must render NO pixel at all: a
+		/// broken image in someone's inbox is worse than a missing metric.</para>
+		/// <para>Only rails whose engagement signal arrives out of band need this. Push gets Opened
+		/// from the handset echoing <see cref="MessageRailContract.OutreachKey"/>, so a push federation
+		/// can ignore it; email has no handset, which is why the pixel is the only signal available.</para>
+		/// <para>Do NOT build this URL yourself. It carries a signed token whose payload includes the
+		/// recipient's gamer tag, which the campaign funnel needs to resolve an account — a
+		/// federation-built copy cannot be signed and has historically dropped that field, which makes
+		/// every open it records invisible to the campaign funnel.</para>
+		/// </summary>
+		public string openTrackingUrl;
 	}
 
 	[Serializable]

--- a/client/Packages/com.beamable/Common/Runtime/Federation/FederatedMessageRail.cs
+++ b/client/Packages/com.beamable/Common/Runtime/Federation/FederatedMessageRail.cs
@@ -30,6 +30,22 @@ namespace Beamable.Common
 		/// back to this exact recipient. Optional on the wire (empty when the producer omits it).
 		/// </summary>
 		public string outreachId;
+
+		/// <summary>
+		/// Ready-made open-tracking pixel URL for this recipient. A rendering federation places it as
+		/// <c>&lt;img src="..." width="1" height="1" alt=""&gt;</c> and needs to understand nothing
+		/// about it — the URL is opaque, signed by the platform, and identifies this one recipient.
+		/// <para>EMPTY means tracking is not configured, and empty must render NO pixel at all: a
+		/// broken image in someone's inbox is worse than a missing metric.</para>
+		/// <para>Only rails whose engagement signal arrives out of band need this. Push gets Opened
+		/// from the handset echoing <see cref="MessageRailContract.OutreachKey"/>, so a push federation
+		/// can ignore it; email has no handset, which is why the pixel is the only signal available.</para>
+		/// <para>Do NOT build this URL yourself. It carries a signed token whose payload includes the
+		/// recipient's gamer tag, which the campaign funnel needs to resolve an account — a
+		/// federation-built copy cannot be signed and has historically dropped that field, which makes
+		/// every open it records invisible to the campaign funnel.</para>
+		/// </summary>
+		public string openTrackingUrl;
 	}
 
 	[Serializable]


### PR DESCRIPTION
# Brief Description

Adds one field to the message-rail federation contract so a rendering federation can place an
open-tracking pixel in an email, which is what makes the email campaign funnel able to report
`Opened`.

`MessageRailRecipient` gains `openTrackingUrl`, in
`cli/beamable.common/Runtime/Federation/FederatedMessageRail.cs` plus its auto-copied Unity
mirror under `client/Packages/com.beamable/`.

The URL is **minted platform-side** and handed over ready-made,  the federation places it and
needs to understand nothing about it. That is deliberate. The previous design had the email
federation build its own URL from a hand-rolled copy of the platform's token codec; the two
drifted, and the federation's copy silently omitted the recipient's gamer tag, which the
campaign funnel needs to resolve an account. Every open it recorded was therefore discarded.
One encoder, owned by the platform, prevents that recurring, and it also means the token can
be signed without shipping a signing key to a customer microservice.

Empty means tracking is off, and a federation given an empty URL must render **no** pixel
rather than a broken image. Only rails whose engagement signal arrives out of band need the
field: push gets `Opened` from the handset, so a push federation can ignore it.

Companion PRs: BeamableAPI (mints the URL, records the stage) and BeamableBackend (injects the
pixel into the rendered body).

# Checklist

* [ ] Have you added appropriate text to the CHANGELOG.md files?
* [x] Have you documented all your public methods and interfaces?
 * [ ] Have you included a docs file as `/wiki/BEAM-1234.md`?

# Notes

**Backward compatibility.** Additive and defaulted, so a federation built before this field
keeps working unchanged. The backend locks the wire shape in
`BeamableShared.Tests/Tests/Federation/MessageRailWireShapeTest.cs`. The SDK deserializer drops
unknown wire fields, which is why this SDK change is required rather than optional — without
it the microservice never sees the value the platform sends.