### PR TITLE
Fix - Omit empty inventory scope instead of sending `?scope=` (#4833)

### DIFF
--- a/microservice/microservice/Api/Inventory/MicroserviceInventoryApi.cs
+++ b/microservice/microservice/Api/Inventory/MicroserviceInventoryApi.cs
@@ -19,9 +19,8 @@ namespace Beamable.Server.Api.Inventory
 
 		public override Promise<InventoryView> GetCurrent(string scope = "")
 		{
-			// An empty scope means "the whole inventory". It must be omitted from the request rather than sent as
-			// an empty query value (`?scope=`): the gateway never replies to that request, and the promise would hang
-			// forever. This matches the pre-7.1.0 behaviour, which only appended the scope when it was non-empty.
+			// Null or empty scope means "the whole inventory". Omit the query parameter, as the pre-7.1.0
+			// BeamableGetApiResource did. Sending `?scope=` can leave the websocket request pending (#4833).
 			Optional<string> scopeArg = string.IsNullOrEmpty(scope)
 				? OptionalString.None
 				: new OptionalString(scope);

--- a/microservice/microservice/Api/Inventory/MicroserviceInventoryApi.cs
+++ b/microservice/microservice/Api/Inventory/MicroserviceInventoryApi.cs
@@ -19,7 +19,14 @@ namespace Beamable.Server.Api.Inventory
 
 		public override Promise<InventoryView> GetCurrent(string scope = "")
 		{
-			return InventoryApi.ObjectGet(UserContext.UserId,scope).Map(InventoryViewToAutoGenInventoryView);
+			// An empty scope means "the whole inventory". It must be omitted from the request rather than sent as
+			// an empty query value (`?scope=`): the gateway never replies to that request, and the promise would hang
+			// forever. This matches the pre-7.1.0 behaviour, which only appended the scope when it was non-empty.
+			Optional<string> scopeArg = string.IsNullOrEmpty(scope)
+				? OptionalString.None
+				: new OptionalString(scope);
+
+			return InventoryApi.ObjectGet(UserContext.UserId, scopeArg).Map(InventoryViewToAutoGenInventoryView);
 		}
 
 		public async Promise SendCurrency(Dictionary<string, long> currencies, long recipientPlayer,

--- a/microservice/microservice/CHANGELOG.md
+++ b/microservice/microservice/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `Services.Inventory.GetCurrent()` with an empty or null scope no longer sends an empty `?scope=` query value, which the gateway never answered and left the call hanging forever on runtime 7.1.0 and later.
+- `Services.Inventory.GetCurrent()` and `GetCurrent("")` now omit the empty scope query parameter, which could leave inventory requests pending on runtimes 7.1.0 through 7.2.3. `GetCurrent(null)` also treats the scope as omitted instead of throwing before sending the request.
 
 ## [7.2.3] - 2026-08-26
 

--- a/microservice/microservice/CHANGELOG.md
+++ b/microservice/microservice/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `Services.Inventory.GetCurrent()` with an empty or null scope no longer sends an empty `?scope=` query value, which the gateway never answered and left the call hanging forever on runtime 7.1.0 and later.
+
 ## [7.2.3] - 2026-08-26
 
 ### Added

--- a/microservice/microserviceTests/microservice/TestArgs.cs
+++ b/microservice/microserviceTests/microservice/TestArgs.cs
@@ -150,9 +150,9 @@ namespace microserviceTests.microservice
 				.Run();
 		}
 
-		public async Task OnShutdown(object sender, EventArgs args)
+		public Task OnShutdown(object sender, EventArgs args)
 		{
-			Service.OnShutdown(sender, args);
+			return Service.OnShutdown(sender, args);
 		}
 	}
 	

--- a/microservice/microserviceTests/microservice/TestSetupShutdownTests.cs
+++ b/microservice/microserviceTests/microservice/TestSetupShutdownTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading.Tasks;
+using Beamable.Common.Dependencies;
+using Beamable.Server;
+using NUnit.Framework;
+
+namespace microserviceTests.microservice
+{
+	[TestFixture]
+	public class TestSetupShutdownTests
+	{
+		private sealed class PendingShutdownService : IBeamableService
+		{
+			public readonly TaskCompletionSource<bool> ShutdownCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+			public SocketRequesterContext SocketContext => null;
+			public bool HasInitialized => true;
+			public IDependencyProvider Provider => null;
+			public Task OnShutdown(object sender, EventArgs args) => ShutdownCompleted.Task;
+		}
+
+		[Test]
+		public async Task OnShutdown_WaitsForServiceShutdown()
+		{
+			var service = new PendingShutdownService();
+			var setup = new TestSetup(null) { Service = service };
+			var shutdown = setup.OnShutdown(this, EventArgs.Empty);
+			try
+			{
+				Assert.That(shutdown.IsCompleted, Is.False, "The harness returned before the service finished shutting down.");
+			}
+			finally
+			{
+				service.ShutdownCompleted.TrySetResult(true);
+			}
+
+			await shutdown;
+		}
+	}
+}

--- a/microservice/microserviceTests/microservice/dbmicroservice/BeamableMicroServiceTests/InventoryScopeTests.cs
+++ b/microservice/microserviceTests/microservice/dbmicroservice/BeamableMicroServiceTests/InventoryScopeTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Beamable.Common.Api.Inventory;
+using Beamable.Common.Inventory;
 using Beamable.Microservice.Tests.Socket;
 using Beamable.Server;
 using NUnit.Framework;
@@ -13,8 +14,8 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
 	/// Regression tests for https://github.com/beamable/BeamableProduct/issues/4833.
 	///
 	/// <see cref="Beamable.Server.Api.Inventory.MicroserviceInventoryApi.GetCurrent"/> must omit the scope query
-	/// parameter when the scope is empty. Sending it as an empty value (`?scope=`) produces a request the gateway
-	/// never answers, and the promise hangs forever.
+	/// parameter when the scope is empty. Sending it as an empty value (`?scope=`) can leave the websocket
+	/// request pending. A null scope must also be omitted instead of throwing before the request is sent.
 	/// </summary>
 	[TestFixture]
 	public class InventoryScopeTests : CommonTest
@@ -54,6 +55,13 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
 			}
 
 			[ClientCallable]
+			public async Task<string> GetEmptyItemReferences()
+			{
+				var items = await Services.Inventory.GetItems<ItemContent>(Array.Empty<ItemRef<ItemContent>>());
+				return $"items={items.Count}";
+			}
+
+			[ClientCallable]
 			public async Task<string> GetScoped(string scope)
 			{
 				var view = await Services.Inventory.GetCurrent(scope);
@@ -71,10 +79,12 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
 		/// and expects exactly one 200 reply to the client. Every inventory route the service sends is recorded in the
 		/// returned list so a failing test can show what actually went over the wire.
 		/// </summary>
-		private static (TestSetup setup, Func<TestSocket> socket, List<string> routes) Build(TestSocketMessageMatcher routeMatcher)
+		private static (TestSetup setup, Func<TestSocket> socket, List<string> routes, Task reply) Build(
+			TestSocketMessageMatcher routeMatcher, string expectedClientPayload = ExpectedClientPayload)
 		{
 			TestSocket testSocket = null;
 			var routes = new List<string>();
+			var reply = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 			var setup = new TestSetup(new TestSocketProvider(socket =>
 			{
 				testSocket = socket;
@@ -99,30 +109,55 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
 						MessageMatcher
 							.WithReqId(1)
 							.WithStatus(200)
-							.WithPayload(ExpectedClientPayload),
-						MessageResponder.NoResponse(),
+							.WithPayload(expectedClientPayload),
+						_ =>
+						{
+							reply.TrySetResult(true);
+							return (object)null;
+						},
 						MessageFrequency.OnlyOnce());
 			}));
 
-			return (setup, () => testSocket, routes);
+			return (setup, () => testSocket, routes, reply.Task);
+		}
+
+		private static async Task WaitForReply(Task reply, List<string> routes)
+		{
+			try
+			{
+				await reply.WaitAsync(TimeSpan.FromSeconds(5));
+			}
+			catch (TimeoutException)
+			{
+				lock (routes)
+				{
+					Assert.Fail("The expected client reply was not received. Inventory routes seen: " + string.Join(" | ", routes));
+				}
+			}
 		}
 
 		[Test]
 		[NonParallelizable]
-		[TestCase(nameof(InventoryScopeMicroservice.GetDefaultScope))]
-		[TestCase(nameof(InventoryScopeMicroservice.GetEmptyScope))]
-		[TestCase(nameof(InventoryScopeMicroservice.GetNullScope))]
-		public async Task GetCurrent_WithoutScope_OmitsScopeQueryParameter(string callableName)
+		[TestCase(nameof(InventoryScopeMicroservice.GetDefaultScope), ExpectedClientPayload)]
+		[TestCase(nameof(InventoryScopeMicroservice.GetEmptyScope), ExpectedClientPayload)]
+		[TestCase(nameof(InventoryScopeMicroservice.GetNullScope), ExpectedClientPayload)]
+		[TestCase(nameof(InventoryScopeMicroservice.GetEmptyItemReferences), "items=0")]
+		public async Task InventoryRead_WithoutScope_OmitsScopeQueryParameter(string callableName, string expectedClientPayload)
 		{
-			var (ms, socket, routes) = Build(req => req.path.EndsWith($"object/inventory/{PlayerId}/"));
+			var (ms, socket, routes, reply) = Build(req => req.path.EndsWith($"object/inventory/{PlayerId}/"), expectedClientPayload);
 
 			await ms.Start<InventoryScopeMicroservice>(new TestArgs());
 			Assert.IsTrue(ms.HasInitialized);
 
-			socket().SendToClient(ClientRequest.ClientCallable(ServiceRoute, callableName, 1, PlayerId));
-
-			await Task.Delay(50);
-			await ms.OnShutdown(this, null);
+			try
+			{
+				socket().SendToClient(ClientRequest.ClientCallable(ServiceRoute, callableName, 1, PlayerId));
+				await WaitForReply(reply, routes);
+			}
+			finally
+			{
+				await ms.OnShutdown(this, null);
+			}
 
 			Assert.That(routes, Is.Not.Empty, "the service never called the inventory endpoint");
 			Assert.That(routes, Has.All.Not.Contains("scope"),
@@ -135,15 +170,20 @@ namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTest
 		public async Task GetCurrent_WithScope_SendsScopeQueryParameter()
 		{
 			const string scope = "currency";
-			var (ms, socket, routes) = Build(req => req.path.EndsWith($"object/inventory/{PlayerId}/?scope={scope}"));
+			var (ms, socket, routes, reply) = Build(req => req.path.EndsWith($"object/inventory/{PlayerId}/?scope={scope}"));
 
 			await ms.Start<InventoryScopeMicroservice>(new TestArgs());
 			Assert.IsTrue(ms.HasInitialized);
 
-			socket().SendToClient(ClientRequest.ClientCallable(ServiceRoute, nameof(InventoryScopeMicroservice.GetScoped), 1, PlayerId, scope));
-
-			await Task.Delay(50);
-			await ms.OnShutdown(this, null);
+			try
+			{
+				socket().SendToClient(ClientRequest.ClientCallable(ServiceRoute, nameof(InventoryScopeMicroservice.GetScoped), 1, PlayerId, scope));
+				await WaitForReply(reply, routes);
+			}
+			finally
+			{
+				await ms.OnShutdown(this, null);
+			}
 
 			Assert.That(routes, Has.Some.Contains($"?scope={scope}"),
 				"a non-empty scope must still be sent. Routes seen: " + string.Join(" | ", routes));

--- a/microservice/microserviceTests/microservice/dbmicroservice/BeamableMicroServiceTests/InventoryScopeTests.cs
+++ b/microservice/microserviceTests/microservice/dbmicroservice/BeamableMicroServiceTests/InventoryScopeTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Beamable.Common.Api.Inventory;
+using Beamable.Microservice.Tests.Socket;
+using Beamable.Server;
+using NUnit.Framework;
+
+namespace microserviceTests.microservice.dbmicroservice.BeamableMicroServiceTests
+{
+	/// <summary>
+	/// Regression tests for https://github.com/beamable/BeamableProduct/issues/4833.
+	///
+	/// <see cref="Beamable.Server.Api.Inventory.MicroserviceInventoryApi.GetCurrent"/> must omit the scope query
+	/// parameter when the scope is empty. Sending it as an empty value (`?scope=`) produces a request the gateway
+	/// never answers, and the promise hangs forever.
+	/// </summary>
+	[TestFixture]
+	public class InventoryScopeTests : CommonTest
+	{
+		private const string ServiceName = "inventoryscopeservice";
+		private const string ServiceRoute = "micro_" + ServiceName;
+		private const int PlayerId = 1;
+
+		// The autogen InventoryView the platform would return. Only currencies are needed to prove the round trip.
+		private const string InventoryJson =
+			"{\"currencies\":[{\"id\":\"currency.gems\",\"amount\":5}],\"items\":[],\"scope\":\"currency\"}";
+
+		private const string ExpectedClientPayload = "currency.gems=5";
+
+		[Microservice(ServiceName, EnableEagerContentLoading = false)]
+		public class InventoryScopeMicroservice : Microservice
+		{
+			[ClientCallable]
+			public async Task<string> GetDefaultScope()
+			{
+				var view = await Services.Inventory.GetCurrent();
+				return Describe(view);
+			}
+
+			[ClientCallable]
+			public async Task<string> GetEmptyScope()
+			{
+				var view = await Services.Inventory.GetCurrent("");
+				return Describe(view);
+			}
+
+			[ClientCallable]
+			public async Task<string> GetNullScope()
+			{
+				var view = await Services.Inventory.GetCurrent(null);
+				return Describe(view);
+			}
+
+			[ClientCallable]
+			public async Task<string> GetScoped(string scope)
+			{
+				var view = await Services.Inventory.GetCurrent(scope);
+				return Describe(view);
+			}
+
+			private static string Describe(InventoryView view)
+			{
+				return string.Join(",", view.currencies.Select(kvp => $"{kvp.Key}={kvp.Value}"));
+			}
+		}
+
+		/// <summary>
+		/// Builds a service whose socket answers exactly one inventory GET that satisfies <paramref name="routeMatcher"/>,
+		/// and expects exactly one 200 reply to the client. Every inventory route the service sends is recorded in the
+		/// returned list so a failing test can show what actually went over the wire.
+		/// </summary>
+		private static (TestSetup setup, Func<TestSocket> socket, List<string> routes) Build(TestSocketMessageMatcher routeMatcher)
+		{
+			TestSocket testSocket = null;
+			var routes = new List<string>();
+			var setup = new TestSetup(new TestSocketProvider(socket =>
+			{
+				testSocket = socket;
+				socket.AddStandardMessageHandlers()
+					.AddMessageHandler(
+						MessageMatcher
+							.WithGet()
+							.WithRouteContains("object/inventory/")
+							.And(req =>
+							{
+								lock (routes)
+								{
+									if (!routes.Contains(req.path)) routes.Add(req.path);
+								}
+
+								return true;
+							})
+							.And(routeMatcher),
+						MessageResponder.Success(InventoryJson),
+						MessageFrequency.OnlyOnce())
+					.AddMessageHandler(
+						MessageMatcher
+							.WithReqId(1)
+							.WithStatus(200)
+							.WithPayload(ExpectedClientPayload),
+						MessageResponder.NoResponse(),
+						MessageFrequency.OnlyOnce());
+			}));
+
+			return (setup, () => testSocket, routes);
+		}
+
+		[Test]
+		[NonParallelizable]
+		[TestCase(nameof(InventoryScopeMicroservice.GetDefaultScope))]
+		[TestCase(nameof(InventoryScopeMicroservice.GetEmptyScope))]
+		[TestCase(nameof(InventoryScopeMicroservice.GetNullScope))]
+		public async Task GetCurrent_WithoutScope_OmitsScopeQueryParameter(string callableName)
+		{
+			var (ms, socket, routes) = Build(req => req.path.EndsWith($"object/inventory/{PlayerId}/"));
+
+			await ms.Start<InventoryScopeMicroservice>(new TestArgs());
+			Assert.IsTrue(ms.HasInitialized);
+
+			socket().SendToClient(ClientRequest.ClientCallable(ServiceRoute, callableName, 1, PlayerId));
+
+			await Task.Delay(50);
+			await ms.OnShutdown(this, null);
+
+			Assert.That(routes, Is.Not.Empty, "the service never called the inventory endpoint");
+			Assert.That(routes, Has.All.Not.Contains("scope"),
+				"an empty scope must be omitted, never sent as `?scope=`. Routes seen: " + string.Join(" | ", routes));
+			Assert.IsTrue(socket().AllMocksCalled(), "the inventory reply did not make it back to the client");
+		}
+
+		[Test]
+		[NonParallelizable]
+		public async Task GetCurrent_WithScope_SendsScopeQueryParameter()
+		{
+			const string scope = "currency";
+			var (ms, socket, routes) = Build(req => req.path.EndsWith($"object/inventory/{PlayerId}/?scope={scope}"));
+
+			await ms.Start<InventoryScopeMicroservice>(new TestArgs());
+			Assert.IsTrue(ms.HasInitialized);
+
+			socket().SendToClient(ClientRequest.ClientCallable(ServiceRoute, nameof(InventoryScopeMicroservice.GetScoped), 1, PlayerId, scope));
+
+			await Task.Delay(50);
+			await ms.OnShutdown(this, null);
+
+			Assert.That(routes, Has.Some.Contains($"?scope={scope}"),
+				"a non-empty scope must still be sent. Routes seen: " + string.Join(" | ", routes));
+			Assert.IsTrue(socket().AllMocksCalled(), "the inventory reply did not make it back to the client");
+		}
+	}
+}


### PR DESCRIPTION
Fixes #4833.

`Services.Inventory.GetCurrent()` and `GetCurrent("")` now omit the empty scope query parameter. This avoids the request shape associated with inventory calls remaining pending on runtimes 7.1.0 through 7.2.3. `GetCurrent(null)` also treats the scope as omitted; previously it threw before sending a request. Non-empty scopes keep their existing behavior.

## Cause and evidence

PR #4535 changed `MicroserviceInventoryApi.GetCurrent` to pass its raw scope string into the autogenerated `IInventoryApi.ObjectGet`. The implicit conversion to `Optional<string>` marks an empty string as present, so the generator sends `object/inventory/{id}/?scope=`. A null string also becomes a present optional, but then `scope.Value.ToString()` throws before the requester is called.

The requester registers a response listener with no outbound response deadline. If no matching response arrives, the promise remains pending. This code path is verified. It does not establish where the platform loses the request or response.

The production probe recorded in beamable/BeamableBackend#931 reported no reply after 15 seconds for `?scope=`, while omitted scope and `scope=currency` returned in roughly 230 ms on the same socket. We did not rerun that production probe during this review. The precise platform failure location remains unproven; the gateway query parser is the hypothesis tracked in that issue.

Before 7.1.0, `GetCurrent` used `BeamableGetApiResource.RequestData` and its URL builder in `ISupportsGet.cs`, which omitted null or empty scope. We restore that omission, not the exact previous URL bytes: the generated route still has a trailing slash.

## Scope and remaining work

- The empty-reference-array overload of `GetItems<T>(...)` joins its references into an empty scope and reaches the corrected `GetCurrent` method, so it also benefits from this fix.
- `GetCurrency("")` and `GetCurrencies(new[] { "" })` still construct a present empty scope independently of `GetCurrent`. We should validate each supplied currency ID before sending and add tests that assert no outbound request for invalid IDs. The existing null/empty currency-array behavior, which requests all currencies, should remain unchanged.
- Direct generated calls such as `IInventoryApi.ObjectGet(id, "")` remain exposed. Callers can use `OptionalString.None` to omit scope. A broader SDK guard needs an endpoint-specific contract; changing all optional strings could discard meaningful empty values.
- Gateway request/response handling is tracked in beamable/BeamableBackend#931. Outbound timeout and pending-listener cleanup are tracked separately in #4834. Neither change is included here.
- Unity's normal inventory `GetCurrent` path uses a POST helper with scopes in the body. The CLI references the microservice runtime project; this patch changes the runtime inventory wrapper, not CLI command logic.

## Verification

- Five `InventoryScopeTests` cases cover default, empty, and null scope; an empty item-reference array; and a non-empty currency scope. Each checks the outgoing route and the client reply.
- `TestSetupShutdownTests` proves that the shared shutdown helper waits for the service. This regression test failed before the harness fix and passed afterward.
- The inventory fixture waits for an explicit client reply and awaits shutdown in `finally`, replacing the fixed 50 ms sleeps.
- Focused local run: 6 passed, 0 failed.
- Full local `microserviceTests` suite: 280 passed, 0 failed, 0 skipped.
